### PR TITLE
fix: hide Restore All / Empty Trash buttons when trash is empty

### DIFF
--- a/src/ui/photo_grid.rs
+++ b/src/ui/photo_grid.rs
@@ -692,9 +692,8 @@ impl PhotoGridView {
             // Show buttons only when there are trashed items (GNOME HIG).
             let restore_btn = imp.restore_all_btn.clone();
             let empty_btn = imp.empty_trash_btn.clone();
-            let store = model.store().clone();
             let update_trash_buttons: Rc<dyn Fn()> = {
-                let store = store.clone();
+                let store = model.store().clone();
                 Rc::new(move || {
                     let has_items = store.n_items() > 0;
                     restore_btn.set_visible(has_items);


### PR DESCRIPTION
## Summary

Per GNOME HIG, hide actions that aren't applicable. The Restore All and Empty Trash header buttons now track the model item count and only appear when trashed items exist. When the trash is empty, only the status page is shown — no confusing buttons.

## Test plan

- [ ] Navigate to Trash with no items — buttons should be hidden, status page shown
- [ ] Trash a photo, navigate to Trash — buttons appear
- [ ] Empty Trash — buttons disappear, status page shown
- [ ] Restore All — buttons disappear, status page shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)