### PR TITLE
fix: add Rust source files to POTFILES.in for string extraction

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -3,4 +3,10 @@
 data/io.github.justinf555.Moments.desktop.in
 data/io.github.justinf555.Moments.metainfo.xml.in
 data/io.github.justinf555.Moments.gschema.xml
+src/application.rs
+src/ui/collection_grid/cell.rs
+src/ui/photo_grid/cell.rs
+src/ui/photo_grid/factory.rs
+src/ui/video_viewer.rs
+src/ui/viewer.rs
 src/window.ui


### PR DESCRIPTION
## Summary
- Add all Rust source files containing `gettext()` calls to `po/POTFILES.in`
- Without these entries, xgettext cannot extract translatable strings into the .pot file
- Affected strings: "Select", "Remove from favourites", "Add to favourites", "hidden", "translator-credits"

The gettext patterns themselves are already correct (fixed in #319 review).

## Test plan
- [ ] `meson compile -C _build moments-pot` (or equivalent) generates a .pot file containing all new strings
- [ ] No duplicate or missing entries in POTFILES.in

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)