### PR TITLE
Fix 14 compiler warnings

### DIFF
--- a/src/library/db.rs
+++ b/src/library/db.rs
@@ -6,7 +6,6 @@ use sqlx::SqlitePool;
 use tracing::{info, instrument};
 
 use super::error::LibraryError;
-use super::media::{MediaId, MediaRecord};
 
 mod albums;
 pub(crate) mod faces;

--- a/src/library/db/sync.rs
+++ b/src/library/db/sync.rs
@@ -1,5 +1,5 @@
 use crate::library::error::LibraryError;
-use crate::library::media::{MediaId, MediaMetadataRecord, MediaRecord};
+use crate::library::media::{MediaMetadataRecord, MediaRecord};
 
 use super::Database;
 
@@ -128,18 +128,6 @@ impl Database {
             .await
             .map_err(LibraryError::Db)?;
         Ok(rows.into_iter().map(|(id,)| id).collect())
-    }
-
-    /// Retrieve all sync checkpoints.
-    pub async fn get_sync_checkpoints(
-        &self,
-    ) -> Result<std::collections::HashMap<String, String>, LibraryError> {
-        let rows: Vec<(String, String)> =
-            sqlx::query_as("SELECT entity_type, ack FROM sync_checkpoints")
-                .fetch_all(&self.pool)
-                .await
-                .map_err(LibraryError::Db)?;
-        Ok(rows.into_iter().collect())
     }
 
     /// Save sync checkpoints (batch upsert).

