### PR TITLE
Editing: data model, trait, and DB persistence

### DIFF
--- a/docs/design-photo-editing.md
+++ b/docs/design-photo-editing.md
@@ -1,0 +1,204 @@
+# Design: Non-Destructive Photo Editing (#17)
+
+## Context
+
+Users want to edit photos in Moments without modifying originals. Immich already supports non-destructive editing (crop, rotate, mirror) by creating a new version of the asset. We extend this with exposure, color, and filter adjustments. Design targets Immich backend first, then backports to local.
+
+## Approach
+
+Edit operations stored as a flat JSON parameter model. Edits are applied in real-time via a downscaled preview in the viewer sidebar. On save, the full-res result is rendered and uploaded to Immich as the edited version. Originals are never modified.
+
+---
+
+## 1. Edit State Data Model
+
+New file: `src/library/editing.rs`
+
+Flat parameter model — all values default to identity (0.0 / false / None):
+
+```rust
+pub struct EditState {
+    pub version: u32,           // Schema version for future-proofing
+    pub transforms: TransformState,
+    pub exposure: ExposureState,
+    pub color: ColorState,
+    pub filter: Option<String>, // Preset name, or None
+}
+
+pub struct CropRect {
+    pub x: f64, pub y: f64,     // Normalized 0.0-1.0
+    pub width: f64, pub height: f64,
+}
+
+pub struct TransformState {
+    pub crop: Option<CropRect>,
+    pub rotate_degrees: i32,       // 0, 90, 180, 270
+    pub straighten_degrees: f64,   // -45.0 to 45.0
+    pub flip_horizontal: bool,
+    pub flip_vertical: bool,
+}
+
+pub struct ExposureState {
+    // All -1.0 to 1.0, neutral at 0.0
+    pub brightness: f64,
+    pub contrast: f64,
+    pub highlights: f64,
+    pub shadows: f64,
+    pub white_balance: f64,
+}
+
+pub struct ColorState {
+    // All -1.0 to 1.0, neutral at 0.0
+    pub saturation: f64,
+    pub vibrance: f64,
+    pub hue_shift: f64,
+    pub temperature: f64,
+    pub tint: f64,
+}
+```
+
+Filters are preset combinations of exposure/color values. Selecting a filter overwrites those sections; the user can tweak sliders on top.
+
+## 2. Database Schema
+
+Migration `014_create_edits.sql`:
+
+```sql
+CREATE TABLE edits (
+    media_id    TEXT    PRIMARY KEY REFERENCES media(id) ON DELETE CASCADE,
+    edit_json   TEXT    NOT NULL,
+    updated_at  INTEGER NOT NULL,
+    rendered_at INTEGER
+);
+```
+
+- One row per asset. Revert = delete row.
+- `rendered_at` tracks when last uploaded to Immich. `updated_at > rendered_at` = dirty.
+
+## 3. Library Trait: `LibraryEditing`
+
+```rust
+pub trait LibraryEditing: Send + Sync {
+    async fn get_edit_state(&self, id: &MediaId) -> Result<Option<EditState>, LibraryError>;
+    async fn save_edit_state(&self, id: &MediaId, state: &EditState) -> Result<(), LibraryError>;
+    async fn revert_edits(&self, id: &MediaId) -> Result<(), LibraryError>;
+    async fn render_and_save(&self, id: &MediaId) -> Result<(), LibraryError>;
+    async fn has_pending_edits(&self, id: &MediaId) -> Result<bool, LibraryError>;
+}
+```
+
+Added to the `Library` supertrait in `src/library.rs`. DB methods in new `src/library/db/edits.rs`.
+
+## 4. Rendering Pipeline
+
+New file: `src/library/edit_renderer.rs`
+
+Pure function, no I/O:
+
+```rust
+pub fn apply_edits(img: DynamicImage, state: &EditState) -> DynamicImage;
+```
+
+Fixed application order:
+1. Rotate (90° steps) → Flip → Straighten (freeform)
+2. Crop (denormalize coordinates)
+3. Brightness → Contrast → Highlights → Shadows → White balance
+4. Saturation → Vibrance → Hue shift → Temperature → Tint
+
+**Real-time preview strategy**: downscaled preview (~1200px), full-res only on save.
+
+```
+Slider change → debounce (50ms) → apply_edits on spawn_blocking
+  → MemoryTexture → set_paintable on gtk::Picture
+```
+
+## 5. Immich Integration
+
+**Save**: Load original → apply edits → encode JPEG → `PUT /assets/{id}/original` → update `rendered_at` → regenerate thumbnail
+
+**Revert**: `DELETE /assets/{id}/original` → delete `edits` row → regenerate thumbnail from original
+
+New `ImmichClient` methods:
+- `upload_edited_asset(asset_id, rendered_bytes, filename)`
+- `revert_asset(asset_id)`
+
+**Note**: Exact Immich API endpoints need verification against the server version. Fallback: upload as new asset linked to original.
+
+## 6. UI: Edit Panel in Viewer Sidebar
+
+Reuses existing `OverlaySplitView` — edit panel replaces info panel when active.
+
+```
+EditPanel (gtk::Box vertical, scrollable)
+├── Filter row (horizontal scroll, 80px thumbnails)
+│   ├── "Original" | "B&W" | "Vintage" | "Warm" | "Cool" | "Vivid"
+├── PreferencesGroup "Transform"
+│   ├── Rotate 90° CW / CCW buttons
+│   ├── Flip H / Flip V toggles
+│   ├── Straighten slider
+│   └── Crop button (opens overlay)
+├── PreferencesGroup "Exposure"
+│   ├── Brightness slider
+│   ├── Contrast slider
+│   ├── Highlights slider
+│   ├── Shadows slider
+│   └── White Balance slider
+├── PreferencesGroup "Color"
+│   ├── Saturation slider
+│   ├── Vibrance slider
+│   ├── Hue slider
+│   ├── Temperature slider
+│   └── Tint slider
+└── Action bar
+    ├── "Revert" (destructive)
+    └── "Save" (suggested-action)
+```
+
+Header bar: add "Edit" toggle button (`document-edit-symbolic`) next to info toggle. Mutually exclusive — one panel visible at a time.
+
+Edit session state held in viewer as `Option<EditSession>`:
+```rust
+struct EditSession {
+    state: EditState,
+    preview_image: Arc<DynamicImage>,  // ~1200px for fast preview
+    full_res_image: Arc<DynamicImage>, // For final render on save
+    render_gen: u64,                   // Debounce generation counter
+}
+```
+
+## 7. Phased Implementation
+
+| Phase | Scope | Key files |
+|-------|-------|-----------|
+| 1 | Data model + DB persistence | `editing.rs`, `db/edits.rs`, migration 014, trait impls |
+| 2 | Edit renderer (no UI) | `edit_renderer.rs`, unit tests with reference images |
+| 3 | Edit panel UI + exposure/color sliders | `viewer/edit_panel.rs`, `viewer.rs` changes |
+| 4 | Geometric transforms (rotate, flip, straighten, crop) | Edit panel extensions, crop overlay widget |
+| 5 | Filters/presets | Filter thumbnail row, preset definitions |
+| 6 | Immich render-and-upload | `immich_client.rs` endpoints, `immich.rs` render_and_save |
+| 7 | Polish | Grid edit indicator, thumbnail regen, keyboard shortcuts, error handling |
+
+## Risks
+
+- **Immich API**: `PUT /assets/{id}/original` needs verification. Fallback: upload as new asset.
+- **Straighten**: `image` crate has no freeform rotation. Need `imageproc` dependency or manual bilinear interpolation. Can defer to Phase 4.
+- **Crop overlay**: Draggable handles in GTK4 are complex. Start with dialog-based crop, upgrade to overlay later.
+- **Preview performance**: If 1200px is too slow, drop to 800px. Profile in Phase 3.
+
+## Files to Create
+
+- `src/library/editing.rs` — EditState types + LibraryEditing trait
+- `src/library/edit_renderer.rs` — apply_edits() pure function
+- `src/library/db/edits.rs` — Database CRUD
+- `src/library/db/migrations/014_create_edits.sql` — Schema
+- `src/ui/viewer/edit_panel.rs` — Edit panel widget
+
+## Files to Modify
+
+- `src/library.rs` — Add LibraryEditing to Library supertrait
+- `src/library/db.rs` — Add mod edits
+- `src/library/providers/local.rs` — Implement LibraryEditing
+- `src/library/providers/immich.rs` — Implement LibraryEditing + render_and_save
+- `src/library/immich_client.rs` — Add edit upload/revert endpoints
+- `src/ui/viewer.rs` — Edit button, session state, preview rendering
+- `src/library/thumbnailer.rs` — Support edited thumbnail generation

