### PR TITLE
fix: guard unsafe unwraps on library borrow and edit session

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -518,8 +518,12 @@ impl MomentsApplication {
                         // The dispatcher is a unit struct; the real work is the
                         // subscriber closure registered in new(), which lives in
                         // the bus's thread-local SUBSCRIBERS for the app lifetime.
+                        let Some(lib) = app.imp().library.borrow().as_ref().map(Arc::clone) else {
+                            tracing::error!("library not initialised when creating dispatcher");
+                            return;
+                        };
                         let _dispatcher = crate::commands::dispatcher::CommandDispatcher::new(
-                            Arc::clone(app.imp().library.borrow().as_ref().unwrap()),
+                            lib,
                             tokio.clone(),
                             &bus,
                         );

--- a/src/ui/viewer/edit_panel.rs
+++ b/src/ui/viewer/edit_panel.rs
@@ -145,7 +145,13 @@ impl EditPanel {
         self.sync_ui_from_state();
 
         // Render initial preview if state is not identity.
-        if !self.session.borrow().as_ref().unwrap().state.is_identity() {
+        let is_identity = self
+            .session
+            .borrow()
+            .as_ref()
+            .map(|s| s.state.is_identity())
+            .unwrap_or(true);
+        if !is_identity {
             self.render_preview();
         }
     }


### PR DESCRIPTION
## Summary
- `application.rs:522` — library `RefCell<Option<>>` unwrap replaced with let-else guard + early return
- `edit_panel.rs:148` — session `RefCell<Option<>>` unwrap replaced with `.map().unwrap_or(true)`
- Both were potential panics if preconditions weren't met (race conditions during initialization)

Closes #372

## Test plan
- [ ] App starts normally — no behaviour change
- [ ] Edit panel opens and renders preview correctly
- [ ] `make lint` and `make test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)