### PR TITLE
refactor: use GTK widget lifecycle for subscriptions (#512)

### DIFF
--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -17,9 +17,9 @@ use crate::app_event::AppEvent;
 ///
 /// # Subscriber contract
 ///
-/// All subscribers must be registered before events begin flowing (i.e. in
-/// component constructors during app setup). Calling [`subscribe`](Self::subscribe)
-/// from within a subscriber callback will panic due to `RefCell` re-entrancy.
+/// Subscriptions can be created and dropped at any time, including during
+/// event dispatch (e.g. from `WidgetImpl::realize` / `unrealize`).
+/// Drops during dispatch are deferred and flushed after the dispatch loop.
 ///
 /// See `docs/design-event-bus.md` for the full design.
 pub struct EventBus {
@@ -40,6 +40,9 @@ thread_local! {
     static SUBSCRIBERS: RefCell<SubscriberList> = const { RefCell::new(Vec::new()) };
     static RECEIVER: RefCell<Option<mpsc::Receiver<AppEvent>>> = const { RefCell::new(None) };
     static NEXT_ID: Cell<u64> = const { Cell::new(0) };
+    /// IDs of subscriptions dropped during dispatch. Flushed after the
+    /// dispatch loop releases its immutable borrow of `SUBSCRIBERS`.
+    static PENDING_REMOVALS: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) };
 }
 
 fn next_subscriber_id() -> u64 {
@@ -62,9 +65,9 @@ fn next_subscriber_id() -> u64 {
 ///
 /// # Re-entrancy
 ///
-/// A `Subscription` must not be dropped from within a subscriber callback —
-/// `drain_events()` holds an immutable borrow of the subscriber list during
-/// dispatch, and `Drop` requires a mutable borrow, which would panic.
+/// Safe to drop during event dispatch (e.g. from a `WidgetImpl::unrealize`
+/// triggered by a handler). The removal is deferred and flushed after
+/// dispatch completes.
 pub struct Subscription {
     id: u64,
     /// Marker to prevent `Send` — `Drop` operates on thread-local state.
@@ -73,10 +76,32 @@ pub struct Subscription {
 
 impl Drop for Subscription {
     fn drop(&mut self) {
-        SUBSCRIBERS.with(|cell| {
-            cell.borrow_mut().retain(|entry| entry.id != self.id);
+        PENDING_REMOVALS.with(|cell| {
+            cell.borrow_mut().push(self.id);
         });
+        flush_pending_removals();
     }
+}
+
+/// Apply any deferred subscription removals. Uses `try_borrow_mut` so it
+/// is a no-op when `drain_events` holds an immutable borrow — the removals
+/// are flushed after the dispatch loop instead.
+fn flush_pending_removals() {
+    PENDING_REMOVALS.with(|removals_cell| {
+        let removals = removals_cell.borrow();
+        if removals.is_empty() {
+            return;
+        }
+        SUBSCRIBERS.with(|subs_cell| {
+            if let Ok(mut subs) = subs_cell.try_borrow_mut() {
+                subs.retain(|entry| !removals.contains(&entry.id));
+                drop(removals);
+                removals_cell.borrow_mut().clear();
+            }
+            // If try_borrow_mut fails we are inside dispatch —
+            // drain_events will flush after the loop.
+        });
+    });
 }
 
 /// Drain all pending events from the channel and deliver to subscribers.
@@ -100,6 +125,10 @@ fn drain_events() {
                 }
             }
         });
+
+        // Flush any subscriptions that were dropped during dispatch
+        // (e.g. via WidgetImpl::unrealize triggered by a handler).
+        flush_pending_removals();
     });
 }
 