--- a/src/library.rs
+++ b/src/library.rs
@@ -2,6 +2,7 @@ pub mod album;
 pub mod bundle;
 pub mod config;
 pub mod db;
+pub mod editing;
 pub mod error;
 pub mod event;
 pub mod exif;
@@ -23,6 +24,7 @@ pub mod video_meta;
 pub mod viewer;
 
 use album::LibraryAlbums;
+use editing::LibraryEditing;
 use faces::LibraryFaces;
 use import::LibraryImport;
 use media::LibraryMedia;
@@ -44,6 +46,7 @@ use viewer::LibraryViewer;
 /// - [`LibraryViewer`]    — detail-view data access (issue #10)
 /// - [`LibraryAlbums`]    — album management (issue #11)
 /// - [`LibraryFaces`]     — face/people management (issue #178)
+/// - [`LibraryEditing`]   — non-destructive photo editing (issue #17)
 ///
 /// `close()` is inherited from `LibraryStorage` and is not duplicated here.
 pub trait Library:
@@ -54,6 +57,7 @@ pub trait Library:
     + LibraryViewer
     + LibraryAlbums
     + LibraryFaces
+    + LibraryEditing
     + Send
     + Sync
 {
@@ -67,6 +71,7 @@ impl<
         + LibraryViewer
         + LibraryAlbums
         + LibraryFaces
+        + LibraryEditing
         + Send
         + Sync,
 > Library for T

--- a/src/library/db.rs
+++ b/src/library/db.rs
@@ -8,6 +8,7 @@ use tracing::{info, instrument};
 use super::error::LibraryError;
 
 mod albums;
+mod edits;
 pub(crate) mod faces;
 mod media;
 mod stats;

--- a/src/library/db/edits.rs
+++ b/src/library/db/edits.rs
@@ -1,0 +1,172 @@
+use crate::library::editing::EditState;
+use crate::library::error::LibraryError;
+use crate::library::media::MediaId;
+
+use super::Database;
+
+impl Database {
+    /// Get the current edit state for a media item.
+    pub async fn get_edit_state(&self, id: &MediaId) -> Result<Option<EditState>, LibraryError> {
+        let id_str = id.as_str();
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT edit_json FROM edits WHERE media_id = ?",
+        )
+        .bind(id_str)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(LibraryError::Db)?;
+
+        match row {
+            Some((json,)) => {
+                let state: EditState =
+                    serde_json::from_str(&json).map_err(|e| LibraryError::Runtime(e.to_string()))?;
+                Ok(Some(state))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Save or update the edit state for a media item.
+    pub async fn upsert_edit_state(
+        &self,
+        id: &MediaId,
+        state: &EditState,
+    ) -> Result<(), LibraryError> {
+        let id_str = id.as_str();
+        let json =
+            serde_json::to_string(state).map_err(|e| LibraryError::Runtime(e.to_string()))?;
+        let now = chrono::Utc::now().timestamp();
+
+        sqlx::query(
+            "INSERT INTO edits (media_id, edit_json, updated_at)
+             VALUES (?, ?, ?)
+             ON CONFLICT(media_id) DO UPDATE SET
+                 edit_json = excluded.edit_json,
+                 updated_at = excluded.updated_at,
+                 rendered_at = NULL",
+        )
+        .bind(id_str)
+        .bind(&json)
+        .bind(now)
+        .execute(&self.pool)
+        .await
+        .map_err(LibraryError::Db)?;
+
+        Ok(())
+    }
+
+    /// Delete the edit state for a media item (revert to original).
+    pub async fn delete_edit_state(&self, id: &MediaId) -> Result<(), LibraryError> {
+        let id_str = id.as_str();
+        sqlx::query("DELETE FROM edits WHERE media_id = ?")
+            .bind(id_str)
+            .execute(&self.pool)
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Mark the edit as rendered (uploaded to server).
+    #[allow(dead_code)]
+    pub async fn mark_edit_rendered(&self, id: &MediaId) -> Result<(), LibraryError> {
+        let id_str = id.as_str();
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE edits SET rendered_at = ? WHERE media_id = ?")
+            .bind(now)
+            .bind(id_str)
+            .execute(&self.pool)
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Check whether an asset has edits that haven't been rendered yet.
+    pub async fn has_pending_edits(&self, id: &MediaId) -> Result<bool, LibraryError> {
+        let id_str = id.as_str();
+        let row: Option<(i64,)> = sqlx::query_as(
+            "SELECT 1 FROM edits WHERE media_id = ? AND (rendered_at IS NULL OR updated_at > rendered_at)",
+        )
+        .bind(id_str)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(LibraryError::Db)?;
+
+        Ok(row.is_some())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::library::db::test_helpers::{open_test_db, test_record};
+    use crate::library::media::LibraryMedia;
+
+    #[tokio::test]
+    async fn get_nonexistent_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let id = MediaId::new("abc123".to_string());
+        let result = db.get_edit_state(&id).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn upsert_and_get_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let id = MediaId::new("abc123".to_string());
+        db.insert_media(&test_record(id.clone())).await.unwrap();
+
+        let mut state = EditState::default();
+        state.exposure.brightness = 0.5;
+        state.color.saturation = -0.3;
+
+        db.upsert_edit_state(&id, &state).await.unwrap();
+        let loaded = db.get_edit_state(&id).await.unwrap().unwrap();
+        assert_eq!(loaded, state);
+    }
+
+    #[tokio::test]
+    async fn upsert_overwrites_and_clears_rendered() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let id = MediaId::new("abc123".to_string());
+        db.insert_media(&test_record(id.clone())).await.unwrap();
+
+        let state = EditState::default();
+        db.upsert_edit_state(&id, &state).await.unwrap();
+        db.mark_edit_rendered(&id).await.unwrap();
+
+        // Verify rendered
+        assert!(!db.has_pending_edits(&id).await.unwrap());
+
+        // Update should clear rendered_at
+        let mut updated = EditState::default();
+        updated.exposure.contrast = 0.2;
+        db.upsert_edit_state(&id, &updated).await.unwrap();
+        assert!(db.has_pending_edits(&id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_edit_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let id = MediaId::new("abc123".to_string());
+        db.insert_media(&test_record(id.clone())).await.unwrap();
+
+        let state = EditState::default();
+        db.upsert_edit_state(&id, &state).await.unwrap();
+        assert!(db.get_edit_state(&id).await.unwrap().is_some());
+
+        db.delete_edit_state(&id).await.unwrap();
+        assert!(db.get_edit_state(&id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn has_pending_edits_returns_false_when_no_edits() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let id = MediaId::new("abc123".to_string());
+        assert!(!db.has_pending_edits(&id).await.unwrap());
+    }
+}

--- a/src/library/db/migrations/014_create_edits.sql
+++ b/src/library/db/migrations/014_create_edits.sql
@@ -1,0 +1,6 @@
+CREATE TABLE edits (
+    media_id    TEXT    PRIMARY KEY NOT NULL REFERENCES media(id) ON DELETE CASCADE,
+    edit_json   TEXT    NOT NULL,
+    updated_at  INTEGER NOT NULL,
+    rendered_at INTEGER
+);

--- a/src/library/editing.rs
+++ b/src/library/editing.rs
@@ -1,0 +1,189 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::error::LibraryError;
+use super::media::MediaId;
+
+/// Normalized crop rectangle with coordinates in the 0.0–1.0 range,
+/// relative to the image dimensions after orientation correction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CropRect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+/// Geometric transforms: crop, rotate, straighten, flip.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct TransformState {
+    /// Crop rectangle in normalized coordinates, or `None` for no crop.
+    pub crop: Option<CropRect>,
+    /// Rotation in 90-degree steps: 0, 90, 180, or 270.
+    pub rotate_degrees: i32,
+    /// Freeform straighten angle in degrees (-45.0 to 45.0).
+    pub straighten_degrees: f64,
+    pub flip_horizontal: bool,
+    pub flip_vertical: bool,
+}
+
+/// Exposure adjustments. All values range from -1.0 to 1.0 with 0.0 as neutral.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ExposureState {
+    pub brightness: f64,
+    pub contrast: f64,
+    pub highlights: f64,
+    pub shadows: f64,
+    pub white_balance: f64,
+}
+
+/// Color adjustments. All values range from -1.0 to 1.0 with 0.0 as neutral.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct ColorState {
+    pub saturation: f64,
+    pub vibrance: f64,
+    pub hue_shift: f64,
+    pub temperature: f64,
+    pub tint: f64,
+}
+
+/// Complete non-destructive edit state for a media asset.
+///
+/// Stored as JSON in the `edits` table. All fields default to identity
+/// values (no visible change). Filters are preset combinations of
+/// exposure/color values — selecting a filter sets those sections, but
+/// the user can further tweak individual sliders.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EditState {
+    /// Schema version for forward compatibility.
+    pub version: u32,
+    #[serde(default)]
+    pub transforms: TransformState,
+    #[serde(default)]
+    pub exposure: ExposureState,
+    #[serde(default)]
+    pub color: ColorState,
+    /// Name of the applied filter preset, or `None`.
+    #[serde(default)]
+    pub filter: Option<String>,
+}
+
+impl Default for EditState {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            transforms: TransformState::default(),
+            exposure: ExposureState::default(),
+            color: ColorState::default(),
+            filter: None,
+        }
+    }
+}
+
+impl EditState {
+    /// Returns `true` if this edit state represents no visible change.
+    pub fn is_identity(&self) -> bool {
+        self.transforms == TransformState::default()
+            && self.exposure == ExposureState::default()
+            && self.color == ColorState::default()
+            && self.filter.is_none()
+    }
+}
+
+/// Feature trait for non-destructive photo editing.
+///
+/// Edit operations are stored as JSON and applied on the fly during
+/// display. For the Immich backend, `render_and_save` uploads the
+/// rendered result as an edited version. For the local backend, edits
+/// are applied during viewing and thumbnail generation.
+#[async_trait]
+pub trait LibraryEditing: Send + Sync {
+    /// Get the current edit state for a media item.
+    /// Returns `None` if no edits have been applied.
+    async fn get_edit_state(&self, id: &MediaId) -> Result<Option<EditState>, LibraryError>;
+
+    /// Save the current edit state for a media item.
+    /// Overwrites any existing state.
+    async fn save_edit_state(&self, id: &MediaId, state: &EditState) -> Result<(), LibraryError>;
+
+    /// Remove all edits for a media item (revert to original).
+    async fn revert_edits(&self, id: &MediaId) -> Result<(), LibraryError>;
+
+    /// Render the current edit state to a full-resolution image and persist it.
+    /// For Immich: uploads as edited version. For local: no-op (edits applied on the fly).
+    async fn render_and_save(&self, id: &MediaId) -> Result<(), LibraryError>;
+
+    /// Check whether an asset has unsaved/unrendered edits.
+    async fn has_pending_edits(&self, id: &MediaId) -> Result<bool, LibraryError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_edit_state_is_identity() {
+        let state = EditState::default();
+        assert!(state.is_identity());
+        assert_eq!(state.version, 1);
+    }
+
+    #[test]
+    fn modified_state_is_not_identity() {
+        let mut state = EditState::default();
+        state.exposure.brightness = 0.5;
+        assert!(!state.is_identity());
+    }
+
+    #[test]
+    fn filter_only_is_not_identity() {
+        let mut state = EditState::default();
+        state.filter = Some("bw".to_string());
+        assert!(!state.is_identity());
+    }
+
+    #[test]
+    fn serialize_round_trip() {
+        let state = EditState {
+            version: 1,
+            transforms: TransformState {
+                crop: Some(CropRect {
+                    x: 0.1,
+                    y: 0.2,
+                    width: 0.8,
+                    height: 0.6,
+                }),
+                rotate_degrees: 90,
+                straighten_degrees: 2.5,
+                flip_horizontal: true,
+                flip_vertical: false,
+            },
+            exposure: ExposureState {
+                brightness: 0.3,
+                contrast: -0.2,
+                highlights: 0.1,
+                shadows: -0.1,
+                white_balance: 0.0,
+            },
+            color: ColorState {
+                saturation: 0.5,
+                vibrance: 0.2,
+                hue_shift: -0.1,
+                temperature: 0.3,
+                tint: -0.05,
+            },
+            filter: Some("vintage".to_string()),
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: EditState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state, restored);
+    }
+
+    #[test]
+    fn deserialize_with_missing_fields_uses_defaults() {
+        let json = r#"{"version": 1}"#;
+        let state: EditState = serde_json::from_str(json).unwrap();
+        assert!(state.is_identity());
+    }
+}

--- a/src/library/providers/immich.rs
+++ b/src/library/providers/immich.rs
@@ -8,6 +8,7 @@ use tracing::{debug, info, instrument};
 use crate::library::album::{Album, AlbumId, LibraryAlbums};
 use crate::library::bundle::Bundle;
 use crate::library::db::Database;
+use crate::library::editing::{EditState, LibraryEditing};
 use crate::library::error::LibraryError;
 use crate::library::event::LibraryEvent;
 use crate::library::faces::{LibraryFaces, Person, PersonId};
@@ -686,5 +687,30 @@ impl LibraryFaces for ImmichLibrary {
         } else {
             None
         }
+    }
+}
+
+#[async_trait]
+impl LibraryEditing for ImmichLibrary {
+    async fn get_edit_state(&self, id: &MediaId) -> Result<Option<EditState>, LibraryError> {
+        self.db.get_edit_state(id).await
+    }
+
+    async fn save_edit_state(&self, id: &MediaId, state: &EditState) -> Result<(), LibraryError> {
+        self.db.upsert_edit_state(id, state).await
+    }
+
+    async fn revert_edits(&self, id: &MediaId) -> Result<(), LibraryError> {
+        // TODO: wire to Immich API to remove edited version (#224)
+        self.db.delete_edit_state(id).await
+    }
+
+    async fn render_and_save(&self, _id: &MediaId) -> Result<(), LibraryError> {
+        // TODO: render edits and upload to Immich (#224)
+        Ok(())
+    }
+
+    async fn has_pending_edits(&self, id: &MediaId) -> Result<bool, LibraryError> {
+        self.db.has_pending_edits(id).await
     }
 }

