### PR TITLE
fix: People view — Show Unnamed icon missing

### DIFF
--- a/src/ui/collection_grid.rs
+++ b/src/ui/collection_grid.rs
@@ -65,7 +65,7 @@ impl CollectionGridView {
         });
 
         let unnamed_toggle = gtk::ToggleButton::builder()
-            .icon_name("person-symbolic")
+            .icon_name("avatar-default-symbolic")
             .tooltip_text(gettext("Show Unnamed"))
             .build();
         unnamed_toggle.add_css_class("flat");


### PR DESCRIPTION
## Summary
- `person-symbolic` does not exist in the Adwaita icon theme — the "Show Unnamed" toggle button rendered blank
- Replaced with `avatar-default-symbolic` which exists and fits the purpose

Closes #383

## Test plan
- [ ] Open People view — "Show Unnamed" toggle has a visible person avatar icon
- [ ] "Show Hidden" toggle still has its eye icon
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)