### PR TITLE
fix: increase checkbox touch target to GNOME HIG minimum 24×24px

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -16,9 +16,9 @@ gridview.selection-active > child:selected photo-grid-cell picture {
 
 /* Smaller checkbox overlay on grid cells. */
 photo-grid-cell checkbutton {
-    -gtk-icon-size: 12px;
-    min-height: 16px;
-    min-width: 16px;
+    -gtk-icon-size: 16px;
+    min-height: 24px;
+    min-width: 24px;
 }
 
 /* Taller action bar with larger buttons. */


### PR DESCRIPTION
## Summary
- Increase photo grid checkbox from 16×16px to 24×24px (GNOME HIG minimum interactive target)
- Increase icon size from 12px to 16px for better visibility

## Test plan
- [ ] Checkbox is visually larger on grid cells
- [ ] Touch/click target is easier to hit on touchscreen devices
- [ ] Checkbox still aligns correctly in top-left of grid cell

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)