### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "moments"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moments"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 description = "A GNOME photo management app with local and Immich server support"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('moments', 'rust', 
-          version: '0.1.4',
+          version: '0.2.0',
     meson_version: '>= 1.0.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )


### PR DESCRIPTION
Bump version to 0.2.0. Merging this PR will automatically create a git tag and GitHub Release.