### PR TITLE
chore: remove editing feature flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,3 @@ Design docs live in `docs/` and follow a consistent format with issue links, sta
 
 Some widgets use Blueprint (`.blp`) declarative templates compiled to GTK XML: `window.blp`, `setup_window.blp` + pages, `import_dialog.blp`, `shortcuts-dialog.blp`. New widgets should evaluate whether their layout is static enough to benefit from Blueprint (see #417 for the decision framework).
 
-### Feature flags
-
-The `editing` Cargo feature gates the edit button in the viewer. It is disabled by default but will be enabled for the next Flathub release (v0.2.0). Enable with `cargo run --features editing` for development.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["photos", "gnome", "gtk4", "image-management"]
 categories = ["multimedia::images"]
 
 [features]
-editing = []
 integration-tests = []
 
 [dependencies]

--- a/io.github.justinf555.Moments.dev.json
+++ b/io.github.justinf555.Moments.dev.json
@@ -44,7 +44,6 @@
             "builddir" : true,
             "buildsystem" : "meson",
             "config-opts" : [
-                "-Dediting=true",
                 "--libdir=lib"
             ],
             "sources" : [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('editing', type: 'boolean', value: false, description: 'Enable the photo editing feature (WIP)')

--- a/src/meson.build
+++ b/src/meson.build
@@ -61,9 +61,6 @@ else
   rust_target = 'debug'
 endif
 
-if get_option('editing')
-  cargo_opt += [ '--features', 'editing' ]
-endif
 
 cargo_build = custom_target(
   'cargo-build',

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -209,7 +209,6 @@ impl PhotoViewer {
             .icon_name("document-edit-symbolic")
             .tooltip_text(gettext("Edit Photo"))
             .build();
-        #[cfg(feature = "editing")]
         header.pack_end(&edit_toggle);
 
         // ── Info toggle ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Editing feature is complete enough to ship unconditionally — remove the feature gate
- Removes `editing` Cargo feature, `#[cfg(feature = "editing")]` guard, meson option, and dev manifest config
- Edit button now always appears in the photo viewer headerbar

## Test plan
- [x] `make lint` — clean
- [x] `make test` — 228 tests pass
- [ ] `make run-dev` — verify edit button appears in viewer headerbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)