### PR TITLE
refactor: extract shared update_star_button helper

### DIFF
--- a/src/ui/video_viewer.rs
+++ b/src/ui/video_viewer.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use adw::prelude::*;
 use adw::subclass::prelude::*;
-use gettextrs::gettext;
 use gtk::{gdk, gio, glib};
 use tracing::debug;
 
@@ -172,24 +171,7 @@ impl VideoViewer {
         {
             let items = imp.items.borrow();
             if let Some(obj) = items.get(index) {
-                let is_fav = obj.is_favorite();
-                imp.star_btn.set_icon_name(if is_fav {
-                    "starred-symbolic"
-                } else {
-                    "non-starred-symbolic"
-                });
-                if is_fav {
-                    imp.star_btn.add_css_class("warning");
-                } else {
-                    imp.star_btn.remove_css_class("warning");
-                }
-                let fav_label = if is_fav {
-                    gettext("Remove from favourites")
-                } else {
-                    gettext("Add to favourites")
-                };
-                imp.star_btn
-                    .update_property(&[gtk::accessible::Property::Label(&fav_label)]);
+                crate::ui::widgets::update_star_button(&imp.star_btn, obj.is_favorite());
             }
         }
 
@@ -349,18 +331,7 @@ impl VideoViewer {
 
                 let was_fav = obj.is_favorite();
                 let new_fav = !was_fav;
-                btn.set_icon_name(if new_fav { "starred-symbolic" } else { "non-starred-symbolic" });
-                if new_fav {
-                    btn.add_css_class("warning");
-                } else {
-                    btn.remove_css_class("warning");
-                }
-                let fav_label = if new_fav {
-                    gettext("Remove from favourites")
-                } else {
-                    gettext("Add to favourites")
-                };
-                btn.update_property(&[gtk::accessible::Property::Label(&fav_label)]);
+                crate::ui::widgets::update_star_button(btn, new_fav);
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use adw::prelude::*;
 use adw::subclass::prelude::*;
-use gettextrs::gettext;
 use gtk::{gdk, glib};
 
 use crate::library::media::{MediaId, MediaMetadataRecord};
@@ -207,24 +206,7 @@ impl PhotoViewer {
         {
             let items = imp.items.borrow();
             if let Some(obj) = items.get(index) {
-                let is_fav = obj.is_favorite();
-                imp.star_btn.set_icon_name(if is_fav {
-                    "starred-symbolic"
-                } else {
-                    "non-starred-symbolic"
-                });
-                if is_fav {
-                    imp.star_btn.add_css_class("warning");
-                } else {
-                    imp.star_btn.remove_css_class("warning");
-                }
-                let fav_label = if is_fav {
-                    gettext("Remove from favourites")
-                } else {
-                    gettext("Add to favourites")
-                };
-                imp.star_btn
-                    .update_property(&[gtk::accessible::Property::Label(&fav_label)]);
+                crate::ui::widgets::update_star_button(&imp.star_btn, obj.is_favorite());
             }
         }
 
@@ -328,22 +310,7 @@ impl PhotoViewer {
                 let new_fav = !was_fav;
 
                 // Optimistic: update icon and current item immediately.
-                btn.set_icon_name(if new_fav {
-                    "starred-symbolic"
-                } else {
-                    "non-starred-symbolic"
-                });
-                if new_fav {
-                    btn.add_css_class("warning");
-                } else {
-                    btn.remove_css_class("warning");
-                }
-                let fav_label = if new_fav {
-                    gettext("Remove from favourites")
-                } else {
-                    gettext("Add to favourites")
-                };
-                btn.update_property(&[gtk::accessible::Property::Label(&fav_label)]);
+                crate::ui::widgets::update_star_button(btn, new_fav);
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,6 +1,7 @@
 //! Shared reusable UI components used across the info and edit panels.
 
 use adw::prelude::*;
+use gettextrs::gettext;
 use gtk::glib::object::IsA;
 
 /// Create an expander row with an optional icon prefix, title left,
@@ -95,6 +96,30 @@ pub fn wrap_in_row(widget: &impl IsA<gtk::Widget>) -> gtk::ListBoxRow {
         .selectable(false)
         .child(widget)
         .build()
+}
+
+/// Update a star (favourite) button's icon, CSS class, and accessible label.
+///
+/// Used by photo viewer, video viewer, and anywhere an icon-only favourite
+/// toggle button is needed. Sets `starred-symbolic` / `non-starred-symbolic`
+/// icon and toggles the `warning` CSS class for the gold star colour.
+pub fn update_star_button(btn: &gtk::Button, is_favourite: bool) {
+    btn.set_icon_name(if is_favourite {
+        "starred-symbolic"
+    } else {
+        "non-starred-symbolic"
+    });
+    if is_favourite {
+        btn.add_css_class("warning");
+    } else {
+        btn.remove_css_class("warning");
+    }
+    let label = if is_favourite {
+        gettext("Remove from favourites")
+    } else {
+        gettext("Add to favourites")
+    };
+    btn.update_property(&[gtk::accessible::Property::Label(&label)]);
 }
 
 /// Wire a group of expander rows so that only one can be expanded at a time.


### PR DESCRIPTION
## Summary

Closes #321, closes #322

Extract the duplicated favourite toggle logic from `viewer.rs` and `video_viewer.rs` into a shared `update_star_button()` helper in `widgets.rs`. The helper sets icon name (`starred-symbolic`/`non-starred-symbolic`), toggles the `warning` CSS class, and updates the accessible label.

Replaces ~40 lines of duplicated code across both viewers with single-line calls.

## Test plan

- [ ] Photo viewer: star button toggles correctly (icon, colour, accessible label)
- [ ] Video viewer: same behaviour
- [ ] Favourite state persists after navigating between photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)