### PR TITLE
docs: update CLAUDE.md with event bus, viewer, album picker, error handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Two backends exist:
 
 ### Database
 
-`src/library/db.rs` — backend-agnostic `Database` struct wrapping an `sqlx::SqlitePool`. Used by all backends that need persistence. Migrations live at `src/library/db/migrations/` (001–013) and are embedded via `sqlx::migrate!()`. **Every schema change must be a numbered migration — no ad-hoc `CREATE TABLE IF NOT EXISTS` in code.** Query implementations are split into submodules: `db/media.rs`, `db/albums.rs`, `db/faces.rs`, `db/sync.rs`, `db/thumbnails.rs`, `db/stats.rs`, `db/upload.rs`.
+`src/library/db.rs` — backend-agnostic `Database` struct wrapping an `sqlx::SqlitePool`. Used by all backends that need persistence. Migrations live at `src/library/db/migrations/` (001–014) and are embedded via `sqlx::migrate!()`. **Every schema change must be a numbered migration — no ad-hoc `CREATE TABLE IF NOT EXISTS` in code.** Query implementations are split into submodules: `db/media.rs`, `db/albums.rs`, `db/faces.rs`, `db/sync.rs`, `db/thumbnails.rs`, `db/stats.rs`, `db/upload.rs`.
 
 After any schema change, regenerate the offline query snapshot:
 ```bash


### PR DESCRIPTION
## Summary

Updates CLAUDE.md to reflect the architecture changes from today's session:

- **Module structure**: Added event_bus, app_event, commands/, album_picker_dialog/, action_bar, widgets, empty_library. Removed stale model_registry.rs.
- **Event bus section**: Documents EventBus, AppEvent, CommandDispatcher, error toast pattern (with critical WidgetExt vs ActionGroupExt note).
- **Viewer headerbar section**: Documents overflow menu pattern (manual popover, not GMenuModel).
- **Album picker section**: Documents data-in/events-out architecture.
- **Design docs**: Added event-bus.md and integration-testing.md references.
- **Feature flags**: Updated editing flag note for v0.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)