### PR TITLE
fix: simplify release action to tag + GitHub Release only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,6 @@ jobs:
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
-      - name: Update Flathub manifest
-        run: |
-          COMMIT=$(git rev-parse HEAD)
-          TAG="${{ steps.version.outputs.tag }}"
-          sed -i "s/\"tag\" : \"v[0-9]*\.[0-9]*\.[0-9]*\"/\"tag\" : \"$TAG\"/" io.github.justinf555.Moments.flathub.json
-          sed -i "s/\"commit\" : \"[0-9a-f]*\"/\"commit\" : \"$COMMIT\"/" io.github.justinf555.Moments.flathub.json
-          git add io.github.justinf555.Moments.flathub.json
-          git commit -m "chore: update Flathub manifest for $TAG"
-          git push origin main
-
       - name: Create GitHub Release
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \


### PR DESCRIPTION
## Summary

Remove the Flathub manifest auto-update from the release action — branch protection prevents the bot from pushing to main. The action now just creates the annotated tag and GitHub Release.

**Release flow:**
1. `make release VERSION=x.y.z` → creates PR
2. Merge PR → Action creates tag + GitHub Release
3. Manually update Flathub manifest with new tag/commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)