### PR TITLE
chore: add release target and sync version to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "moments"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moments"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 description = "A GNOME photo management app with local and Immich server support"
 license = "GPL-3.0-or-later"

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,43 @@ run-dev:
 
 clean:
 	rm -rf flatpak-build-dir
+
+# ── Release ───────────────────────────────────────────────────────────────────
+#
+# Usage: make release VERSION=0.2.0
+#
+# Steps:
+#   1. Updates version in meson.build and Cargo.toml
+#   2. Commits the version bump
+#   3. Creates a git tag (v0.2.0)
+#   4. Pushes commit + tag to origin
+#   5. Updates the Flathub manifest with the new tag and commit hash
+#   6. Commits and pushes the Flathub manifest update
+
+release:
+ifndef VERSION
+	$(error VERSION is required. Usage: make release VERSION=0.2.0)
+endif
+	@echo "==> Releasing v$(VERSION)"
+	@# ── 1. Update version in source files ────────────────────────────────
+	sed -i "s/version: '[0-9]*\.[0-9]*\.[0-9]*'/version: '$(VERSION)'/" meson.build
+	sed -i 's/^version = "[0-9]*\.[0-9]*\.[0-9]*"/version = "$(VERSION)"/' Cargo.toml
+	@# ── 2. Update Cargo.lock ─────────────────────────────────────────────
+	cargo check --quiet 2>/dev/null || true
+	@# ── 3. Commit version bump ───────────────────────────────────────────
+	git add meson.build Cargo.toml Cargo.lock
+	git commit -m "chore: bump version to $(VERSION)"
+	@# ── 4. Create tag and push ───────────────────────────────────────────
+	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
+	git push origin main
+	git push origin "v$(VERSION)"
+	@# ── 5. Update Flathub manifest ───────────────────────────────────────
+	$(eval COMMIT_HASH := $(shell git rev-parse HEAD))
+	sed -i 's/"tag" : "v[0-9]*\.[0-9]*\.[0-9]*"/"tag" : "v$(VERSION)"/' io.github.justinf555.Moments.flathub.json
+	sed -i 's/"commit" : "[0-9a-f]*"/"commit" : "$(COMMIT_HASH)"/' io.github.justinf555.Moments.flathub.json
+	@# ── 6. Commit Flathub manifest ───────────────────────────────────────
+	git add io.github.justinf555.Moments.flathub.json
+	git commit -m "chore: update Flathub manifest for v$(VERSION)"
+	git push origin main
+	@echo "==> Released v$(VERSION) (tag: v$(VERSION), commit: $(COMMIT_HASH))"
+	@echo "==> Don't forget to update the Flathub fork with the new manifest"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('moments', 'rust', 
-          version: '0.1.0',
+          version: '0.1.2',
     meson_version: '>= 1.0.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )


### PR DESCRIPTION
## Summary

- **`make release VERSION=x.y.z`** — single command to cut a release:
  1. Updates version in `meson.build` and `Cargo.toml`
  2. Updates `Cargo.lock`
  3. Commits the version bump
  4. Creates annotated git tag `vx.y.z`
  5. Pushes commit + tag to origin
  6. Updates Flathub manifest (`tag` + `commit` fields)
  7. Commits and pushes the manifest update
- **Synced version to 0.1.2** — `meson.build` and `Cargo.toml` were stuck at 0.1.0 while the git tag was at v0.1.2

## Usage

```bash
make release VERSION=0.1.3
```

After running, update the Flathub fork with the new manifest.

## Test plan

- [ ] `grep version meson.build` shows `0.1.2`
- [ ] `grep version Cargo.toml` shows `0.1.2`
- [ ] `make release VERSION=0.1.3` (dry run on a test branch) updates all files correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)