### PR TITLE
fix: zoom buttons disabled on app startup

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -219,6 +219,12 @@ impl MomentsWindow {
 
         sidebar.select_first();
 
+        // Explicitly navigate to "photos" and install view actions.
+        // AdwSidebar::set_selected() does not emit `activated` (only user
+        // interactions do), so the sidebar callback that installs zoom
+        // actions won't fire on startup.
+        self.navigate("photos");
+
         self.install_show_toast_action();
         self.install_toggle_sidebar_action();
 


### PR DESCRIPTION
## Summary
- `AdwSidebar::set_selected()` does not emit the `activated` signal — only user interactions do
- The sidebar callback that calls `navigate("photos")` and installs view actions never fires during startup
- Fix: explicitly call `self.navigate("photos")` after `sidebar.select_first()` to install the zoom action group immediately

Closes #352

## Test plan
- [ ] Launch app — zoom in/out buttons are enabled immediately
- [ ] Zoom in/out works on first click without switching tabs first
- [ ] Switching between sidebar views still installs correct actions
- [ ] `make lint` and `make test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)