### PR TITLE
fix: log JoinError on sidebar album load

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -267,8 +267,10 @@ impl MomentsWindow {
                 let result = tk
                     .spawn(async move { lib.library_stats().await })
                     .await;
-                if let Ok(Ok(stats)) = result {
-                    sb.set_trash_count(stats.trashed_count as u32);
+                match result {
+                    Ok(Ok(stats)) => sb.set_trash_count(stats.trashed_count as u32),
+                    Ok(Err(e)) => warn!("failed to load library stats: {e}"),
+                    Err(e) => error!("library stats task panicked: {e}"),
                 }
             });
         }


### PR DESCRIPTION
## Summary

Closes #366

Replace `if let Ok(Ok(albums))` with a three-arm match to log both `LibraryError` and `JoinError` (task panic/cancellation) when loading albums for the sidebar pinned section.

## Test plan

- [ ] Sidebar pinned albums still load correctly
- [ ] With debug logging, errors are visible if album load fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)