--- a/src/library/format/registry.rs
+++ b/src/library/format/registry.rs
@@ -30,7 +30,7 @@ pub trait FormatHandler: Send + Sync {
 /// Single source of truth for all supported image formats.
 ///
 /// Owns a map from extension → handler. Used by:
-/// - The import scanner, via [`FormatRegistry::is_supported`], to decide
+/// - The import scanner, via [`FormatRegistry::media_type`], to decide
 ///   which files to accept.
 /// - The thumbnail pipeline, via [`FormatRegistry::decode`], to dispatch
 ///   to the correct decoder.
@@ -52,11 +52,6 @@ impl FormatRegistry {
         for ext in handler.extensions() {
             self.handlers.insert(ext.to_string(), Arc::clone(&handler));
         }
-    }
-
-    /// Returns `true` if any registered handler claims `ext` (case-insensitive).
-    pub fn is_supported(&self, ext: &str) -> bool {
-        self.handlers.contains_key(ext)
     }
 
     /// Decode the file at `path` using the handler registered for its extension.
@@ -141,11 +136,11 @@ mod tests {
     }
 
     #[test]
-    fn is_supported_returns_true_for_registered_extension() {
+    fn media_type_returns_some_for_registered_extension() {
         let mut reg = FormatRegistry::new();
         reg.register(Arc::new(FakeHandler));
-        assert!(reg.is_supported("fake"));
-        assert!(!reg.is_supported("jpg"));
+        assert!(reg.media_type("fake").is_some());
+        assert!(reg.media_type("jpg").is_none());
     }
 
     #[test]

--- a/src/library/immich_client.rs
+++ b/src/library/immich_client.rs
@@ -93,6 +93,7 @@ impl ImmichClient {
         Ok(login)
     }
 
+    #[allow(dead_code)]
     /// The base server URL (without trailing slash).
     pub fn base_url(&self) -> &str {
         &self.base_url
@@ -103,6 +104,7 @@ impl ImmichClient {
         format!("{}/api{}", self.base_url, path)
     }
 
+    #[allow(dead_code)]
     /// Ping the server to check connectivity.
     ///
     /// Returns `Ok(())` if the server responds with `{"res": "pong"}`.
@@ -170,6 +172,7 @@ impl ImmichClient {
         Ok(about)
     }
 
+    #[allow(dead_code)]
     /// Validate the connection by pinging and fetching server info.
     ///
     /// Used by the setup wizard to test that the server URL and API key
@@ -246,6 +249,7 @@ impl ImmichClient {
         self.send_json(self.client.post(&self.url(path)).json(body), "POST", path).await
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn put<B: serde::Serialize, T: serde::de::DeserializeOwned>(
         &self,
         path: &str,
@@ -254,6 +258,7 @@ impl ImmichClient {
         self.send_json(self.client.put(&self.url(path)).json(body), "PUT", path).await
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn delete<T: serde::de::DeserializeOwned>(
         &self,
         path: &str,
@@ -405,6 +410,7 @@ pub struct LoginResponse {
     /// Session token — use as `Authorization: Bearer {access_token}`.
     #[serde(rename = "accessToken")]
     pub access_token: String,
+    #[allow(dead_code)]
     /// Immich user ID (UUID).
     #[serde(rename = "userId")]
     pub user_id: String,
@@ -421,6 +427,7 @@ pub struct UploadResponse {
     pub status: String,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct PingResponse {
     res: String,
@@ -430,6 +437,7 @@ struct PingResponse {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerAbout {
     pub version: String,
+    #[allow(dead_code)]
     #[serde(default)]
     pub licensed: bool,
 }

--- a/src/library/immich_importer.rs
+++ b/src/library/immich_importer.rs
@@ -22,8 +22,6 @@ pub struct ImmichImportJob {
 
 impl ImmichImportJob {
     pub async fn run(&self, sources: Vec<PathBuf>) {
-        use sha1::Digest;
-
         let mut registry = FormatRegistry::new();
         registry.register(Arc::new(StandardHandler));
         registry.register(Arc::new(RawHandler));

--- a/src/library/importer.rs
+++ b/src/library/importer.rs
@@ -143,7 +143,7 @@ impl ImportJob {
             Some(mt) => mt,
             None => return Ok(Some(SkipReason::UnsupportedFormat)),
         };
-        let is_video = media_type == MediaType::Video;
+        let _is_video = media_type == MediaType::Video;
 
         // ── 2. Hash + metadata extract ───────────────────────────────────────
         // Images: extract EXIF. Videos: extract duration via GStreamer.

--- a/src/library/keyring.rs
+++ b/src/library/keyring.rs
@@ -50,6 +50,7 @@ pub fn lookup_access_token(server_url: &str) -> Result<Option<String>, LibraryEr
     Ok(secret.map(|s| s.to_string()))
 }
 
+#[allow(dead_code)]
 /// Delete a stored Immich session token from the GNOME Keyring.
 #[instrument(fields(server_url = %server_url))]
 pub fn delete_access_token(server_url: &str) -> Result<(), LibraryError> {

--- a/src/library/providers/immich.rs
+++ b/src/library/providers/immich.rs
@@ -16,7 +16,6 @@ use crate::library::import::LibraryImport;
 use crate::library::sync::SyncHandle;
 use crate::library::media::{
     LibraryMedia, MediaCursor, MediaFilter, MediaId, MediaItem, MediaMetadataRecord, MediaRecord,
-    MediaType,
 };
 use crate::library::storage::LibraryStorage;
 use crate::library::thumbnail::{sharded_thumbnail_path, LibraryThumbnail, ThumbnailStatus};

--- a/src/library/sync.rs
+++ b/src/library/sync.rs
@@ -24,9 +24,6 @@ pub struct SyncHandle {
     interval_tx: tokio::sync::watch::Sender<u64>,
 }
 
-/// Default interval between sync cycles (seconds).
-const DEFAULT_SYNC_INTERVAL_SECS: u64 = 30;
-
 /// Maximum concurrent thumbnail downloads.
 const MAX_THUMBNAIL_WORKERS: usize = 4;
 /// Bounded channel capacity for thumbnail download queue.

--- a/src/ui/collection_grid/factory.rs
+++ b/src/ui/collection_grid/factory.rs
@@ -1,4 +1,4 @@
-use gtk::{glib, prelude::*};
+use gtk::prelude::*;
 
 use super::cell::CollectionGridCell;
 use super::item::CollectionItemObject;


### PR DESCRIPTION
## Summary
- Remove 5 unused imports
- Prefix 1 unused variable with `_`
- Remove 3 dead code items (unused method, constant, function)
- Add `#[allow(dead_code)]` to 5 ImmichClient methods and API response fields that will be needed for future features

Closes #209

## Test plan
- [ ] `cargo check` produces zero warnings
- [ ] `cargo test` passes