### PR TITLE
feat: reorganize grid view headerbar per GNOME HIG

### DIFF
--- a/src/ui/photo_grid.rs
+++ b/src/ui/photo_grid.rs
@@ -286,11 +286,6 @@ pub struct PhotoGridView {
     library: Arc<dyn Library>,
     tokio: tokio::runtime::Handle,
     texture_cache: Rc<texture_cache::TextureCache>,
-    trash_btn: gtk::Button,
-    restore_btn: gtk::Button,
-    delete_btn: gtk::Button,
-    album_btn: gtk::Button,
-    remove_from_album_btn: gtk::Button,
     widget: gtk::Widget,
     /// Zoom actions — must be installed on the window so accelerators work
     /// regardless of which widget has focus.
@@ -339,51 +334,19 @@ impl PhotoGridView {
 
         header.pack_start(&zoom_box);
 
-        // ── Selection action buttons (right side, before menu) ─────────
-        // Trash view gets Restore + Delete; other views get Trash.
-        let restore_btn = gtk::Button::builder()
-            .icon_name("edit-undo-symbolic")
-            .tooltip_text("Restore")
-            .sensitive(false)
-            .visible(false)
-            .build();
-        restore_btn.add_css_class("flat");
-        header.pack_end(&restore_btn);
+        // ── Content overflow menu (⋮) ────────────────────────────────────
+        let content_menu = gio::Menu::new();
+        let content_section = gio::Menu::new();
+        content_section.append(Some("_Select"), Some("view.enter-selection"));
+        content_menu.append_section(None, &content_section);
 
-        let delete_btn = gtk::Button::builder()
-            .icon_name("edit-delete-symbolic")
-            .tooltip_text("Delete Permanently")
-            .sensitive(false)
-            .visible(false)
+        let content_menu_btn = gtk::MenuButton::builder()
+            .icon_name("view-more-symbolic")
+            .tooltip_text("Menu")
+            .menu_model(&content_menu)
             .build();
-        delete_btn.add_css_class("flat");
-        delete_btn.add_css_class("error");
-        header.pack_end(&delete_btn);
-
-        let trash_btn = gtk::Button::builder()
-            .icon_name("user-trash-symbolic")
-            .tooltip_text("Move to Trash")
-            .sensitive(false)
-            .build();
-        trash_btn.add_css_class("flat");
-        header.pack_end(&trash_btn);
-
-        let remove_from_album_btn = gtk::Button::builder()
-            .icon_name("list-remove-symbolic")
-            .tooltip_text("Remove from Album")
-            .sensitive(false)
-            .visible(false)
-            .build();
-        remove_from_album_btn.add_css_class("flat");
-        header.pack_end(&remove_from_album_btn);
-
-        let album_btn = gtk::Button::builder()
-            .icon_name("folder-new-symbolic")
-            .tooltip_text("Add to Album")
-            .sensitive(false)
-            .build();
-        album_btn.add_css_class("flat");
-        header.pack_end(&album_btn);
+        content_menu_btn.add_css_class("flat");
+        header.pack_end(&content_menu_btn);
 
         // ── Grid toolbar view (root nav page content) ────────────────────────
         let photo_grid = PhotoGrid::new();
@@ -445,6 +408,10 @@ impl PhotoGridView {
         action_group.add_action(&zoom_in_action);
         action_group.add_action(&zoom_out_action);
 
+        // Stub action for "Select" menu item — implemented in PR 2.
+        let enter_selection = gio::SimpleAction::new("enter-selection", None);
+        action_group.add_action(&enter_selection);
+
         let widget = nav_view.clone().upcast::<gtk::Widget>();
 
         Self {
@@ -455,11 +422,6 @@ impl PhotoGridView {
             library,
             tokio,
             texture_cache,
-            trash_btn,
-            restore_btn,
-            delete_btn,
-            album_btn,
-            remove_from_album_btn,
             widget,
             view_actions: action_group,
         }
@@ -526,15 +488,6 @@ impl PhotoGridView {
             grid_view,
         };
 
-        actions::wire_selection_buttons(
-            &ctx,
-            &self.trash_btn,
-            &self.restore_btn,
-            &self.delete_btn,
-            &self.album_btn,
-            &self.remove_from_album_btn,
-        );
-        actions::wire_album_controls(&ctx, &self.album_btn);
         actions::wire_context_menu(&ctx);
     }
 }

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -73,6 +73,8 @@ pub(super) fn run_action<F, Fut>(
 }
 
 /// Wire the selection-changed signal to enable/disable header bar buttons.
+/// Temporarily unused — will be refactored into action bar wiring in PR 2.
+#[allow(dead_code)]
 pub(super) fn wire_selection_buttons(
     ctx: &ActionContext,
     trash_btn: &gtk::Button,
@@ -270,6 +272,8 @@ fn wire_remove_from_album_button(ctx: &ActionContext, btn: gtk::Button, album_id
 }
 
 /// Wire the "Add to Album" button popover.
+/// Temporarily unused — will be refactored into action bar wiring in PR 2.
+#[allow(dead_code)]
 pub(super) fn wire_album_controls(ctx: &ActionContext, album_btn: &gtk::Button) {
     let lib = Arc::clone(&ctx.library);
     let tk = ctx.tokio.clone();

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -111,27 +111,21 @@ mod imp {
             // ── Sidebar header bar ───────────────────────────────────────
             let header = adw::HeaderBar::new();
 
-            // Import button (LHS).
-            let import_button = gtk::Button::builder()
-                .icon_name("document-send-symbolic")
-                .tooltip_text("Import Photos")
-                .action_name("app.import")
-                .build();
-            import_button.add_css_class("flat");
-            header.pack_start(&import_button);
-
-            // Hamburger menu (RHS).
+            // Hamburger menu (RHS) — contains Import + app-level actions.
             let menu_button = gtk::MenuButton::builder()
                 .primary(true)
                 .icon_name("open-menu-symbolic")
                 .tooltip_text("Main Menu")
                 .build();
             let menu = gio::Menu::new();
-            let section = gio::Menu::new();
-            section.append(Some("_Preferences"), Some("app.preferences"));
-            section.append(Some("_Keyboard Shortcuts"), Some("app.shortcuts"));
-            section.append(Some("_About Moments"), Some("app.about"));
-            menu.append_section(None, &section);
+            let import_section = gio::Menu::new();
+            import_section.append(Some("_Import"), Some("app.import"));
+            menu.append_section(None, &import_section);
+            let app_section = gio::Menu::new();
+            app_section.append(Some("_Keyboard Shortcuts"), Some("app.shortcuts"));
+            app_section.append(Some("_About Moments"), Some("app.about"));
+            app_section.append(Some("_Preferences"), Some("app.preferences"));
+            menu.append_section(None, &app_section);
             menu_button.set_menu_model(Some(&menu));
             header.pack_end(&menu_button);
 


### PR DESCRIPTION
## Summary

- **Import moved** from sidebar headerbar button to sidebar hamburger menu (top section)
- **Menu order**: Import | Keyboard Shortcuts, About Moments, Preferences
- **Selection buttons removed** from content headerbar (trash, restore, delete, album, remove-from-album)
- **Content overflow menu (⋮)** added with "Select" item (stub action, implemented in PR 2)
- **Zoom controls** kept on left side of content headerbar

Part 1 of #254. PR 2 will add selection mode, checkbox overlays, and bottom action bar.

## Test plan

- [ ] Import accessible from sidebar hamburger menu (top of menu)
- [ ] Content headerbar: zoom left, title centred, ⋮ menu right
- [ ] No selection buttons in headerbar
- [ ] "Select" item visible in ⋮ menu (no-op for now)
- [ ] Double-click still opens viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)