### PR TITLE
refactor: return named button struct from viewer menu builder

### DIFF
--- a/src/ui/video_viewer.rs
+++ b/src/ui/video_viewer.rs
@@ -132,11 +132,12 @@ impl VideoViewer {
         *imp.info_panel.borrow_mut() = Some(info_panel);
 
         // Build and attach overflow menu.
-        let menu_popover = crate::ui::viewer::build_viewer_menu_popover(false, "Delete video");
+        let (menu_popover, menu_buttons) =
+            crate::ui::viewer::build_viewer_menu_popover(false, "Delete video");
         imp.menu_btn.set_popover(Some(&menu_popover));
 
         // Wire all signal handlers.
-        self.setup_signals(&menu_popover);
+        self.setup_signals(&menu_popover, &menu_buttons);
     }
 
     /// Load `items` and navigate to `index`.
@@ -316,7 +317,11 @@ impl VideoViewer {
         }
     }
 
-    fn setup_signals(&self, menu_popover: &gtk::Popover) {
+    fn setup_signals(
+        &self,
+        menu_popover: &gtk::Popover,
+        menu_buttons: &crate::ui::viewer::ViewerMenuButtons,
+    ) {
         let imp = self.imp();
 
         // Prev button
@@ -437,7 +442,7 @@ impl VideoViewer {
         }
 
         // ── Wire overflow menu buttons ──────────────────────────────────────
-        wire_overflow_menu(menu_popover, self);
+        wire_overflow_menu(menu_popover, menu_buttons, self);
 
         // Subscribe to bus: clear pending favourite state on confirmation.
         {
@@ -459,12 +464,16 @@ impl VideoViewer {
 }
 
 /// Wire overflow menu button handlers for the video viewer.
-fn wire_overflow_menu(popover: &gtk::Popover, viewer: &VideoViewer) {
+fn wire_overflow_menu(
+    popover: &gtk::Popover,
+    buttons: &crate::ui::viewer::ViewerMenuButtons,
+    viewer: &VideoViewer,
+) {
     // Add to album
-    if let Some(btn) = crate::ui::viewer::find_menu_button(popover, "add-to-album") {
+    {
         let weak = viewer.downgrade();
         let pop = popover.downgrade();
-        btn.connect_clicked(move |_| {
+        buttons.add_to_album.connect_clicked(move |_| {
             if let Some(p) = pop.upgrade() {
                 p.popdown();
             }
@@ -487,22 +496,24 @@ fn wire_overflow_menu(popover: &gtk::Popover, viewer: &VideoViewer) {
     }
 
     // Stub items — just close the popover on click.
-    for name in &["share", "export-original", "show-in-files"] {
-        if let Some(btn) = crate::ui::viewer::find_menu_button(popover, name) {
-            let pop = popover.downgrade();
-            btn.connect_clicked(move |_| {
-                if let Some(p) = pop.upgrade() {
-                    p.popdown();
-                }
-            });
-        }
+    for btn in [
+        &buttons.share,
+        &buttons.export_original,
+        &buttons.show_in_files,
+    ] {
+        let pop = popover.downgrade();
+        btn.connect_clicked(move |_| {
+            if let Some(p) = pop.upgrade() {
+                p.popdown();
+            }
+        });
     }
 
     // Delete video — trash + pop back to grid.
-    if let Some(btn) = crate::ui::viewer::find_menu_button(popover, "delete") {
+    {
         let weak = viewer.downgrade();
         let pop = popover.downgrade();
-        btn.connect_clicked(move |_| {
+        buttons.delete.connect_clicked(move |_| {
             if let Some(p) = pop.upgrade() {
                 p.popdown();
             }

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -19,7 +19,7 @@ use edit_panel::EditPanel;
 use info_panel::InfoPanel;
 
 // Re-export shared menu utilities used by video_viewer.
-pub use menu::{build_viewer_menu_popover, find_menu_button};
+pub use menu::{build_viewer_menu_popover, ViewerMenuButtons};
 
 // ── GObject subclass ─────────────────────────────────────────────────────────
 
@@ -166,11 +166,11 @@ impl PhotoViewer {
         *imp.edit_panel.borrow_mut() = Some(edit_panel);
 
         // Build and attach overflow menu.
-        let menu_popover = menu::build_viewer_menu_popover(true, "Delete photo");
+        let (menu_popover, menu_buttons) = menu::build_viewer_menu_popover(true, "Delete photo");
         imp.menu_btn.set_popover(Some(&menu_popover));
 
         // Wire all signal handlers.
-        self.setup_signals(&menu_popover);
+        self.setup_signals(&menu_popover, &menu_buttons);
     }
 
     /// Load `items` and navigate to `index`.
@@ -278,7 +278,7 @@ impl PhotoViewer {
         }
     }
 
-    fn setup_signals(&self, menu_popover: &gtk::Popover) {
+    fn setup_signals(&self, menu_popover: &gtk::Popover, menu_buttons: &menu::ViewerMenuButtons) {
         let imp = self.imp();
 
         // Start deferred full-res load after the slide-in animation completes,
@@ -467,7 +467,7 @@ impl PhotoViewer {
         }
 
         // Wire overflow menu buttons.
-        menu::wire_overflow_menu(menu_popover, self);
+        menu::wire_overflow_menu(menu_popover, menu_buttons, self);
 
         // Subscribe to bus: clear pending favourite state on confirmation.
         {

--- a/src/ui/viewer/menu.rs
+++ b/src/ui/viewer/menu.rs
@@ -7,12 +7,27 @@ use crate::app_event::AppEvent;
 
 use super::PhotoViewer;
 
+/// Named references to all buttons in the viewer overflow menu.
+pub struct ViewerMenuButtons {
+    pub add_to_album: gtk::Button,
+    pub share: gtk::Button,
+    pub export_original: gtk::Button,
+    pub set_wallpaper: Option<gtk::Button>,
+    pub show_in_files: gtk::Button,
+    pub delete: gtk::Button,
+}
+
 /// Build the overflow menu popover content for photo/video viewers.
 ///
 /// `include_wallpaper` controls whether "Set as wallpaper" is shown
 /// (photos only, not videos). `delete_label` sets the destructive
 /// action label ("Delete photo" vs "Delete video").
-pub fn build_viewer_menu_popover(include_wallpaper: bool, delete_label: &str) -> gtk::Popover {
+///
+/// Returns the popover and named button references for direct wiring.
+pub fn build_viewer_menu_popover(
+    include_wallpaper: bool,
+    delete_label: &str,
+) -> (gtk::Popover, ViewerMenuButtons) {
     let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
     vbox.set_margin_top(6);
     vbox.set_margin_bottom(6);
@@ -20,24 +35,20 @@ pub fn build_viewer_menu_popover(include_wallpaper: bool, delete_label: &str) ->
     vbox.set_margin_end(6);
 
     // Section 1: actions
-    vbox.append(&overflow_btn(
-        "Add to album",
-        "folder-new-symbolic",
-        "add-to-album",
-    ));
-    vbox.append(&overflow_btn("Share", "send-to-symbolic", "share"));
-    vbox.append(&overflow_btn(
-        "Export original",
-        "document-save-symbolic",
-        "export-original",
-    ));
-    if include_wallpaper {
-        vbox.append(&overflow_btn(
-            "Set as wallpaper",
-            "preferences-desktop-wallpaper-symbolic",
-            "set-wallpaper",
-        ));
-    }
+    let add_to_album = overflow_btn("Add to album", "folder-new-symbolic");
+    let share = overflow_btn("Share", "send-to-symbolic");
+    let export_original = overflow_btn("Export original", "document-save-symbolic");
+    vbox.append(&add_to_album);
+    vbox.append(&share);
+    vbox.append(&export_original);
+
+    let set_wallpaper = if include_wallpaper {
+        let btn = overflow_btn("Set as wallpaper", "preferences-desktop-wallpaper-symbolic");
+        vbox.append(&btn);
+        Some(btn)
+    } else {
+        None
+    };
 
     // Separator
     let sep1 = gtk::Separator::new(gtk::Orientation::Horizontal);
@@ -46,11 +57,8 @@ pub fn build_viewer_menu_popover(include_wallpaper: bool, delete_label: &str) ->
     vbox.append(&sep1);
 
     // Section 2: file system
-    vbox.append(&overflow_btn(
-        "Show in Files",
-        "folder-open-symbolic",
-        "show-in-files",
-    ));
+    let show_in_files = overflow_btn("Show in Files", "folder-open-symbolic");
+    vbox.append(&show_in_files);
 
     // Separator
     let sep2 = gtk::Separator::new(gtk::Orientation::Horizontal);
@@ -59,17 +67,27 @@ pub fn build_viewer_menu_popover(include_wallpaper: bool, delete_label: &str) ->
     vbox.append(&sep2);
 
     // Section 3: destructive
-    let delete_btn = overflow_btn(delete_label, "user-trash-symbolic", "delete");
-    delete_btn.add_css_class("error");
-    vbox.append(&delete_btn);
+    let delete = overflow_btn(delete_label, "user-trash-symbolic");
+    delete.add_css_class("error");
+    vbox.append(&delete);
 
     let popover = gtk::Popover::new();
     popover.set_child(Some(&vbox));
-    popover
+
+    let buttons = ViewerMenuButtons {
+        add_to_album,
+        share,
+        export_original,
+        set_wallpaper,
+        show_in_files,
+        delete,
+    };
+
+    (popover, buttons)
 }
 
 /// Create a flat button with icon + label for the overflow menu.
-fn overflow_btn(label: &str, icon_name: &str, widget_name: &str) -> gtk::Button {
+fn overflow_btn(label: &str, icon_name: &str) -> gtk::Button {
     let hbox = gtk::Box::builder()
         .orientation(gtk::Orientation::Horizontal)
         .spacing(8)
@@ -79,35 +97,22 @@ fn overflow_btn(label: &str, icon_name: &str, widget_name: &str) -> gtk::Button 
 
     let btn = gtk::Button::builder().child(&hbox).build();
     btn.add_css_class("flat");
-    btn.set_widget_name(widget_name);
     btn
-}
-
-/// Find a button in the popover by its widget name.
-pub fn find_menu_button(popover: &gtk::Popover, name: &str) -> Option<gtk::Button> {
-    let child = popover.child()?;
-    let vbox = child.downcast_ref::<gtk::Box>()?;
-    let mut widget = vbox.first_child();
-    while let Some(w) = widget {
-        if let Some(btn) = w.downcast_ref::<gtk::Button>() {
-            if btn.widget_name() == name {
-                return Some(btn.clone());
-            }
-        }
-        widget = w.next_sibling();
-    }
-    None
 }
 
 /// Wire overflow menu button handlers for the photo viewer.
 ///
 /// Connects: Add to album, Share/Export/Wallpaper/Files stubs, Delete (trash + pop).
-pub(super) fn wire_overflow_menu(popover: &gtk::Popover, viewer: &PhotoViewer) {
+pub(super) fn wire_overflow_menu(
+    popover: &gtk::Popover,
+    buttons: &ViewerMenuButtons,
+    viewer: &PhotoViewer,
+) {
     // Add to album
-    if let Some(btn) = find_menu_button(popover, "add-to-album") {
+    {
         let v = viewer.downgrade();
         let pop = popover.downgrade();
-        btn.connect_clicked(move |_| {
+        buttons.add_to_album.connect_clicked(move |_| {
             if let Some(p) = pop.upgrade() {
                 p.popdown();
             }
@@ -130,22 +135,30 @@ pub(super) fn wire_overflow_menu(popover: &gtk::Popover, viewer: &PhotoViewer) {
     }
 
     // Stub items — just close the popover on click.
-    for name in &["share", "export-original", "set-wallpaper", "show-in-files"] {
-        if let Some(btn) = find_menu_button(popover, name) {
-            let pop = popover.downgrade();
-            btn.connect_clicked(move |_| {
-                if let Some(p) = pop.upgrade() {
-                    p.popdown();
-                }
-            });
-        }
+    let stubs: Vec<&gtk::Button> = [
+        Some(&buttons.share),
+        Some(&buttons.export_original),
+        buttons.set_wallpaper.as_ref(),
+        Some(&buttons.show_in_files),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    for btn in stubs {
+        let pop = popover.downgrade();
+        btn.connect_clicked(move |_| {
+            if let Some(p) = pop.upgrade() {
+                p.popdown();
+            }
+        });
     }
 
     // Delete photo — trash + pop back to grid.
-    if let Some(btn) = find_menu_button(popover, "delete") {
+    {
         let v = viewer.downgrade();
         let pop = popover.downgrade();
-        btn.connect_clicked(move |_| {
+        buttons.delete.connect_clicked(move |_| {
             if let Some(p) = pop.upgrade() {
                 p.popdown();
             }


### PR DESCRIPTION
## Summary

Closes #368

Replace the fragile `find_menu_button` widget-name traversal with a `ViewerMenuButtons` struct returned directly from `build_viewer_menu_popover`. Button references are now compile-time checked — no silent failures if the popover layout changes.

- `find_menu_button` eliminated entirely
- Both photo and video viewer menu wiring updated to use named struct fields
- `overflow_btn` no longer sets widget_name (not needed)

Also closes #331 — closed as premature optimisation (binary search does ~14 comparisons for 10k items).

## Test plan

- [ ] Photo viewer: overflow menu works (add to album, delete, show in files)
- [ ] Video viewer: same
- [ ] All menu buttons close the popover on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)