### PR TITLE
fix: correct accessible role and truncate API errors

### DIFF
--- a/src/library/immich_client.rs
+++ b/src/library/immich_client.rs
@@ -4,6 +4,14 @@ use tracing::{debug, instrument};
 
 use super::error::LibraryError;
 
+/// Truncate an API error body to avoid leaking server internals in toasts.
+fn truncate_error_body(body: &str, max_len: usize) -> &str {
+    match body.char_indices().nth(max_len) {
+        Some((idx, _)) => &body[..idx],
+        None => body,
+    }
+}
+
 /// HTTP client for the Immich server API.
 ///
 /// Uses session-based authentication (`Authorization: Bearer {token}`).
@@ -80,7 +88,8 @@ impl ImmichClient {
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
             return Err(LibraryError::Immich(format!(
-                "login failed with status {status}: {body}"
+                "login failed with status {status}: {}",
+                truncate_error_body(&body, 200),
             )));
         }
 
@@ -199,7 +208,8 @@ impl ImmichClient {
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
             return Err(LibraryError::Immich(format!(
-                "{method} {path} returned {status}: {body}"
+                "{method} {path} returned {status}: {}",
+                truncate_error_body(&body, 200),
             )));
         }
 
@@ -334,7 +344,8 @@ impl ImmichClient {
         if !status_code.is_success() {
             let body = resp.text().await.unwrap_or_default();
             return Err(LibraryError::Immich(format!(
-                "upload returned {status_code}: {body}"
+                "upload returned {status_code}: {}",
+                truncate_error_body(&body, 200),
             )));
         }
 

--- a/src/ui/collection_grid/cell.blp
+++ b/src/ui/collection_grid/cell.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 
 template $MomentsCollectionGridCell : Gtk.Widget {
-  accessible-role: button;
+  accessible-role: grid_cell;
 
   Gtk.Frame thumbnail_frame {
     halign: center;


### PR DESCRIPTION
## Summary

Closes #330, closes #332

1. **#330** — Change `CollectionGridCell` accessible-role from `button` to `grid_cell` in the Blueprint template. Screen readers now get correct grid navigation semantics instead of treating each cell as a button.

2. **#332** — Truncate Immich API error response bodies to 200 characters before storing in error messages. Prevents server internals (stack traces, paths, version info) from leaking into user-visible error toasts.

## Test plan

- [ ] People view: screen reader announces cells with grid semantics (if testable)
- [ ] Immich connection error: toast shows truncated message, not full server response

🤖 Generated with [Claude Code](https://claude.com/claude-code)