### PR TITLE
fix: theme-aware filter-none swatch and improved hidden person contrast

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -58,9 +58,10 @@ collection-grid-cell .collection-thumbnail-frame {
 /* Custom rule: Adwaita has .dim-label but no whole-widget dimming class.
  * Hidden people need to be visually de-emphasised while remaining
  * recognisable, so we reduce opacity on the thumbnail only (not the
- * whole cell) so the overlay icon remains fully visible. */
+ * whole cell) so the overlay icon remains fully visible.
+ * 0.5 balances de-emphasis with WCAG contrast accessibility. */
 collection-grid-cell.hidden-person .collection-thumbnail-frame {
-    opacity: 0.4;
+    opacity: 0.5;
 }
 
 /* Custom rule: the eye-slash overlay icon on hidden-person thumbnails
@@ -113,7 +114,7 @@ collection-grid-cell .hidden-icon {
     padding: 2px;
 }
 
-.filter-none   { background: linear-gradient(135deg, #e8e8e8, #c0c0c0); }
+.filter-none   { background: linear-gradient(135deg, @window_bg_color, @borders); }
 .filter-bw     { background: linear-gradient(135deg, #666666, #333333); }
 .filter-vivid  { background: linear-gradient(135deg, #e07020, #3080d0); }
 .filter-cool   { background: linear-gradient(135deg, #6090c0, #90b8e0); }


### PR DESCRIPTION
## Summary

Closes #327, closes #328

Two CSS fixes:

1. **#327** — Replace hardcoded hex colours on the "None" filter swatch (`#e8e8e8`/`#c0c0c0`) with `@window_bg_color`/`@borders` theme variables. The swatch now adapts to light/dark themes instead of being nearly invisible in light mode.

2. **#328** — Bump hidden-person thumbnail opacity from 0.4 to 0.5 for better accessibility contrast. The overlay icon is already always visible (not hover-dependent), and the accessible label is set — this improves the visual indication for sighted users with low vision.

## Test plan

- [ ] Edit panel: filter-none swatch visible in both light and dark themes
- [ ] People view: hidden persons are visually dimmed but still recognisable
- [ ] Hidden person overlay icon (eye-slash) visible in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)