@@ -144,10 +173,6 @@ impl EventBus {
     ///
     /// The subscriber receives every event — use `match` to filter.
     /// Subscribers are called in registration order.
-    ///
-    /// **Must not be called from within a subscriber callback** — the
-    /// `RefCell` borrow will panic. Register all subscribers during
-    /// component construction, before events start flowing.
     pub fn subscribe(&self, handler: impl Fn(&AppEvent) + 'static) -> Subscription {
         let id = next_subscriber_id();
         SUBSCRIBERS.with(|cell| {
@@ -190,6 +215,9 @@ impl Drop for EventBus {
             cell.borrow_mut().take();
         });
         SUBSCRIBERS.with(|cell| {
+            cell.borrow_mut().clear();
+        });
+        PENDING_REMOVALS.with(|cell| {
             cell.borrow_mut().clear();
         });
     }

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -86,21 +86,28 @@ impl Drop for Subscription {
 /// Apply any deferred subscription removals. Uses `try_borrow_mut` so it
 /// is a no-op when `drain_events` holds an immutable borrow — the removals
 /// are flushed after the dispatch loop instead.
+///
+/// Drains `PENDING_REMOVALS` to a local vec before touching `SUBSCRIBERS`,
+/// so that dropping a `SubscriberEntry` whose closure captures a
+/// `Subscription` cannot re-enter `PENDING_REMOVALS.borrow_mut()`.
 fn flush_pending_removals() {
-    PENDING_REMOVALS.with(|removals_cell| {
-        let removals = removals_cell.borrow();
-        if removals.is_empty() {
-            return;
+    let removals: Vec<u64> = PENDING_REMOVALS.with(|cell| {
+        let mut r = cell.borrow_mut();
+        if r.is_empty() {
+            return vec![];
         }
-        SUBSCRIBERS.with(|subs_cell| {
-            if let Ok(mut subs) = subs_cell.try_borrow_mut() {
-                subs.retain(|entry| !removals.contains(&entry.id));
-                drop(removals);
-                removals_cell.borrow_mut().clear();
-            }
-            // If try_borrow_mut fails we are inside dispatch —
-            // drain_events will flush after the loop.
-        });
+        r.drain(..).collect()
+    });
+    if removals.is_empty() {
+        return;
+    }
+    SUBSCRIBERS.with(|subs_cell| {
+        if let Ok(mut subs) = subs_cell.try_borrow_mut() {
+            subs.retain(|entry| !removals.contains(&entry.id));
+        } else {
+            // Re-queue: we are inside dispatch, drain_events will flush after.
+            PENDING_REMOVALS.with(|cell| cell.borrow_mut().extend(removals));
+        }
     });
 }
 

--- a/src/ui/album_grid.rs
+++ b/src/ui/album_grid.rs
@@ -93,7 +93,39 @@ mod imp {
             }
         }
     }
-    impl WidgetImpl for AlbumGridView {}
+    impl WidgetImpl for AlbumGridView {
+        fn realize(&self) {
+            self.parent_realize();
+
+            if let (Some(store), Some(library), Some(tokio), Some(sort_order)) = (
+                self.store.get(),
+                self.library.get(),
+                self.tokio.get(),
+                self.sort_order.get(),
+            ) {
+                super::reload_albums(store, library, tokio, Rc::clone(sort_order));
+
+                let st = store.clone();
+                let lib = Arc::clone(library);
+                let tk = tokio.clone();
+                let so = Rc::clone(sort_order);
+                let sub = crate::event_bus::subscribe(move |event| match event {
+                    crate::app_event::AppEvent::AlbumCreated { .. }
+                    | crate::app_event::AppEvent::AlbumRenamed { .. }
+                    | crate::app_event::AppEvent::AlbumDeleted { .. } => {
+                        super::reload_albums(&st, &lib, &tk, Rc::clone(&so));
+                    }
+                    _ => {}
+                });
+                *self._subscription.borrow_mut() = Some(sub);
+            }
+        }
+
+        fn unrealize(&self) {
+            self._subscription.borrow_mut().take();
+            self.parent_unrealize();
+        }
+    }
 }
 
 glib::wrapper! {
@@ -298,26 +330,6 @@ impl AlbumGridView {
 
         imp.toolbar_view
             .insert_action_group("album", Some(&action_group));
-
-        // ── Load albums asynchronously ──────────────────────────────────
-        reload_albums(&store, &library, &tokio, Rc::clone(&sort_order));
-
-        // ── Subscribe to bus for album changes ──────────────────────────
-        {
-            let st = store.clone();
-            let lib = Arc::clone(&library);
-            let tk = tokio.clone();
-            let so = Rc::clone(&sort_order);
-            let sub = crate::event_bus::subscribe(move |event| match event {
-                crate::app_event::AppEvent::AlbumCreated { .. }
-                | crate::app_event::AppEvent::AlbumRenamed { .. }
-                | crate::app_event::AppEvent::AlbumDeleted { .. } => {
-                    reload_albums(&st, &lib, &tk, Rc::clone(&so));
-                }
-                _ => {}
-            });
-            *imp._subscription.borrow_mut() = Some(sub);
-        }
 
         assert!(imp.store.set(store).is_ok());
         assert!(imp.sort_order.set(sort_order).is_ok());

--- a/src/ui/album_grid.rs
+++ b/src/ui/album_grid.rs
@@ -97,28 +97,31 @@ mod imp {
         fn realize(&self) {
             self.parent_realize();
 
-            if let (Some(store), Some(library), Some(tokio), Some(sort_order)) = (
+            let (Some(store), Some(library), Some(tokio), Some(sort_order)) = (
                 self.store.get(),
                 self.library.get(),
                 self.tokio.get(),
                 self.sort_order.get(),
-            ) {
-                super::reload_albums(store, library, tokio, Rc::clone(sort_order));
+            ) else {
+                tracing::warn!("AlbumGridView realized before setup()");
+                return;
+            };
 
-                let st = store.clone();
-                let lib = Arc::clone(library);
-                let tk = tokio.clone();
-                let so = Rc::clone(sort_order);
-                let sub = crate::event_bus::subscribe(move |event| match event {
-                    crate::app_event::AppEvent::AlbumCreated { .. }
-                    | crate::app_event::AppEvent::AlbumRenamed { .. }
-                    | crate::app_event::AppEvent::AlbumDeleted { .. } => {
-                        super::reload_albums(&st, &lib, &tk, Rc::clone(&so));
-                    }
-                    _ => {}
-                });
-                *self._subscription.borrow_mut() = Some(sub);
-            }
+            super::reload_albums(store, library, tokio, Rc::clone(sort_order));
+
+            let st = store.clone();
+            let lib = Arc::clone(library);
+            let tk = tokio.clone();
+            let so = Rc::clone(sort_order);
+            let sub = crate::event_bus::subscribe(move |event| match event {
+                crate::app_event::AppEvent::AlbumCreated { .. }
+                | crate::app_event::AppEvent::AlbumRenamed { .. }
+                | crate::app_event::AppEvent::AlbumDeleted { .. } => {
+                    super::reload_albums(&st, &lib, &tk, Rc::clone(&so));
+                }
+                _ => {}
+            });
+            *self._subscription.borrow_mut() = Some(sub);
         }
 
         fn unrealize(&self) {

--- a/src/ui/album_grid/actions.rs
+++ b/src/ui/album_grid/actions.rs
@@ -46,7 +46,6 @@ pub(crate) fn open_album_drilldown(
         bus_sender.clone(),
     );
     view.set_model(model.clone());
-    model.subscribe_to_bus();
 
     let page = adw::NavigationPage::builder()
         .tag("album-detail")

--- a/src/ui/people_grid/actions.rs
+++ b/src/ui/people_grid/actions.rs
@@ -61,7 +61,6 @@ pub(super) fn wire_activation(
             bs.clone(),
         );
         view.set_model(model.clone());
-        model.subscribe_to_bus();
 
         let display_name = if data.name.is_empty() {
             gettext("Unnamed")

--- a/src/ui/photo_grid.rs
+++ b/src/ui/photo_grid.rs
@@ -304,8 +304,6 @@ impl PhotoGrid {
                 .connect_items_changed(move |_, _, _, _| update());
         }
 
-        model.load_more();
-
         let model_scroll = model.clone();
         let adj = scrolled.vadjustment();
         adj.connect_value_changed(move |adj| {
@@ -466,7 +464,43 @@ mod view_imp {
             self.dispose_template();
         }
     }
-    impl WidgetImpl for PhotoGridView {}
+    impl WidgetImpl for PhotoGridView {
+        fn realize(&self) {
+            self.parent_realize();
+
+            // Activate the model's bus subscription and trigger initial load.
+            if let Some(model) = self.photo_grid.imp().model.borrow().as_ref() {
+                model.activate();
+                model.load_more();
+            }
+
+            // Subscribe for exit-selection on result events.
+            if let Some(exit) = self.exit_selection.get() {
+                let exit = exit.clone();
+                let sub = crate::event_bus::subscribe(move |event| match event {
+                    crate::app_event::AppEvent::Trashed { .. }
+                    | crate::app_event::AppEvent::Deleted { .. }
+                    | crate::app_event::AppEvent::Restored { .. }
+                    | crate::app_event::AppEvent::AlbumMediaChanged { .. }
+                    | crate::app_event::AppEvent::FavoriteChanged { .. } => {
+                        exit.activate(None);
+                    }
+                    _ => {}
+                });
+                *self._subscription.borrow_mut() = Some(sub);
+            }
+        }
+
+        fn unrealize(&self) {
+            self._subscription.borrow_mut().take();
+
+            if let Some(model) = self.photo_grid.imp().model.borrow().as_ref() {
+                model.deactivate();
+            }
+
+            self.parent_unrealize();
+        }
+    }
 }
 
 glib::wrapper! {
@@ -842,22 +876,6 @@ impl PhotoGridView {
                     dialog.present(win.as_ref());
                 });
             }
-        }
-
-        // Subscribe for exit-selection on result events.
-        {
-            let exit = imp.exit_selection().clone();
-            let sub = crate::event_bus::subscribe(move |event| match event {
-                AppEvent::Trashed { .. }
-                | AppEvent::Deleted { .. }
-                | AppEvent::Restored { .. }
-                | AppEvent::AlbumMediaChanged { .. }
-                | AppEvent::FavoriteChanged { .. } => {
-                    exit.activate(None);
-                }
-                _ => {}
-            });
-            *imp._subscription.borrow_mut() = Some(sub);
         }
 
         // ── Selection changed → update count, auto-exit ─────────────────

--- a/src/ui/photo_grid/model.rs
+++ b/src/ui/photo_grid/model.rs
@@ -7,7 +7,7 @@ use gtk::{gdk, gio, glib, prelude::*};
 use tracing::{debug, error};
 
 use crate::app_event::AppEvent;
-use crate::event_bus::{EventBus, EventSender};
+use crate::event_bus::EventSender;
 use crate::library::media::{MediaCursor, MediaFilter, MediaId, MediaItem};
 use crate::library::Library;
 
@@ -102,19 +102,11 @@ impl PhotoGridModel {
         &self.imp().store
     }
 
-    /// Subscribe to relevant events on the bus.
-    pub fn subscribe(&self, bus: &EventBus) {
-        let weak = self.downgrade();
-        let sub = bus.subscribe(move |event| {
-            if let Some(model) = weak.upgrade() {
-                model.handle_event(event);
-            }
-        });
-        *self.imp()._subscription.borrow_mut() = Some(sub);
-    }
-
-    /// Subscribe to the bus via the thread-local free function.
-    pub fn subscribe_to_bus(&self) {
+    /// Activate this model: subscribe to the event bus.
+    ///
+    /// Called by `PhotoGridView::realize` — ties the model's subscription
+    /// lifetime to the owning widget's lifecycle.
+    pub fn activate(&self) {
         let weak = self.downgrade();
         let sub = crate::event_bus::subscribe(move |event| {
             if let Some(model) = weak.upgrade() {
@@ -122,6 +114,13 @@ impl PhotoGridModel {
             }
         });
         *self.imp()._subscription.borrow_mut() = Some(sub);
+    }
+
+    /// Deactivate this model: drop the event bus subscription.
+    ///
+    /// Called by `PhotoGridView::unrealize`.
+    pub fn deactivate(&self) {
+        self.imp()._subscription.borrow_mut().take();
     }
 
     /// Dispatch a bus event to the appropriate handler.

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -478,7 +478,72 @@ mod imp {
         bottom_sheet
     }
 
-    impl WidgetImpl for MomentsSidebar {}
+    impl WidgetImpl for MomentsSidebar {
+        fn realize(&self) {
+            self.parent_realize();
+
+            let weak = self.obj().downgrade();
+            let sub = crate::event_bus::subscribe(move |event| {
+                let Some(sidebar) = weak.upgrade() else {
+                    return;
+                };
+                match event {
+                    crate::app_event::AppEvent::SyncStarted => {
+                        sidebar.show_sync_started();
+                    }
+                    crate::app_event::AppEvent::SyncProgress {
+                        assets,
+                        people,
+                        faces,
+                    } => {
+                        sidebar.show_sync_progress(*assets, *people, *faces);
+                    }
+                    crate::app_event::AppEvent::SyncComplete { assets, .. } => {
+                        sidebar.show_sync_complete(*assets);
+                    }
+                    crate::app_event::AppEvent::ThumbnailDownloadProgress {
+                        completed,
+                        total,
+                    } => {
+                        sidebar.show_thumbnail_progress(*completed, *total);
+                    }
+                    crate::app_event::AppEvent::ThumbnailDownloadsComplete { total } => {
+                        sidebar.show_thumbnails_complete(*total);
+                    }
+                    crate::app_event::AppEvent::ImportProgress {
+                        current,
+                        total,
+                        imported,
+                        skipped,
+                        failed,
+                    } => {
+                        sidebar.show_upload_progress(
+                            *current, *total, *imported, *skipped, *failed,
+                        );
+                    }
+                    crate::app_event::AppEvent::ImportComplete { summary } => {
+                        sidebar.show_upload_complete(summary);
+                    }
+                    crate::app_event::AppEvent::Trashed { ids } => {
+                        sidebar.adjust_trash_count(ids.len() as i32);
+                    }
+                    crate::app_event::AppEvent::Restored { ids } => {
+                        sidebar.adjust_trash_count(-(ids.len() as i32));
+                    }
+                    crate::app_event::AppEvent::Deleted { ids } => {
+                        sidebar.adjust_trash_count(-(ids.len() as i32));
+                    }
+                    _ => {}
+                }
+            });
+            *self._subscription.borrow_mut() = Some(sub);
+        }
+
+        fn unrealize(&self) {
+            self._subscription.borrow_mut().take();
+            self.parent_unrealize();
+        }
+    }
     impl adw::subclass::prelude::NavigationPageImpl for MomentsSidebar {}
 }
 
@@ -497,61 +562,6 @@ impl Default for MomentsSidebar {
 impl MomentsSidebar {
     pub fn new() -> Self {
         glib::Object::new()
-    }
-
-    /// Subscribe to sync, import, thumbnail, and trash count events.
-    pub fn subscribe_to_bus(&self) {
-        let weak = self.downgrade();
-        let sub = crate::event_bus::subscribe(move |event| {
-            let Some(sidebar) = weak.upgrade() else {
-                return;
-            };
-            match event {
-                crate::app_event::AppEvent::SyncStarted => {
-                    sidebar.show_sync_started();
-                }
-                crate::app_event::AppEvent::SyncProgress {
-                    assets,
-                    people,
-                    faces,
-                } => {
-                    sidebar.show_sync_progress(*assets, *people, *faces);
-                }
-                crate::app_event::AppEvent::SyncComplete { assets, .. } => {
-                    sidebar.show_sync_complete(*assets);
-                }
-                crate::app_event::AppEvent::ThumbnailDownloadProgress { completed, total } => {
-                    sidebar.show_thumbnail_progress(*completed, *total);
-                }
-                crate::app_event::AppEvent::ThumbnailDownloadsComplete { total } => {
-                    sidebar.show_thumbnails_complete(*total);
-                }
-                crate::app_event::AppEvent::ImportProgress {
-                    current,
-                    total,
-                    imported,
-                    skipped,
-                    failed,
-                } => {
-                    sidebar.show_upload_progress(*current, *total, *imported, *skipped, *failed);
-                }
-                crate::app_event::AppEvent::ImportComplete { summary } => {
-                    sidebar.show_upload_complete(summary);
-                }
-                // Dynamic trash count updates.
-                crate::app_event::AppEvent::Trashed { ids } => {
-                    sidebar.adjust_trash_count(ids.len() as i32);
-                }
-                crate::app_event::AppEvent::Restored { ids } => {
-                    sidebar.adjust_trash_count(-(ids.len() as i32));
-                }
-                crate::app_event::AppEvent::Deleted { ids } => {
-                    sidebar.adjust_trash_count(-(ids.len() as i32));
-                }
-                _ => {}
-            }
-        });
-        *self.imp()._subscription.borrow_mut() = Some(sub);
     }
 
     /// Connect a callback that fires when the user activates a sidebar item.

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -501,10 +501,7 @@ mod imp {
                     crate::app_event::AppEvent::SyncComplete { assets, .. } => {
                         sidebar.show_sync_complete(*assets);
                     }
-                    crate::app_event::AppEvent::ThumbnailDownloadProgress {
-                        completed,
-                        total,
-                    } => {
+                    crate::app_event::AppEvent::ThumbnailDownloadProgress { completed, total } => {
                         sidebar.show_thumbnail_progress(*completed, *total);
                     }
                     crate::app_event::AppEvent::ThumbnailDownloadsComplete { total } => {
@@ -517,9 +514,8 @@ mod imp {
                         skipped,
                         failed,
                     } => {
-                        sidebar.show_upload_progress(
-                            *current, *total, *imported, *skipped, *failed,
-                        );
+                        sidebar
+                            .show_upload_progress(*current, *total, *imported, *skipped, *failed);
                     }
                     crate::app_event::AppEvent::ImportComplete { summary } => {
                         sidebar.show_upload_complete(summary);

--- a/src/ui/video_viewer.rs
+++ b/src/ui/video_viewer.rs
@@ -93,7 +93,33 @@ mod imp {
             self.dispose_template();
         }
     }
-    impl WidgetImpl for VideoViewer {}
+    impl WidgetImpl for VideoViewer {
+        fn realize(&self) {
+            self.parent_realize();
+
+            let weak = self.obj().downgrade();
+            let sub = crate::event_bus::subscribe(move |event| {
+                if let crate::app_event::AppEvent::FavoriteChanged { ids, .. } = event {
+                    let Some(viewer) = weak.upgrade() else {
+                        return;
+                    };
+                    let imp = viewer.imp();
+                    let mut pf = imp.pending_fav.borrow_mut();
+                    if let Some((ref pending_id, _)) = *pf {
+                        if ids.contains(pending_id) {
+                            *pf = None;
+                        }
+                    }
+                }
+            });
+            *self._subscription.borrow_mut() = Some(sub);
+        }
+
+        fn unrealize(&self) {
+            self._subscription.borrow_mut().take();
+            self.parent_unrealize();
+        }
+    }
     impl NavigationPageImpl for VideoViewer {}
 }
 
@@ -446,23 +472,6 @@ impl VideoViewer {
         // ── Wire overflow menu buttons ──────────────────────────────────────
         wire_overflow_menu(menu_popover, menu_buttons, self);
 
-        // Subscribe to bus: clear pending favourite state on confirmation.
-        {
-            let weak = self.downgrade();
-            let sub = crate::event_bus::subscribe(move |event| {
-                if let AppEvent::FavoriteChanged { ids, .. } = event {
-                    let Some(viewer) = weak.upgrade() else { return };
-                    let imp = viewer.imp();
-                    let mut pf = imp.pending_fav.borrow_mut();
-                    if let Some((ref pending_id, _)) = *pf {
-                        if ids.contains(pending_id) {
-                            *pf = None;
-                        }
-                    }
-                }
-            });
-            *self.imp()._subscription.borrow_mut() = Some(sub);
-        }
     }
 }
 

--- a/src/ui/video_viewer.rs
+++ b/src/ui/video_viewer.rs
@@ -471,7 +471,6 @@ impl VideoViewer {
 
         // ── Wire overflow menu buttons ──────────────────────────────────────
         wire_overflow_menu(menu_popover, menu_buttons, self);
-
     }
 }
 

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -116,7 +116,33 @@ mod imp {
             self.dispose_template();
         }
     }
-    impl WidgetImpl for PhotoViewer {}
+    impl WidgetImpl for PhotoViewer {
+        fn realize(&self) {
+            self.parent_realize();
+
+            let viewer = self.obj().downgrade();
+            let sub = crate::event_bus::subscribe(move |event| {
+                if let crate::app_event::AppEvent::FavoriteChanged { ids, .. } = event {
+                    let Some(viewer) = viewer.upgrade() else {
+                        return;
+                    };
+                    let imp = viewer.imp();
+                    let mut pf = imp.pending_fav.borrow_mut();
+                    if let Some((ref pending_id, _)) = *pf {
+                        if ids.contains(pending_id) {
+                            *pf = None;
+                        }
+                    }
+                }
+            });
+            *self._subscription.borrow_mut() = Some(sub);
+        }
+
+        fn unrealize(&self) {
+            self._subscription.borrow_mut().take();
+            self.parent_unrealize();
+        }
+    }
     impl NavigationPageImpl for PhotoViewer {}
 }
 
@@ -471,24 +497,5 @@ impl PhotoViewer {
         // Wire overflow menu buttons.
         menu::wire_overflow_menu(menu_popover, menu_buttons, self);
 
-        // Subscribe to bus: clear pending favourite state on confirmation.
-        {
-            let viewer = self.downgrade();
-            let sub = crate::event_bus::subscribe(move |event| {
-                if let AppEvent::FavoriteChanged { ids, .. } = event {
-                    let Some(viewer) = viewer.upgrade() else {
-                        return;
-                    };
-                    let imp = viewer.imp();
-                    let mut pf = imp.pending_fav.borrow_mut();
-                    if let Some((ref pending_id, _)) = *pf {
-                        if ids.contains(pending_id) {
-                            *pf = None;
-                        }
-                    }
-                }
-            });
-            *self.imp()._subscription.borrow_mut() = Some(sub);
-        }
     }
 }

--- a/src/ui/viewer.rs
+++ b/src/ui/viewer.rs
@@ -496,6 +496,5 @@ impl PhotoViewer {
 
         // Wire overflow menu buttons.
         menu::wire_overflow_menu(menu_popover, menu_buttons, self);
-
     }
 }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -202,7 +202,6 @@ impl MomentsWindow {
             &settings,
             &texture_cache,
             &bus_sender,
-            bus,
         );
 
         self.register_lazy_views(
@@ -318,7 +317,6 @@ impl MomentsWindow {
         settings: &gio::Settings,
         texture_cache: &Rc<TextureCache>,
         bus_sender: &crate::event_bus::EventSender,
-        bus: &crate::event_bus::EventBus,
     ) -> (gtk::Stack, Rc<RefCell<ContentCoordinator>>, PhotoGridModel) {
         use crate::library::media::MediaFilter;
 
@@ -344,7 +342,6 @@ impl MomentsWindow {
             bus_sender.clone(),
         );
         photos_view.set_model(photos_model.clone());
-        photos_model.subscribe(bus);
         coordinator.register("photos", &photos_view);
 
         (
@@ -381,7 +378,6 @@ impl MomentsWindow {
                 let view = PhotoGridView::new();
                 view.setup(lib, tk, s, tc, bs);
                 view.set_model(model.clone());
-                model.subscribe_to_bus();
                 view.upcast()
             });
         }
@@ -404,7 +400,6 @@ impl MomentsWindow {
                 let view = PhotoGridView::new();
                 view.setup(lib, tk, s, tc, bs);
                 view.set_model(model.clone());
-                model.subscribe_to_bus();
                 view.upcast()
             });
         }
@@ -425,7 +420,6 @@ impl MomentsWindow {
                 let view = PhotoGridView::new();
                 view.setup(lib, tk, s, tc, bs);
                 view.set_model(model.clone());
-                model.subscribe_to_bus();
                 view.upcast()
             });
         }
@@ -530,7 +524,6 @@ impl MomentsWindow {
                         bs.clone(),
                     );
                     view.set_model(model.clone());
-                    model.subscribe_to_bus();
                     coord.register(id, &view);
                 }
                 coord.navigate(id);

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -196,13 +196,8 @@ impl MomentsWindow {
 
         let texture_cache = Rc::new(TextureCache::new());
 
-        let (content_stack, coordinator, photos_model) = self.build_coordinator(
-            &library,
-            &tokio,
-            &settings,
-            &texture_cache,
-            &bus_sender,
-        );
+        let (content_stack, coordinator, photos_model) =
+            self.build_coordinator(&library, &tokio, &settings, &texture_cache, &bus_sender);
 
         self.register_lazy_views(
             &mut coordinator.borrow_mut(),

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -261,7 +261,6 @@ impl MomentsWindow {
         let imp = self.imp();
 
         let sidebar = MomentsSidebar::new();
-        sidebar.subscribe_to_bus();
 
         // Hide People route for Local backend (no face detection).
         let app = crate::application::MomentsApplication::default();

--- a/tests/baseline_event_wiring.rs
+++ b/tests/baseline_event_wiring.rs
@@ -308,8 +308,8 @@ mod bus_broadcast {
         let model_a = make_model(MediaFilter::All);
         let model_b = make_model(MediaFilter::All);
 
-        model_a.subscribe(&bus);
-        model_b.subscribe(&bus);
+        model_a.activate();
+        model_b.activate();
 
         model_a.insert_item_sorted(test_item("shared-id"));
         model_b.insert_item_sorted(test_item("shared-id"));
@@ -329,8 +329,8 @@ mod bus_broadcast {
         let model_a = make_model(MediaFilter::All);
         let model_b = make_model(MediaFilter::All);
 
-        model_a.subscribe(&bus);
-        model_b.subscribe(&bus);
+        model_a.activate();
+        model_b.activate();
 
         model_a.insert_item_sorted(test_item("fav-id"));
         model_b.insert_item_sorted(test_item("fav-id"));
@@ -361,7 +361,7 @@ mod bus_broadcast {
     fn trashed_event_removes_from_all_model() {
         let bus = EventBus::new();
         let model_all = make_model(MediaFilter::All);
-        model_all.subscribe(&bus);
+        model_all.activate();
 
         model_all.insert_item_sorted(test_item("trash-id"));
 
@@ -379,8 +379,8 @@ mod bus_broadcast {
         let model_all = make_model(MediaFilter::All);
         let model_trash = make_model(MediaFilter::Trashed);
 
-        model_all.subscribe(&bus);
-        model_trash.subscribe(&bus);
+        model_all.activate();
+        model_trash.activate();
 
         bus.sender().send(AppEvent::AssetSynced {
             item: test_item("synced-asset"),
@@ -397,8 +397,8 @@ mod bus_broadcast {
         let model_all = make_model(MediaFilter::All);
         let model_trash = make_model(MediaFilter::Trashed);
 
-        model_all.subscribe(&bus);
-        model_trash.subscribe(&bus);
+        model_all.activate();
+        model_trash.activate();
 
         let mut item = test_item("trashed-asset");
         item.is_trashed = true;

--- a/tests/event_bus.rs
+++ b/tests/event_bus.rs
@@ -226,6 +226,46 @@ fn drop_cleans_up_thread_local_state() {
     assert!(received.get(), "new bus after drop should work");
 }
 
+// ── Re-entrancy safety ─────────────────────────────────────────────────────
+
+#[gtk::test]
+fn dropping_subscription_during_dispatch_does_not_panic() {
+    let bus = EventBus::new();
+
+    // Subscriber A holds a subscription for subscriber B.
+    // When A handles an event it drops B's subscription — this must not panic.
+    let sub_b: Rc<std::cell::RefCell<Option<moments::event_bus::Subscription>>> =
+        Rc::new(std::cell::RefCell::new(None));
+
+    let b_count = Rc::new(Cell::new(0u32));
+    let bc = Rc::clone(&b_count);
+    let sub = bus.subscribe(move |event| {
+        if matches!(event, AppEvent::SyncStarted) {
+            bc.set(bc.get() + 1);
+        }
+    });
+    *sub_b.borrow_mut() = Some(sub);
+
+    let sb = Rc::clone(&sub_b);
+    let _sub_a = bus.subscribe(move |event| {
+        if matches!(event, AppEvent::SyncStarted) {
+            // Drop subscriber B's subscription from within dispatch.
+            sb.borrow_mut().take();
+        }
+    });
+
+    // First event: A drops B's subscription during dispatch.
+    // B still fires because the subscriber list snapshot is held for this cycle.
+    bus.sender().send(AppEvent::SyncStarted);
+    flush_events();
+    assert_eq!(b_count.get(), 1, "B fires during the dispatch cycle it was dropped");
+
+    // Second event: B should no longer fire — it was removed after the first cycle.
+    bus.sender().send(AppEvent::SyncStarted);
+    flush_events();
+    assert_eq!(b_count.get(), 1, "B should not fire after being dropped");
+}
+
 // ── Subscription unsubscribe ────────────────────────────────────────────────
 
 #[gtk::test]

--- a/tests/event_bus.rs
+++ b/tests/event_bus.rs
@@ -255,7 +255,8 @@ fn dropping_subscription_during_dispatch_does_not_panic() {
     });
 
     // First event: A drops B's subscription during dispatch.
-    // B still fires because the subscriber list snapshot is held for this cycle.
+    // B still fires because the SUBSCRIBERS immutable borrow is held for the entire
+    // dispatch cycle — the removal is deferred until after the loop completes.
     bus.sender().send(AppEvent::SyncStarted);
     flush_events();
     assert_eq!(

--- a/tests/event_bus.rs
+++ b/tests/event_bus.rs
@@ -258,7 +258,11 @@ fn dropping_subscription_during_dispatch_does_not_panic() {
     // B still fires because the subscriber list snapshot is held for this cycle.
     bus.sender().send(AppEvent::SyncStarted);
     flush_events();
-    assert_eq!(b_count.get(), 1, "B fires during the dispatch cycle it was dropped");
+    assert_eq!(
+        b_count.get(),
+        1,
+        "B fires during the dispatch cycle it was dropped"
+    );
 
     // Second event: B should no longer fire — it was removed after the first cycle.
     bus.sender().send(AppEvent::SyncStarted);


### PR DESCRIPTION
## Summary
- Fix event bus re-entrancy: `Subscription::Drop` now defers removal via `PENDING_REMOVALS` thread-local, preventing `RefCell` panics when handlers trigger widget unrealize
- Move event bus subscriptions from imperative `setup()`/`set_model()` calls to `WidgetImpl::realize`/`unrealize` for PhotoViewer, VideoViewer, MomentsSidebar, AlbumGridView, and PhotoGridView
- Add `activate()`/`deactivate()` lifecycle methods to PhotoGridModel, called by PhotoGridView's realize/unrealize
- Remove all explicit `subscribe()`/`subscribe_to_bus()` calls from window.rs, album_grid/actions.rs, and people_grid/actions.rs

## Test plan
- [x] `make lint` passes
- [x] `make test-integration` — all 14 tests pass
- [ ] `make run-dev` — switch between all sidebar routes, open/close viewers, drill into albums/people
- [ ] Rapid view switching to exercise realize/unrealize cycles
- [ ] Verify events still delivered after re-visiting a view (e.g. favorite in favorites view)

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)