### PR TITLE
refactor: unify album delete to use EventBus command dispatch

### DIFF
--- a/src/app_event.rs
+++ b/src/app_event.rs
@@ -74,6 +74,9 @@ pub enum AppEvent {
         name: String,
         ids: Vec<MediaId>,
     },
+    DeleteAlbumRequested {
+        ids: Vec<AlbumId>,
+    },
 
     // ── Results (CommandDispatcher → subscribers) ────────────────────────────
     FavoriteChanged {

--- a/src/commands/delete_album.rs
+++ b/src/commands/delete_album.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::{debug, error};
+
+use crate::app_event::AppEvent;
+use crate::event_bus::EventSender;
+use crate::library::Library;
+
+use super::CommandHandler;
+
+pub struct DeleteAlbumCommand;
+
+#[async_trait]
+impl CommandHandler for DeleteAlbumCommand {
+    fn handles(&self, event: &AppEvent) -> bool {
+        matches!(event, AppEvent::DeleteAlbumRequested { .. })
+    }
+
+    async fn execute(
+        &self,
+        event: AppEvent,
+        library: &Arc<dyn Library>,
+        bus: &EventSender,
+    ) {
+        let AppEvent::DeleteAlbumRequested { ids } = event else { return };
+        for id in ids {
+            match library.delete_album(&id).await {
+                Ok(()) => {
+                    debug!(album_id = %id, "album deleted");
+                    bus.send(AppEvent::AlbumDeleted { id });
+                }
+                Err(e) => {
+                    error!(album_id = %id, "delete_album failed: {e}");
+                    bus.send(AppEvent::Error(format!("Failed to delete album: {e}")));
+                }
+            }
+        }
+    }
+}

--- a/src/commands/dispatcher.rs
+++ b/src/commands/dispatcher.rs
@@ -7,6 +7,7 @@ use super::CommandHandler;
 use super::add_to_album::AddToAlbumCommand;
 use super::create_album::CreateAlbumCommand;
 use super::delete::DeleteCommand;
+use super::delete_album::DeleteAlbumCommand;
 use super::favorite::FavoriteCommand;
 use super::remove_from_album::RemoveFromAlbumCommand;
 use super::restore::RestoreCommand;
@@ -36,6 +37,7 @@ impl CommandDispatcher {
             Arc::new(RemoveFromAlbumCommand),
             Arc::new(AddToAlbumCommand),
             Arc::new(CreateAlbumCommand),
+            Arc::new(DeleteAlbumCommand),
         ];
 
         let tx = bus.sender();

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod add_to_album;
 pub mod create_album;
 pub mod delete;
+pub mod delete_album;
 pub mod dispatcher;
 pub mod favorite;
 pub mod remove_from_album;

--- a/src/ui/album_grid.rs
+++ b/src/ui/album_grid.rs
@@ -175,8 +175,6 @@ impl AlbumGridView {
             &multi_selection,
             &store,
             &selection_mode,
-            &library,
-            &tokio,
             &bus_sender,
         );
         action_group.add_action(&enter_selection);

--- a/src/ui/album_grid/actions.rs
+++ b/src/ui/album_grid/actions.rs
@@ -168,7 +168,7 @@ pub(crate) fn show_context_menu(
 
     // Wire Delete.
     wire_delete_button(
-        &delete_btn, &popover, library, tokio, bus_sender,
+        &delete_btn, &popover, bus_sender,
         grid_view, &album_id_str, &album_name,
     );
 
@@ -321,20 +321,15 @@ fn wire_rename_button(
 }
 
 /// Wire the Delete button to show a confirmation dialog.
-#[allow(clippy::too_many_arguments)]
 fn wire_delete_button(
     delete_btn: &gtk::Button,
     popover: &gtk::Popover,
-    library: &Arc<dyn Library>,
-    tokio: &tokio::runtime::Handle,
     bus_sender: &crate::event_bus::EventSender,
     grid_view: &gtk::GridView,
     album_id_str: &str,
     album_name: &str,
 ) {
     let pop = popover.downgrade();
-    let lib = Arc::clone(library);
-    let tk = tokio.clone();
     let bs = bus_sender.clone();
     let aid = album_id_str.to_owned();
     let aname = album_name.to_owned();
@@ -343,38 +338,12 @@ fn wire_delete_button(
         if let Some(p) = pop.upgrade() {
             p.popdown();
         }
-        let lib = Arc::clone(&lib);
-        let tk = tk.clone();
         let bs = bs.clone();
         let aid = aid.clone();
         if let Some(win) = gv_ref.root().and_then(|r| r.downcast::<gtk::Window>().ok()) {
             album_dialogs::show_delete_album_dialog(&win, &aname, move || {
-                let lib = Arc::clone(&lib);
-                let tk = tk.clone();
-                let bs = bs.clone();
-                let aid = aid.clone();
-                glib::MainContext::default().spawn_local(async move {
-                    let id = AlbumId::from_raw(aid.clone());
-                    match tk.spawn(async move { lib.delete_album(&id).await }).await {
-                        Ok(Ok(())) => {
-                            debug!(album_id = %aid, "album deleted");
-                            bs.send(crate::app_event::AppEvent::AlbumDeleted {
-                                id: AlbumId::from_raw(aid),
-                            });
-                        }
-                        Ok(Err(e)) => {
-                            tracing::error!("failed to delete album: {e}");
-                            bs.send(crate::app_event::AppEvent::Error(
-                                format!("Failed to delete album: {e}"),
-                            ));
-                        }
-                        Err(e) => {
-                            tracing::error!("tokio join error: {e}");
-                            bs.send(crate::app_event::AppEvent::Error(
-                                format!("Failed to delete album: {e}"),
-                            ));
-                        }
-                    }
+                bs.send(crate::app_event::AppEvent::DeleteAlbumRequested {
+                    ids: vec![AlbumId::from_raw(aid.clone())],
                 });
             });
         }

--- a/src/ui/album_grid/selection.rs
+++ b/src/ui/album_grid/selection.rs
@@ -1,13 +1,10 @@
 use std::rc::Rc;
-use std::sync::Arc;
 
 use gettextrs::gettext;
 use adw::prelude::*;
-use gtk::{gio, glib};
-use tracing::debug;
+use gtk::gio;
 
 use crate::library::album::AlbumId;
-use crate::library::Library;
 
 use super::card;
 use super::item::AlbumItemObject;
@@ -30,8 +27,6 @@ pub(crate) fn wire_selection_mode(
     multi_selection: &gtk::MultiSelection,
     store: &gio::ListStore,
     selection_mode: &Rc<std::cell::Cell<bool>>,
-    library: &Arc<dyn Library>,
-    tokio: &tokio::runtime::Handle,
     bus_sender: &crate::event_bus::EventSender,
 ) {
     // ── Enter selection mode ────────────────────────────────────────
@@ -101,8 +96,6 @@ pub(crate) fn wire_selection_mode(
         action_bar,
         multi_selection,
         store,
-        library,
-        tokio,
         bus_sender,
         &exit_selection,
     );
@@ -129,8 +122,6 @@ fn wire_batch_delete(
     action_bar: &gtk::ActionBar,
     multi_selection: &gtk::MultiSelection,
     store: &gio::ListStore,
-    library: &Arc<dyn Library>,
-    tokio: &tokio::runtime::Handle,
     bus_sender: &crate::event_bus::EventSender,
     exit_selection: &gio::SimpleAction,
 ) {
@@ -143,8 +134,6 @@ fn wire_batch_delete(
 
     let sel = multi_selection.clone();
     let st = store.clone();
-    let lib = Arc::clone(library);
-    let tk = tokio.clone();
     let bs = bus_sender.clone();
     let exit = exit_selection.clone();
     delete_btn.connect_clicked(move |btn| {
@@ -158,13 +147,11 @@ fn wire_batch_delete(
         for i in 0..st.n_items() {
             if sel.is_selected(i) {
                 if let Some(obj) = st.item(i).and_then(|o| o.downcast::<AlbumItemObject>().ok()) {
-                    ids.push(obj.album().id.as_str().to_owned());
+                    ids.push(AlbumId::from_raw(obj.album().id.as_str().to_owned()));
                 }
             }
         }
 
-        let lib = Arc::clone(&lib);
-        let tk = tk.clone();
         let bs = bs.clone();
         let exit = exit.clone();
         let msg = if n == 1 {
@@ -185,43 +172,14 @@ fn wire_batch_delete(
         dialog.set_default_response(Some("cancel"));
         dialog.set_close_response("cancel");
 
-        let ids_clone = ids.clone();
         dialog.connect_response(None, move |_, response| {
             if response != "delete" {
                 return;
             }
-            let lib = Arc::clone(&lib);
-            let tk = tk.clone();
-            let bs = bs.clone();
-            let exit = exit.clone();
-            let ids = ids_clone.clone();
-            glib::MainContext::default().spawn_local(async move {
-                for aid in &ids {
-                    let lib = Arc::clone(&lib);
-                    let id = AlbumId::from_raw(aid.clone());
-                    match tk.spawn(async move { lib.delete_album(&id).await }).await {
-                        Ok(Ok(())) => {
-                            debug!(album_id = %aid, "album deleted (batch)");
-                            bs.send(crate::app_event::AppEvent::AlbumDeleted {
-                                id: AlbumId::from_raw(aid.clone()),
-                            });
-                        }
-                        Ok(Err(e)) => {
-                            tracing::error!("failed to delete album {aid}: {e}");
-                            bs.send(crate::app_event::AppEvent::Error(
-                                format!("Failed to delete album: {e}"),
-                            ));
-                        }
-                        Err(e) => {
-                            tracing::error!("tokio join error: {e}");
-                            bs.send(crate::app_event::AppEvent::Error(
-                                format!("Failed to delete album: {e}"),
-                            ));
-                        }
-                    }
-                }
-                exit.activate(None);
+            bs.send(crate::app_event::AppEvent::DeleteAlbumRequested {
+                ids: ids.clone(),
             });
+            exit.activate(None);
         });
 
         if let Some(win) = btn.root().and_then(|r| r.downcast::<gtk::Window>().ok()) {


### PR DESCRIPTION
## Summary
- Add `DeleteAlbumRequested` command event and `DeleteAlbumCommand` handler following the established pattern (trash, favourite, create album, etc.)
- Replace direct `lib.delete_album()` calls in both context menu and batch delete with event bus dispatch
- Remove `library` and `tokio` params from `wire_delete_button` and `wire_batch_delete` (no longer needed — command handler owns the library call)
- Net -29 lines: simpler UI code, consistent architecture

Closes #381

## Test plan
- [x] `make lint` — clean
- [x] `make test` — 227 passed
- [x] `make test-integration` — 45 passed
- [ ] `make run-dev` — manual smoke test: single album delete (context menu) + batch delete (selection mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)