### PR TITLE
fix: show AdwAlertDialog for critical library failures

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -651,14 +651,14 @@ impl MomentsApplication {
                         dialog.add_response("quit", "Quit");
                         dialog.set_response_appearance("quit", adw::ResponseAppearance::Destructive);
                         dialog.set_default_response(Some("setup"));
-                        dialog.set_close_response("quit");
+                        dialog.set_close_response("setup");
 
                         let app_weak = app.downgrade();
-                        let win_weak2 = window.downgrade();
+                        let win_weak = window.downgrade();
                         dialog.connect_response(None, move |_, response| {
                             if response == "setup" {
                                 if let Some(app) = app_weak.upgrade() {
-                                    if let Some(win) = win_weak2.upgrade() {
+                                    if let Some(win) = win_weak.upgrade() {
                                         win.close();
                                     }
                                     app.show_setup_window();


### PR DESCRIPTION
## Summary

PR 3 of 3 for #278 (user-visible error handling). Closes #278.

Shows `AdwAlertDialog` for critical failures that previously left the app stuck with no feedback:

| Failure | Dialog | Buttons |
|---------|--------|---------|
| Bundle open failure (setup wizard) | "Could not open library" with path + error details | OK → returns to setup |
| Bundle create failure (setup wizard) | "Could not create library" with path + error details | OK → returns to setup |
| Bundle open failure (app launch) | "Could not open library" with path + error details | OK → shows setup wizard |
| Library factory failure (async) | "Could not open library" with error details | Set Up Library / Quit |

## Test plan

- [ ] Delete the library bundle directory → relaunch app → dialog explains the error, setup wizard appears
- [ ] Corrupt the SQLite database → relaunch → dialog with "Set Up Library" and "Quit" buttons
- [ ] "Set Up Library" button works → shows setup wizard
- [ ] "Quit" button works → app exits
- [ ] Normal app launch still works (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)