--- a/src/library/providers/local.rs
+++ b/src/library/providers/local.rs
@@ -8,6 +8,7 @@ use tracing::{debug, info, instrument};
 
 use crate::library::bundle::Bundle;
 use crate::library::db::Database;
+use crate::library::editing::{EditState, LibraryEditing};
 use crate::library::error::LibraryError;
 use crate::library::event::LibraryEvent;
 use crate::library::faces::{LibraryFaces, Person, PersonId};
@@ -351,6 +352,30 @@ impl LibraryFaces for LocalLibrary {
 
     fn person_thumbnail_path(&self, _person_id: &PersonId) -> Option<std::path::PathBuf> {
         None
+    }
+}
+
+#[async_trait]
+impl LibraryEditing for LocalLibrary {
+    async fn get_edit_state(&self, id: &MediaId) -> Result<Option<EditState>, LibraryError> {
+        self.db.get_edit_state(id).await
+    }
+
+    async fn save_edit_state(&self, id: &MediaId, state: &EditState) -> Result<(), LibraryError> {
+        self.db.upsert_edit_state(id, state).await
+    }
+
+    async fn revert_edits(&self, id: &MediaId) -> Result<(), LibraryError> {
+        self.db.delete_edit_state(id).await
+    }
+
+    async fn render_and_save(&self, _id: &MediaId) -> Result<(), LibraryError> {
+        // Local backend applies edits on the fly during viewing.
+        Ok(())
+    }
+
+    async fn has_pending_edits(&self, id: &MediaId) -> Result<bool, LibraryError> {
+        self.db.has_pending_edits(id).await
     }
 }
 


### PR DESCRIPTION
## Summary
- Create `EditState` types (transforms, exposure, color, filter) with serde serialization in `src/library/editing.rs`
- Create `LibraryEditing` trait with `get_edit_state`, `save_edit_state`, `revert_edits`, `render_and_save`, `has_pending_edits`
- Add `LibraryEditing` to the `Library` supertrait
- Add migration `014_create_edits.sql`
- Create `src/library/db/edits.rs` with DB CRUD methods
- Implement `LibraryEditing` for both `LocalLibrary` and `ImmichLibrary` (stub `render_and_save`)
- Add design doc `docs/design-photo-editing.md`

Closes #219

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test` — 184 tests pass (9 new: 4 serialization + 5 DB CRUD)