### PR TITLE
chore: automate release with make target and GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag-and-release:
+    name: Tag and release
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Update Flathub manifest
+        run: |
+          COMMIT=$(git rev-parse HEAD)
+          TAG="${{ steps.version.outputs.tag }}"
+          sed -i "s/\"tag\" : \"v[0-9]*\.[0-9]*\.[0-9]*\"/\"tag\" : \"$TAG\"/" io.github.justinf555.Moments.flathub.json
+          sed -i "s/\"commit\" : \"[0-9a-f]*\"/\"commit\" : \"$COMMIT\"/" io.github.justinf555.Moments.flathub.json
+          git add io.github.justinf555.Moments.flathub.json
+          git commit -m "chore: update Flathub manifest for $TAG"
+          git push origin main
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "Moments ${{ steps.version.outputs.tag }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -13,38 +13,24 @@ clean:
 #
 # Usage: make release VERSION=0.2.0
 #
-# Steps:
-#   1. Updates version in meson.build and Cargo.toml
-#   2. Commits the version bump
-#   3. Creates a git tag (v0.2.0)
-#   4. Pushes commit + tag to origin
-#   5. Updates the Flathub manifest with the new tag and commit hash
-#   6. Commits and pushes the Flathub manifest update
+# Creates a release/v0.2.0 branch with version bumps in meson.build,
+# Cargo.toml, and Cargo.lock, then opens a PR. On merge, the
+# release.yml GitHub Action automatically:
+#   - Creates an annotated git tag (v0.2.0)
+#   - Updates the Flathub manifest with the new tag and commit hash
+#   - Creates a GitHub Release
 
 release:
 ifndef VERSION
 	$(error VERSION is required. Usage: make release VERSION=0.2.0)
 endif
-	@echo "==> Releasing v$(VERSION)"
-	@# ── 1. Update version in source files ────────────────────────────────
+	@echo "==> Preparing release v$(VERSION)"
+	git checkout -b "release/v$(VERSION)"
 	sed -i "s/version: '[0-9]*\.[0-9]*\.[0-9]*'/version: '$(VERSION)'/" meson.build
 	sed -i 's/^version = "[0-9]*\.[0-9]*\.[0-9]*"/version = "$(VERSION)"/' Cargo.toml
-	@# ── 2. Update Cargo.lock ─────────────────────────────────────────────
 	cargo check --quiet 2>/dev/null || true
-	@# ── 3. Commit version bump ───────────────────────────────────────────
 	git add meson.build Cargo.toml Cargo.lock
 	git commit -m "chore: bump version to $(VERSION)"
-	@# ── 4. Create tag and push ───────────────────────────────────────────
-	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
-	git push origin main
-	git push origin "v$(VERSION)"
-	@# ── 5. Update Flathub manifest ───────────────────────────────────────
-	$(eval COMMIT_HASH := $(shell git rev-parse HEAD))
-	sed -i 's/"tag" : "v[0-9]*\.[0-9]*\.[0-9]*"/"tag" : "v$(VERSION)"/' io.github.justinf555.Moments.flathub.json
-	sed -i 's/"commit" : "[0-9a-f]*"/"commit" : "$(COMMIT_HASH)"/' io.github.justinf555.Moments.flathub.json
-	@# ── 6. Commit Flathub manifest ───────────────────────────────────────
-	git add io.github.justinf555.Moments.flathub.json
-	git commit -m "chore: update Flathub manifest for v$(VERSION)"
-	git push origin main
-	@echo "==> Released v$(VERSION) (tag: v$(VERSION), commit: $(COMMIT_HASH))"
-	@echo "==> Don't forget to update the Flathub fork with the new manifest"
+	git push -u origin "release/v$(VERSION)"
+	gh pr create --title "chore: release v$(VERSION)" --body "Bump version to $(VERSION). Merging this PR will automatically create a git tag and GitHub Release."
+	@echo "==> PR created. Merge it to trigger the release."


### PR DESCRIPTION
## Summary

Replace the direct-push release script with a branch-protection-friendly flow:

### `make release VERSION=0.2.0`
- Creates `release/v0.2.0` branch
- Bumps version in `meson.build`, `Cargo.toml`, `Cargo.lock`
- Pushes branch and creates a PR

### On merge (automatic via GitHub Action)
- Creates annotated git tag `v0.2.0`
- Updates Flathub manifest with new tag + commit hash
- Commits manifest update to main
- Creates a GitHub Release with auto-generated notes

## Test plan

- [ ] Run `make release VERSION=0.1.3` on a test branch — verify PR is created
- [ ] Merge the release PR — verify tag, GitHub Release, and Flathub manifest update

🤖 Generated with [Claude Code](https://claude.com/claude-code)