### PR TITLE
refactor: extract private helpers from info panel populate

### DIFF
--- a/src/ui/viewer/info_panel.rs
+++ b/src/ui/viewer/info_panel.rs
@@ -36,230 +36,246 @@ impl InfoPanel {
         vbox.set_margin_start(12);
         vbox.set_margin_end(12);
 
-        // Each section is a separate boxed-list card with gaps between them.
+        vbox.append(&build_date_section(item));
+        vbox.append(&build_image_section(item));
+        vbox.append(&build_camera_section(metadata));
 
-        // ── Date ─────────────────────────────────────────────────────────────
-        {
-            let list = boxed_list();
-            let (short_date, long_date, time_str) = format_date_parts(item.taken_at);
-            let (expander, _) = expander_row(
-                Some("x-office-calendar-symbolic"),
-                "Date",
-                &short_date,
-                true,
-            );
-            expander.add_row(&detail_row("Captured", &long_date));
-            expander.add_row(&detail_row("Time", &time_str));
-            list.append(&expander);
-            vbox.append(&list);
+        if let Some(location) = build_location_section(metadata) {
+            vbox.append(&location);
         }
 
-        // ── Image ────────────────────────────────────────────────────────────
-        {
-            let list = boxed_list();
-            let mp_str = match (item.width, item.height) {
-                (Some(w), Some(h)) => {
-                    let mp = (w * h) as f64 / 1_000_000.0;
-                    format!("{mp:.1} MP")
-                }
-                _ => "Unknown".to_string(),
-            };
-
-            let (expander, _) = expander_row(
-                Some("image-x-generic-symbolic"),
-                "Image",
-                &mp_str,
-                true,
-            );
-
-            if let (Some(w), Some(h)) = (item.width, item.height) {
-                expander.add_row(&detail_row("Dimensions", &format!("{w} \u{d7} {h}")));
-            }
-            expander.add_row(&detail_row("Resolution", &mp_str));
-
-            let format_str = item
-                .original_filename
-                .rsplit('.')
-                .next()
-                .map(|ext| ext.to_uppercase())
-                .unwrap_or_else(|| "Unknown".to_string());
-            expander.add_row(&detail_row("Format", &format_str));
-
-            list.append(&expander);
-            vbox.append(&list);
-        }
-
-        // ── Camera ───────────────────────────────────────────────────────────
-        {
-            let list = boxed_list();
-            let camera_name = metadata.and_then(|m| match (&m.camera_make, &m.camera_model) {
-                (Some(make), Some(model)) => {
-                    if model.starts_with(make.as_str()) {
-                        Some(model.clone())
-                    } else {
-                        Some(format!("{make} {model}"))
-                    }
-                }
-                (Some(make), None) => Some(make.clone()),
-                (None, Some(model)) => Some(model.clone()),
-                _ => None,
-            });
-
-            let subtitle = camera_name.as_deref().unwrap_or("No data");
-            let (expander, _) = expander_row(
-                Some("camera-photo-symbolic"),
-                "Camera",
-                subtitle,
-                true,
-            );
-
-            if let Some(ref name) = camera_name {
-                expander.add_row(&detail_row("Camera", name));
-            }
-
-            if let Some(lens) = metadata.and_then(|m| m.lens_model.as_deref()) {
-                let lens_with_fl = metadata
-                    .and_then(|m| m.focal_length)
-                    .map(|fl| format!("{lens} \u{b7} {fl:.0}mm"))
-                    .unwrap_or_else(|| lens.to_string());
-                expander.add_row(&detail_row("Lens", &lens_with_fl));
-            }
-
-            // EXIF values in a 2-column grid.
-            if let Some(meta) = metadata {
-                let has_exif = meta.aperture.is_some()
-                    || meta.shutter_str.is_some()
-                    || meta.iso.is_some()
-                    || meta.focal_length.is_some();
-
-                if has_exif {
-                    let grid = gtk::Grid::builder()
-                        .column_spacing(8)
-                        .row_spacing(8)
-                        .margin_top(8)
-                        .margin_bottom(8)
-                        .margin_start(12)
-                        .margin_end(12)
-                        .column_homogeneous(true)
-                        .build();
-
-                    let mut row = 0i32;
-                    let mut col = 0i32;
-
-                    if let Some(f) = meta.aperture {
-                        grid.attach(&exif_card("Aperture", &format!("f/{f:.1}")), col, row, 1, 1);
-                        col += 1;
-                    }
-                    if let Some(s) = &meta.shutter_str {
-                        grid.attach(&exif_card("Shutter", &format!("{s}s")), col, row, 1, 1);
-                        col += 1;
-                    }
-                    if col >= 2 {
-                        row += 1;
-                        col = 0;
-                    }
-                    if let Some(iso) = meta.iso {
-                        grid.attach(&exif_card("ISO", &format!("{iso}")), col, row, 1, 1);
-                        col += 1;
-                    }
-                    if let Some(fl) = meta.focal_length {
-                        grid.attach(&exif_card("Focal", &format!("{fl:.0}mm")), col, row, 1, 1);
-                    }
-
-                    let grid_row = gtk::ListBoxRow::builder()
-                        .activatable(false)
-                        .selectable(false)
-                        .child(&grid)
-                        .build();
-                    expander.add_row(&grid_row);
-                }
-            }
-
-            if camera_name.is_none() && metadata.map(|m| !m.has_data()).unwrap_or(true) {
-                expander.add_row(&detail_row("", "No EXIF data available"));
-            }
-
-            list.append(&expander);
-            vbox.append(&list);
-        }
-
-        // ── Location (only when GPS data present) ────────────────────────────
-        if let Some(meta) = metadata {
-            if let (Some(lat), Some(lon)) = (meta.gps_lat, meta.gps_lon) {
-                let list = boxed_list();
-                let coords_str = format!(
-                    "{}\u{b0}, {}\u{b0}",
-                    format_decimal(lat.abs(), 4),
-                    format_decimal(lon.abs(), 4),
-                );
-
-                let (expander, _) = expander_row(
-                    Some("mark-location-symbolic"),
-                    "Location",
-                    &coords_str,
-                    true,
-                );
-
-                expander.add_row(&detail_row("Latitude", &format_coordinate(lat, 'N', 'S')));
-                expander.add_row(&detail_row("Longitude", &format_coordinate(lon, 'E', 'W')));
-
-                if let Some(alt) = meta.gps_alt {
-                    expander.add_row(&detail_row("Altitude", &format!("{alt:.0} m")));
-                }
-
-                // "Open in Maps" button.
-                let btn_content = gtk::Box::builder()
-                    .orientation(gtk::Orientation::Horizontal)
-                    .spacing(8)
-                    .halign(gtk::Align::Center)
-                    .build();
-                btn_content.append(&gtk::Image::from_icon_name("find-location-symbolic"));
-                btn_content.append(&gtk::Label::new(Some("Open in Maps")));
-
-                let map_btn = gtk::Button::builder()
-                    .child(&btn_content)
-                    .margin_top(4)
-                    .margin_bottom(8)
-                    .margin_start(12)
-                    .margin_end(12)
-                    .build();
-                map_btn.add_css_class("outlined");
-
-                let geo_uri = format!("geo:{lat},{lon}");
-                map_btn.connect_clicked(move |btn| {
-                    let launcher = gtk::UriLauncher::new(&geo_uri);
-                    let window = btn.root().and_downcast::<gtk::Window>();
-                    launcher.launch(window.as_ref(), gio::Cancellable::NONE, |_| {});
-                });
-
-                let btn_row = gtk::ListBoxRow::builder()
-                    .activatable(false)
-                    .selectable(false)
-                    .child(&map_btn)
-                    .build();
-                expander.add_row(&btn_row);
-
-                list.append(&expander);
-                vbox.append(&list);
-            }
-        }
-
-        // ── File (collapsed by default) ──────────────────────────────────────
-        {
-            let list = boxed_list();
-            let (expander, _) = expander_row(
-                Some("document-open-symbolic"),
-                "File",
-                &item.original_filename,
-                false,
-            );
-            expander.add_row(&detail_row("Filename", &item.original_filename));
-            list.append(&expander);
-            vbox.append(&list);
-        }
+        vbox.append(&build_file_section(item));
 
         self.scrolled.set_child(Some(&vbox));
     }
+}
+
+// ── Section builders ────────────────────────────────────────────────────────
+
+fn build_date_section(item: &MediaItem) -> gtk::ListBox {
+    let list = boxed_list();
+    let (short_date, long_date, time_str) = format_date_parts(item.taken_at);
+    let (expander, _) = expander_row(
+        Some("x-office-calendar-symbolic"),
+        "Date",
+        &short_date,
+        true,
+    );
+    expander.add_row(&detail_row("Captured", &long_date));
+    expander.add_row(&detail_row("Time", &time_str));
+    list.append(&expander);
+    list
+}
+
+fn build_image_section(item: &MediaItem) -> gtk::ListBox {
+    let list = boxed_list();
+    let mp_str = match (item.width, item.height) {
+        (Some(w), Some(h)) => {
+            let mp = (w * h) as f64 / 1_000_000.0;
+            format!("{mp:.1} MP")
+        }
+        _ => "Unknown".to_string(),
+    };
+
+    let (expander, _) = expander_row(
+        Some("image-x-generic-symbolic"),
+        "Image",
+        &mp_str,
+        true,
+    );
+
+    if let (Some(w), Some(h)) = (item.width, item.height) {
+        expander.add_row(&detail_row("Dimensions", &format!("{w} \u{d7} {h}")));
+    }
+    expander.add_row(&detail_row("Resolution", &mp_str));
+
+    let format_str = item
+        .original_filename
+        .rsplit('.')
+        .next()
+        .map(|ext| ext.to_uppercase())
+        .unwrap_or_else(|| "Unknown".to_string());
+    expander.add_row(&detail_row("Format", &format_str));
+
+    list.append(&expander);
+    list
+}
+
+fn build_camera_section(metadata: Option<&MediaMetadataRecord>) -> gtk::ListBox {
+    let list = boxed_list();
+    let camera_name = metadata.and_then(|m| match (&m.camera_make, &m.camera_model) {
+        (Some(make), Some(model)) => {
+            if model.starts_with(make.as_str()) {
+                Some(model.clone())
+            } else {
+                Some(format!("{make} {model}"))
+            }
+        }
+        (Some(make), None) => Some(make.clone()),
+        (None, Some(model)) => Some(model.clone()),
+        _ => None,
+    });
+
+    let subtitle = camera_name.as_deref().unwrap_or("No data");
+    let (expander, _) = expander_row(
+        Some("camera-photo-symbolic"),
+        "Camera",
+        subtitle,
+        true,
+    );
+
+    if let Some(ref name) = camera_name {
+        expander.add_row(&detail_row("Camera", name));
+    }
+
+    if let Some(lens) = metadata.and_then(|m| m.lens_model.as_deref()) {
+        let lens_with_fl = metadata
+            .and_then(|m| m.focal_length)
+            .map(|fl| format!("{lens} \u{b7} {fl:.0}mm"))
+            .unwrap_or_else(|| lens.to_string());
+        expander.add_row(&detail_row("Lens", &lens_with_fl));
+    }
+
+    if let Some(grid_row) = build_exif_grid(metadata) {
+        expander.add_row(&grid_row);
+    }
+
+    if camera_name.is_none() && metadata.map(|m| !m.has_data()).unwrap_or(true) {
+        expander.add_row(&detail_row("", "No EXIF data available"));
+    }
+
+    list.append(&expander);
+    list
+}
+
+fn build_exif_grid(metadata: Option<&MediaMetadataRecord>) -> Option<gtk::ListBoxRow> {
+    let meta = metadata?;
+
+    let has_exif = meta.aperture.is_some()
+        || meta.shutter_str.is_some()
+        || meta.iso.is_some()
+        || meta.focal_length.is_some();
+
+    if !has_exif {
+        return None;
+    }
+
+    let grid = gtk::Grid::builder()
+        .column_spacing(8)
+        .row_spacing(8)
+        .margin_top(8)
+        .margin_bottom(8)
+        .margin_start(12)
+        .margin_end(12)
+        .column_homogeneous(true)
+        .build();
+
+    let mut row = 0i32;
+    let mut col = 0i32;
+
+    if let Some(f) = meta.aperture {
+        grid.attach(&exif_card("Aperture", &format!("f/{f:.1}")), col, row, 1, 1);
+        col += 1;
+    }
+    if let Some(s) = &meta.shutter_str {
+        grid.attach(&exif_card("Shutter", &format!("{s}s")), col, row, 1, 1);
+        col += 1;
+    }
+    if col >= 2 {
+        row += 1;
+        col = 0;
+    }
+    if let Some(iso) = meta.iso {
+        grid.attach(&exif_card("ISO", &format!("{iso}")), col, row, 1, 1);
+        col += 1;
+    }
+    if let Some(fl) = meta.focal_length {
+        grid.attach(&exif_card("Focal", &format!("{fl:.0}mm")), col, row, 1, 1);
+    }
+
+    Some(
+        gtk::ListBoxRow::builder()
+            .activatable(false)
+            .selectable(false)
+            .child(&grid)
+            .build(),
+    )
+}
+
+fn build_location_section(metadata: Option<&MediaMetadataRecord>) -> Option<gtk::ListBox> {
+    let meta = metadata?;
+    let (lat, lon) = match (meta.gps_lat, meta.gps_lon) {
+        (Some(lat), Some(lon)) => (lat, lon),
+        _ => return None,
+    };
+
+    let list = boxed_list();
+    let coords_str = format!(
+        "{}\u{b0}, {}\u{b0}",
+        format_decimal(lat.abs(), 4),
+        format_decimal(lon.abs(), 4),
+    );
+
+    let (expander, _) = expander_row(
+        Some("mark-location-symbolic"),
+        "Location",
+        &coords_str,
+        true,
+    );
+
+    expander.add_row(&detail_row("Latitude", &format_coordinate(lat, 'N', 'S')));
+    expander.add_row(&detail_row("Longitude", &format_coordinate(lon, 'E', 'W')));
+
+    if let Some(alt) = meta.gps_alt {
+        expander.add_row(&detail_row("Altitude", &format!("{alt:.0} m")));
+    }
+
+    let btn_content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Horizontal)
+        .spacing(8)
+        .halign(gtk::Align::Center)
+        .build();
+    btn_content.append(&gtk::Image::from_icon_name("find-location-symbolic"));
+    btn_content.append(&gtk::Label::new(Some("Open in Maps")));
+
+    let map_btn = gtk::Button::builder()
+        .child(&btn_content)
+        .margin_top(4)
+        .margin_bottom(8)
+        .margin_start(12)
+        .margin_end(12)
+        .build();
+    map_btn.add_css_class("outlined");
+
+    let geo_uri = format!("geo:{lat},{lon}");
+    map_btn.connect_clicked(move |btn| {
+        let launcher = gtk::UriLauncher::new(&geo_uri);
+        let window = btn.root().and_downcast::<gtk::Window>();
+        launcher.launch(window.as_ref(), gio::Cancellable::NONE, |_| {});
+    });
+
+    let btn_row = gtk::ListBoxRow::builder()
+        .activatable(false)
+        .selectable(false)
+        .child(&map_btn)
+        .build();
+    expander.add_row(&btn_row);
+
+    list.append(&expander);
+    Some(list)
+}
+
+fn build_file_section(item: &MediaItem) -> gtk::ListBox {
+    let list = boxed_list();
+    let (expander, _) = expander_row(
+        Some("document-open-symbolic"),
+        "File",
+        &item.original_filename,
+        false,
+    );
+    expander.add_row(&detail_row("Filename", &item.original_filename));
+    list.append(&expander);
+    list
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extract five section-builder functions (`build_date_section`, `build_image_section`, `build_camera_section`, `build_location_section`, `build_file_section`) and a `build_exif_grid` helper from the monolithic `populate()` method
- `populate()` is now a short coordinator (~15 lines) that assembles the panel by calling section builders
- Pure refactor — no behavior changes

Closes #407

## Test plan
- [ ] `make check` passes (verified)
- [ ] `make run-dev` — open viewer info panel, verify all sections render identically (Date, Image, Camera with EXIF grid, Location with map button, File)
- [ ] Verify items with no EXIF data still show "No EXIF data available"
- [ ] Verify items without GPS still omit the Location section

🤖 Generated with [Claude Code](https://claude.com/claude-code)