### PR TITLE
perf: decode album mosaic thumbnails in parallel

### DIFF
--- a/src/ui/album_grid/factory.rs
+++ b/src/ui/album_grid/factory.rs
@@ -106,13 +106,14 @@ pub fn build_factory(
                     return;
                 }
 
-                for (i, media_id) in cover_ids.into_iter().enumerate() {
-                    let path = lib.thumbnail_path(&media_id);
+                // Decode all cover thumbnails in parallel to avoid
+                // visible flicker as each one loads sequentially.
+                let mut futures = Vec::new();
+                for media_id in &cover_ids {
+                    let path = lib.thumbnail_path(media_id);
                     let tk2 = tk.clone();
-                    let item_weak2 = item_weak.clone();
-
-                    let result = tk2
-                        .spawn(async move {
+                    futures.push(async move {
+                        tk2.spawn(async move {
                             tokio::task::spawn_blocking(move || -> Option<(Vec<u8>, u32, u32)> {
                                 let data = std::fs::read(&path).ok()?;
                                 let img = image::load_from_memory(&data).ok()?;
@@ -125,10 +126,16 @@ pub fn build_factory(
                         })
                         .await
                         .ok()
-                        .flatten();
+                        .flatten()
+                    });
+                }
 
-                    if let Some((pixels, width, height)) = result {
-                        if let Some(item) = item_weak2.upgrade() {
+                let results = futures_util::future::join_all(futures).await;
+
+                // Apply all textures in a single pass — no flicker.
+                if let Some(item) = item_weak.upgrade() {
+                    for (i, result) in results.into_iter().enumerate() {
+                        if let Some((pixels, width, height)) = result {
                             let gbytes = gtk::glib::Bytes::from_owned(pixels);
                             let texture = gtk::gdk::MemoryTexture::new(
                                 width as i32,

--- a/src/ui/album_grid/factory.rs
+++ b/src/ui/album_grid/factory.rs
@@ -133,7 +133,9 @@ pub fn build_factory(
                 let results = futures_util::future::join_all(futures).await;
 
                 // Apply all textures in a single pass — no flicker.
+                // freeze/thaw batches all property notifications into one emission.
                 if let Some(item) = item_weak.upgrade() {
+                    item.freeze_notify();
                     for (i, result) in results.into_iter().enumerate() {
                         if let Some((pixels, width, height)) = result {
                             let gbytes = gtk::glib::Bytes::from_owned(pixels);
@@ -147,6 +149,7 @@ pub fn build_factory(
                             item.set_mosaic_texture(i, texture.upcast());
                         }
                     }
+                    item.thaw_notify();
                 }
             });
         }

--- a/src/ui/album_grid/factory.rs
+++ b/src/ui/album_grid/factory.rs
@@ -133,9 +133,7 @@ pub fn build_factory(
                 let results = futures_util::future::join_all(futures).await;
 
                 // Apply all textures in a single pass — no flicker.
-                // freeze/thaw batches all property notifications into one emission.
                 if let Some(item) = item_weak.upgrade() {
-                    item.freeze_notify();
                     for (i, result) in results.into_iter().enumerate() {
                         if let Some((pixels, width, height)) = result {
                             let gbytes = gtk::glib::Bytes::from_owned(pixels);
@@ -149,7 +147,6 @@ pub fn build_factory(
                             item.set_mosaic_texture(i, texture.upcast());
                         }
                     }
-                    item.thaw_notify();
                 }
             });
         }


### PR DESCRIPTION
## Summary

Closes #357

Replace serial for-loop thumbnail decoding with `futures_util::future::join_all` to decode all 4 album cover thumbnails concurrently on the Tokio runtime. Textures are then applied in a single pass on the GTK thread, eliminating the visible placeholder → 1 → 2 → 3 → 4 flicker during scroll.

Also benefits from the existing `media_count == 0` early return (line 105) — empty albums skip the work entirely.

## Test plan

- [ ] Album grid: cover mosaics appear without visible step-by-step loading
- [ ] Empty albums still show placeholder correctly
- [ ] Scrolling through albums is smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)