### PR TITLE
refactor: split album_grid.rs — context menu, selection, drill-down

### DIFF
--- a/src/ui/album_grid.rs
+++ b/src/ui/album_grid.rs
@@ -121,7 +121,7 @@ impl AlbumGridView {
         action_bar.set_revealed(false);
 
         // ── Wire selection mode with the real widgets ────────────────────
-        let _exit_selection = selection::wire_selection_mode(
+        selection::wire_selection_mode(
             &enter_selection,
             &header,
             &new_album_btn,

--- a/src/ui/album_grid/actions.rs
+++ b/src/ui/album_grid/actions.rs
@@ -315,8 +315,18 @@ fn wire_rename_button(
                                 name: new_name,
                             });
                         }
-                        Ok(Err(e)) => tracing::error!("failed to rename album: {e}"),
-                        Err(e) => tracing::error!("tokio join error: {e}"),
+                        Ok(Err(e)) => {
+                            tracing::error!("failed to rename album: {e}");
+                            bs.send(crate::app_event::AppEvent::Error(
+                                format!("Failed to rename album: {e}"),
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::error!("tokio join error: {e}");
+                            bs.send(crate::app_event::AppEvent::Error(
+                                format!("Failed to rename album: {e}"),
+                            ));
+                        }
                     }
                 });
             });
@@ -366,8 +376,18 @@ fn wire_delete_button(
                                 id: AlbumId::from_raw(aid),
                             });
                         }
-                        Ok(Err(e)) => tracing::error!("failed to delete album: {e}"),
-                        Err(e) => tracing::error!("tokio join error: {e}"),
+                        Ok(Err(e)) => {
+                            tracing::error!("failed to delete album: {e}");
+                            bs.send(crate::app_event::AppEvent::Error(
+                                format!("Failed to delete album: {e}"),
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::error!("tokio join error: {e}");
+                            bs.send(crate::app_event::AppEvent::Error(
+                                format!("Failed to delete album: {e}"),
+                            ));
+                        }
                     }
                 });
             });

--- a/src/ui/album_grid/selection.rs
+++ b/src/ui/album_grid/selection.rs
@@ -33,7 +33,7 @@ pub(crate) fn wire_selection_mode(
     library: &Arc<dyn Library>,
     tokio: &tokio::runtime::Handle,
     bus_sender: &crate::event_bus::EventSender,
-) -> gio::SimpleAction {
+) {
     // ── Enter selection mode ────────────────────────────────────────
     {
         let sm = Rc::clone(selection_mode);
@@ -107,7 +107,6 @@ pub(crate) fn wire_selection_mode(
         &exit_selection,
     );
 
-    exit_selection
 }
 
 /// Walk the grid view's children and toggle selection checkboxes on all cards.
@@ -207,8 +206,18 @@ fn wire_batch_delete(
                                 id: AlbumId::from_raw(aid.clone()),
                             });
                         }
-                        Ok(Err(e)) => tracing::error!("failed to delete album {aid}: {e}"),
-                        Err(e) => tracing::error!("tokio join error: {e}"),
+                        Ok(Err(e)) => {
+                            tracing::error!("failed to delete album {aid}: {e}");
+                            bs.send(crate::app_event::AppEvent::Error(
+                                format!("Failed to delete album: {e}"),
+                            ));
+                        }
+                        Err(e) => {
+                            tracing::error!("tokio join error: {e}");
+                            bs.send(crate::app_event::AppEvent::Error(
+                                format!("Failed to delete album: {e}"),
+                            ));
+                        }
                     }
                 }
                 exit.activate(None);


### PR DESCRIPTION
## Summary
- Extract `album_grid/actions.rs` — context menu builder + shared `open_album_drilldown()` helper
- Extract `album_grid/selection.rs` — enter/exit selection mode, batch delete with confirmation
- `album_grid.rs` reduced from 830 → 428 lines (coordinator only)
- Eliminates duplicated drill-down logic between `connect_activate` and context menu Open button

Closes #396

## Test plan
- [ ] Albums view loads and displays album cards
- [ ] Click album card → drill-down to photo grid
- [ ] Right-click album → context menu (Open, Rename, Pin, Delete) works
- [ ] Selection mode: enter via menu, select albums, batch delete, cancel
- [ ] `make lint` and `make test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)