### PR TITLE
ci: add integration test job with mutter --headless

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,13 @@ jobs:
           EOF
 
       - name: Run integration tests
-        run: >
-          dbus-run-session
-          mutter --headless --wayland --no-x11 --virtual-monitor 1024x768 --
-          cargo test --features integration-tests -- --test-threads=1
+        run: |
+          export XDG_RUNTIME_DIR=/tmp/runtime-$$
+          mkdir -p "$XDG_RUNTIME_DIR"
+          chmod 700 "$XDG_RUNTIME_DIR"
+          dbus-run-session \
+            mutter --headless --wayland --no-x11 --virtual-monitor 1024x768 -- \
+            cargo test --features integration-tests -- --test-threads=1
 
       - name: Show sccache stats
         if: always()


### PR DESCRIPTION
## Summary
- Adds a second CI job that runs integration tests using `mutter --headless` (Wayland compositor)
- No X11 dependency — forward-compatible with GNOME 50+
- Runs in parallel with the existing unit test job
- Uses `GSK_RENDERER=cairo` for software rendering, `--test-threads=1` for GTK thread safety

## Test plan
- [ ] Unit tests job still passes
- [ ] Integration tests job passes (14 headless widget tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)