### PR TITLE
fix: add RAII unsubscribe to event bus (#434)

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -63,6 +63,10 @@ mod imp {
         /// Centralised event bus for fan-out event delivery.
         /// Created when the library is loaded.
         pub event_bus: RefCell<Option<EventBus>>,
+        /// Holds the command dispatcher so its subscription stays alive.
+        pub dispatcher: RefCell<Option<crate::commands::dispatcher::CommandDispatcher>>,
+        /// App-lifetime event bus subscriptions (error toasts, etc.).
+        pub subscriptions: RefCell<Vec<crate::event_bus::Subscription>>,
     }
 
     #[glib::object_subclass]
@@ -550,24 +554,23 @@ impl MomentsApplication {
 
                         // Create the command dispatcher — routes *Requested
                         // events to library calls on the Tokio runtime.
-                        // The dispatcher is a unit struct; the real work is the
-                        // subscriber closure registered in new(), which lives in
-                        // the bus's thread-local SUBSCRIBERS for the app lifetime.
+                        // Stored in the app imp so the subscription stays alive.
                         let Some(lib) = app.imp().library.borrow().as_ref().map(Arc::clone) else {
                             tracing::error!("library not initialised when creating dispatcher");
                             return;
                         };
-                        let _dispatcher = crate::commands::dispatcher::CommandDispatcher::new(
+                        let dispatcher = crate::commands::dispatcher::CommandDispatcher::new(
                             lib,
                             tokio.clone(),
                             &bus,
                         );
+                        *app.imp().dispatcher.borrow_mut() = Some(dispatcher);
 
                         // Subscribe for error toasts — centralised error
                         // handling for all command failures.
                         {
                             let win_weak = window.downgrade();
-                            bus.subscribe(move |event| {
+                            let sub = bus.subscribe(move |event| {
                                 if let AppEvent::Error(msg) = event {
                                     if let Some(win) = win_weak.upgrade() {
                                         gtk::prelude::WidgetExt::activate_action(
@@ -579,6 +582,7 @@ impl MomentsApplication {
                                     }
                                 }
                             });
+                            app.imp().subscriptions.borrow_mut().push(sub);
                         }
 
                         // Store bus for shutdown cleanup.

--- a/src/commands/dispatcher.rs
+++ b/src/commands/dispatcher.rs
@@ -23,7 +23,12 @@ use super::CommandHandler;
 ///
 /// `library` and `tokio` exist in exactly one place — here. No other
 /// component needs them for action execution.
-pub struct CommandDispatcher;
+///
+/// Holds a [`Subscription`] — the subscriber is removed when the
+/// dispatcher is dropped.
+pub struct CommandDispatcher {
+    _subscription: crate::event_bus::Subscription,
+}
 
 impl CommandDispatcher {
     pub fn new(library: Arc<dyn Library>, tokio: tokio::runtime::Handle, bus: &EventBus) -> Self {
@@ -42,7 +47,7 @@ impl CommandDispatcher {
 
         let tx = bus.sender();
 
-        bus.subscribe(move |event| {
+        let subscription = bus.subscribe(move |event| {
             for handler in &handlers {
                 if handler.handles(event) {
                     let h = Arc::clone(handler);
@@ -57,6 +62,8 @@ impl CommandDispatcher {
             }
         });
 
-        Self
+        Self {
+            _subscription: subscription,
+        }
     }
 }

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -53,8 +53,22 @@ fn next_subscriber_id() -> u64 {
 /// RAII handle for an event bus subscription. Removing the subscriber
 /// closure from the bus when dropped prevents unbounded growth of the
 /// subscriber list over long sessions.
+///
+/// # Thread safety
+///
+/// `Subscription` is `!Send` because its `Drop` impl operates on thread-local
+/// state. It must be dropped on the same thread that created it (the GTK main
+/// thread).
+///
+/// # Re-entrancy
+///
+/// A `Subscription` must not be dropped from within a subscriber callback —
+/// `drain_events()` holds an immutable borrow of the subscriber list during
+/// dispatch, and `Drop` requires a mutable borrow, which would panic.
 pub struct Subscription {
     id: u64,
+    /// Marker to prevent `Send` — `Drop` operates on thread-local state.
+    _not_send: std::marker::PhantomData<std::rc::Rc<()>>,
 }
 
 impl Drop for Subscription {
@@ -142,7 +156,10 @@ impl EventBus {
                 handler: Box::new(handler),
             });
         });
-        Subscription { id }
+        Subscription {
+            id,
+            _not_send: std::marker::PhantomData,
+        }
     }
 }
 
@@ -159,7 +176,10 @@ pub fn subscribe(handler: impl Fn(&AppEvent) + 'static) -> Subscription {
             handler: Box::new(handler),
         });
     });
-    Subscription { id }
+    Subscription {
+        id,
+        _not_send: std::marker::PhantomData,
+    }
 }
 
 impl Drop for EventBus {

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::mpsc;
 
 use gtk::glib;
@@ -26,7 +26,12 @@ pub struct EventBus {
     tx: mpsc::Sender<AppEvent>,
 }
 
-type SubscriberList = Vec<Box<dyn Fn(&AppEvent)>>;
+struct SubscriberEntry {
+    id: u64,
+    handler: Box<dyn Fn(&AppEvent)>,
+}
+
+type SubscriberList = Vec<SubscriberEntry>;
 
 // Thread-local subscriber list. Accessible from `idle_add_once` callbacks
 // which run on the GTK main thread. This avoids the Send constraint — the
@@ -34,6 +39,30 @@ type SubscriberList = Vec<Box<dyn Fn(&AppEvent)>>;
 thread_local! {
     static SUBSCRIBERS: RefCell<SubscriberList> = const { RefCell::new(Vec::new()) };
     static RECEIVER: RefCell<Option<mpsc::Receiver<AppEvent>>> = const { RefCell::new(None) };
+    static NEXT_ID: Cell<u64> = const { Cell::new(0) };
+}
+
+fn next_subscriber_id() -> u64 {
+    NEXT_ID.with(|cell| {
+        let id = cell.get();
+        cell.set(id + 1);
+        id
+    })
+}
+
+/// RAII handle for an event bus subscription. Removing the subscriber
+/// closure from the bus when dropped prevents unbounded growth of the
+/// subscriber list over long sessions.
+pub struct Subscription {
+    id: u64,
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        SUBSCRIBERS.with(|cell| {
+            cell.borrow_mut().retain(|entry| entry.id != self.id);
+        });
+    }
 }
 
 /// Drain all pending events from the channel and deliver to subscribers.
@@ -52,8 +81,8 @@ fn drain_events() {
             // any cycle (A emits B, B emits A) will loop forever and hang the UI.
             // See the circular event loop risk in docs/design-event-bus.md.
             while let Ok(event) = rx.try_recv() {
-                for handler in subs.iter() {
-                    handler(&event);
+                for entry in subs.iter() {
+                    (entry.handler)(&event);
                 }
             }
         });
@@ -96,16 +125,24 @@ impl EventBus {
 
     /// Register a subscriber callback. Called on the GTK main thread.
     ///
+    /// Returns a [`Subscription`] handle — the closure is removed when the
+    /// handle is dropped. Store it in the subscribing component's state.
+    ///
     /// The subscriber receives every event — use `match` to filter.
     /// Subscribers are called in registration order.
     ///
     /// **Must not be called from within a subscriber callback** — the
     /// `RefCell` borrow will panic. Register all subscribers during
     /// component construction, before events start flowing.
-    pub fn subscribe(&self, handler: impl Fn(&AppEvent) + 'static) {
+    pub fn subscribe(&self, handler: impl Fn(&AppEvent) + 'static) -> Subscription {
+        let id = next_subscriber_id();
         SUBSCRIBERS.with(|cell| {
-            cell.borrow_mut().push(Box::new(handler));
+            cell.borrow_mut().push(SubscriberEntry {
+                id,
+                handler: Box::new(handler),
+            });
         });
+        Subscription { id }
     }
 }
 
@@ -114,10 +151,15 @@ impl EventBus {
 /// This is a convenience for components created lazily (e.g. in `register_lazy`
 /// closures) that don't have a direct reference to the `EventBus` struct.
 /// Equivalent to calling `bus.subscribe(handler)`.
-pub fn subscribe(handler: impl Fn(&AppEvent) + 'static) {
+pub fn subscribe(handler: impl Fn(&AppEvent) + 'static) -> Subscription {
+    let id = next_subscriber_id();
     SUBSCRIBERS.with(|cell| {
-        cell.borrow_mut().push(Box::new(handler));
+        cell.borrow_mut().push(SubscriberEntry {
+            id,
+            handler: Box::new(handler),
+        });
     });
+    Subscription { id }
 }
 
 impl Drop for EventBus {

--- a/src/ui/album_grid.rs
+++ b/src/ui/album_grid.rs
@@ -30,7 +30,7 @@ const SORT_CREATED: u32 = 2;
 
 mod imp {
     use super::*;
-    use std::cell::OnceCell;
+    use std::cell::{OnceCell, RefCell};
 
     use gtk::CompositeTemplate;
 
@@ -65,6 +65,8 @@ mod imp {
         // State
         pub(super) store: OnceCell<gio::ListStore>,
         pub(super) sort_order: OnceCell<Rc<Cell<u32>>>,
+        /// Keeps the event bus subscription alive for this view's lifetime.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     #[glib::object_subclass]
@@ -306,7 +308,7 @@ impl AlbumGridView {
             let lib = Arc::clone(&library);
             let tk = tokio.clone();
             let so = Rc::clone(&sort_order);
-            crate::event_bus::subscribe(move |event| match event {
+            let sub = crate::event_bus::subscribe(move |event| match event {
                 crate::app_event::AppEvent::AlbumCreated { .. }
                 | crate::app_event::AppEvent::AlbumRenamed { .. }
                 | crate::app_event::AppEvent::AlbumDeleted { .. } => {
@@ -314,6 +316,7 @@ impl AlbumGridView {
                 }
                 _ => {}
             });
+            *imp._subscription.borrow_mut() = Some(sub);
         }
 
         assert!(imp.store.set(store).is_ok());

--- a/src/ui/photo_grid.rs
+++ b/src/ui/photo_grid.rs
@@ -399,6 +399,8 @@ mod view_imp {
         pub selection_title: OnceCell<gtk::Label>,
         pub bar_box: OnceCell<gtk::Box>,
         pub fav_btn: RefCell<Option<gtk::Button>>,
+        /// Keeps the event bus subscription alive for this view's lifetime.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     impl PhotoGridView {
@@ -845,7 +847,7 @@ impl PhotoGridView {
         // Subscribe for exit-selection on result events.
         {
             let exit = imp.exit_selection().clone();
-            crate::event_bus::subscribe(move |event| match event {
+            let sub = crate::event_bus::subscribe(move |event| match event {
                 AppEvent::Trashed { .. }
                 | AppEvent::Deleted { .. }
                 | AppEvent::Restored { .. }
@@ -855,6 +857,7 @@ impl PhotoGridView {
                 }
                 _ => {}
             });
+            *imp._subscription.borrow_mut() = Some(sub);
         }
 
         // ── Selection changed → update count, auto-exit ─────────────────

--- a/src/ui/photo_grid/model.rs
+++ b/src/ui/photo_grid/model.rs
@@ -33,6 +33,8 @@ mod imp {
         pub has_more: Cell<bool>,
         pub id_index: RefCell<HashMap<MediaId, glib::WeakRef<MediaItemObject>>>,
         pub on_page_ready: RefCell<Option<Box<dyn Fn()>>>,
+        /// Keeps the event bus subscription alive for this model's lifetime.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     impl Default for PhotoGridModel {
@@ -48,6 +50,7 @@ mod imp {
                 has_more: Cell::new(true),
                 id_index: RefCell::new(HashMap::new()),
                 on_page_ready: RefCell::new(None),
+                _subscription: RefCell::new(None),
             }
         }
     }
@@ -102,21 +105,23 @@ impl PhotoGridModel {
     /// Subscribe to relevant events on the bus.
     pub fn subscribe(&self, bus: &EventBus) {
         let weak = self.downgrade();
-        bus.subscribe(move |event| {
+        let sub = bus.subscribe(move |event| {
             if let Some(model) = weak.upgrade() {
                 model.handle_event(event);
             }
         });
+        *self.imp()._subscription.borrow_mut() = Some(sub);
     }
 
     /// Subscribe to the bus via the thread-local free function.
     pub fn subscribe_to_bus(&self) {
         let weak = self.downgrade();
-        crate::event_bus::subscribe(move |event| {
+        let sub = crate::event_bus::subscribe(move |event| {
             if let Some(model) = weak.upgrade() {
                 model.handle_event(event);
             }
         });
+        *self.imp()._subscription.borrow_mut() = Some(sub);
     }
 
     /// Dispatch a bus event to the appropriate handler.

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -47,6 +47,8 @@ mod imp {
         pub sync_timer: RefCell<Option<glib::SourceId>>,
         /// Current status bar state (for priority logic).
         pub current_state: Cell<StatusState>,
+        /// Keeps the event bus subscription alive for this sidebar's lifetime.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     /// Tracks the active bottom bar state for priority-based switching.
@@ -83,6 +85,7 @@ mod imp {
                 last_synced_at: Cell::new(None),
                 sync_timer: RefCell::new(None),
                 current_state: Cell::new(StatusState::Idle),
+                _subscription: RefCell::new(None),
             }
         }
     }
@@ -499,7 +502,7 @@ impl MomentsSidebar {
     /// Subscribe to sync, import, thumbnail, and trash count events.
     pub fn subscribe_to_bus(&self) {
         let weak = self.downgrade();
-        crate::event_bus::subscribe(move |event| {
+        let sub = crate::event_bus::subscribe(move |event| {
             let Some(sidebar) = weak.upgrade() else {
                 return;
             };
@@ -548,6 +551,7 @@ impl MomentsSidebar {
                 _ => {}
             }
         });
+        *self.imp()._subscription.borrow_mut() = Some(sub);
     }
 
     /// Connect a callback that fires when the user activates a sidebar item.

--- a/src/ui/video_viewer.rs
+++ b/src/ui/video_viewer.rs
@@ -57,6 +57,8 @@ mod imp {
         pub current_metadata: RefCell<Option<MediaMetadataRecord>>,
         /// Tracks a pending optimistic favourite toggle for rollback on failure.
         pub pending_fav: RefCell<Option<(MediaId, bool)>>,
+        /// Keeps the event bus subscription alive for this viewer's lifetime.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     impl VideoViewer {
@@ -447,7 +449,7 @@ impl VideoViewer {
         // Subscribe to bus: clear pending favourite state on confirmation.
         {
             let weak = self.downgrade();
-            crate::event_bus::subscribe(move |event| {
+            let sub = crate::event_bus::subscribe(move |event| {
                 if let AppEvent::FavoriteChanged { ids, .. } = event {
                     let Some(viewer) = weak.upgrade() else { return };
                     let imp = viewer.imp();
@@ -459,6 +461,7 @@ impl VideoViewer {
                     }
                 }
             });
+            *self.imp()._subscription.borrow_mut() = Some(sub);
         }
     }
 }

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -80,6 +80,8 @@ mod imp {
         /// Tracks a pending optimistic favourite toggle for rollback on failure.
         /// Contains `(media_id, previous_favourite_state)`.
         pub pending_fav: RefCell<Option<(MediaId, bool)>>,
+        /// Keeps the event bus subscription alive for this viewer's lifetime.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     impl PhotoViewer {
@@ -472,7 +474,7 @@ impl PhotoViewer {
         // Subscribe to bus: clear pending favourite state on confirmation.
         {
             let viewer = self.downgrade();
-            crate::event_bus::subscribe(move |event| {
+            let sub = crate::event_bus::subscribe(move |event| {
                 if let AppEvent::FavoriteChanged { ids, .. } = event {
                     let Some(viewer) = viewer.upgrade() else {
                         return;
@@ -486,6 +488,7 @@ impl PhotoViewer {
                     }
                 }
             });
+            *self.imp()._subscription.borrow_mut() = Some(sub);
         }
     }
 }

--- a/tests/event_bus.rs
+++ b/tests/event_bus.rs
@@ -27,7 +27,7 @@ fn single_subscriber_receives_event() {
 
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         if matches!(event, AppEvent::SyncStarted) {
             r.set(true);
         }
@@ -44,13 +44,14 @@ fn multiple_subscribers_all_receive() {
     let bus = EventBus::new();
 
     let count = Rc::new(Cell::new(0u32));
+    let mut subs = Vec::new();
     for _ in 0..3 {
         let c = Rc::clone(&count);
-        bus.subscribe(move |event| {
+        subs.push(bus.subscribe(move |event| {
             if matches!(event, AppEvent::SyncStarted) {
                 c.set(c.get() + 1);
             }
-        });
+        }));
     }
 
     bus.sender().send(AppEvent::SyncStarted);
@@ -65,7 +66,7 @@ fn subscribers_ignore_unmatched_events() {
 
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         if matches!(event, AppEvent::SyncStarted) {
             r.set(true);
         }
@@ -91,7 +92,7 @@ fn multiple_events_delivered_in_order() {
 
     let log: Rc<std::cell::RefCell<Vec<String>>> = Rc::new(std::cell::RefCell::new(Vec::new()));
     let l = Rc::clone(&log);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         let name = match event {
             AppEvent::SyncStarted => "start",
             AppEvent::SyncComplete { .. } => "complete",
@@ -129,7 +130,7 @@ fn sender_works_from_another_thread() {
 
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         if matches!(event, AppEvent::SyncStarted) {
             r.set(true);
         }
@@ -159,7 +160,7 @@ fn command_event_reaches_subscriber() {
     let trashed_ids: Rc<std::cell::RefCell<Vec<String>>> =
         Rc::new(std::cell::RefCell::new(Vec::new()));
     let t = Rc::clone(&trashed_ids);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         if let AppEvent::TrashRequested { ids } = event {
             for id in ids {
                 t.borrow_mut().push(id.as_str().to_string());
@@ -184,7 +185,7 @@ fn result_event_reaches_subscriber() {
 
     let favorite_state = Rc::new(Cell::new(false));
     let f = Rc::clone(&favorite_state);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         if let AppEvent::FavoriteChanged { is_favorite, .. } = event {
             f.set(*is_favorite);
         }
@@ -205,7 +206,7 @@ fn result_event_reaches_subscriber() {
 fn drop_cleans_up_thread_local_state() {
     {
         let bus = EventBus::new();
-        bus.subscribe(|_| {});
+        let _sub = bus.subscribe(|_| {});
         // bus dropped here
     }
 
@@ -213,7 +214,7 @@ fn drop_cleans_up_thread_local_state() {
     let bus = EventBus::new();
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
-    bus.subscribe(move |event| {
+    let _sub = bus.subscribe(move |event| {
         if matches!(event, AppEvent::SyncStarted) {
             r.set(true);
         }
@@ -223,4 +224,30 @@ fn drop_cleans_up_thread_local_state() {
     flush_events();
 
     assert!(received.get(), "new bus after drop should work");
+}
+
+// ── Subscription unsubscribe ────────────────────────────────────────────────
+
+#[gtk::test]
+fn dropping_subscription_removes_subscriber() {
+    let bus = EventBus::new();
+
+    let count = Rc::new(Cell::new(0u32));
+    let c = Rc::clone(&count);
+    let sub = bus.subscribe(move |event| {
+        if matches!(event, AppEvent::SyncStarted) {
+            c.set(c.get() + 1);
+        }
+    });
+
+    bus.sender().send(AppEvent::SyncStarted);
+    flush_events();
+    assert_eq!(count.get(), 1);
+
+    // Drop the subscription — subscriber should be removed.
+    drop(sub);
+
+    bus.sender().send(AppEvent::SyncStarted);
+    flush_events();
+    assert_eq!(count.get(), 1, "subscriber should not fire after drop");
 }


### PR DESCRIPTION
## Summary
- `subscribe()` now returns a `Subscription` RAII handle that removes the closure from the thread-local subscriber vec on `Drop`
- All callers (viewer, video_viewer, photo_grid, photo_grid/model, album_grid, sidebar, dispatcher, application) store the handle so it lives as long as the component
- Added integration test `dropping_subscription_removes_subscriber` to verify the unsubscribe mechanism

Closes #434

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] `make run-dev` — verify event delivery still works (favourites, trash, albums, sync status)
- [ ] Verify new integration test passes with `make test-integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)