### PR TITLE
fix: show empty state by default in photo grid

### DIFF
--- a/src/ui/photo_grid.rs
+++ b/src/ui/photo_grid.rs
@@ -117,7 +117,7 @@ mod photo_grid_imp {
             stack.set_transition_type(gtk::StackTransitionType::Crossfade);
             stack.add_named(&scrolled, Some("grid"));
             stack.add_named(&empty_page, Some("empty"));
-            stack.set_visible_child_name("grid");
+            stack.set_visible_child_name("empty");
             stack.set_parent(&*obj);
 
             self.grid_view.set(grid_view).unwrap();


### PR DESCRIPTION
## Summary

Closes #441

One-line fix: default the photo grid content stack to `"empty"` instead of `"grid"`. The `on_page_ready` callback switches to `"grid"` when items load. For views with no items (e.g. empty Trash), the empty status page shows immediately instead of briefly displaying an empty grid.

## Test plan

- [ ] Navigate to Trash with no trashed items — should show "Trash is empty" status page
- [ ] Trash a photo, navigate to Trash — should show the grid with the item
- [ ] Restore all items from Trash — should switch back to empty status page
- [ ] Photos/Favourites/Recent views still show grid correctly when items exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)