### PR TITLE
fix: block checkbox signal during programmatic updates (#438)

### DIFF
--- a/src/ui/photo_grid/cell.rs
+++ b/src/ui/photo_grid/cell.rs
@@ -221,13 +221,25 @@ impl PhotoGridCell {
             imp.checkbox.set_visible(true);
         } else if !active {
             imp.checkbox.set_visible(false);
-            imp.checkbox.set_active(false);
+            self.set_checked(false);
         }
     }
 
-    /// Set the checkbox checked state (reflects MultiSelection).
+    /// Update the checkbox without firing the `toggled` handler.
+    ///
+    /// Blocks the signal while setting the active state so that
+    /// programmatic updates don't trigger select/unselect on the
+    /// `MultiSelection` model with a potentially stale position.
     pub fn set_checked(&self, checked: bool) {
-        self.imp().checkbox.set_active(checked);
+        let imp = self.imp();
+        let handler = imp.checkbox_handler.borrow();
+        if let Some(ref id) = *handler {
+            imp.checkbox.block_signal(id);
+        }
+        imp.checkbox.set_active(checked);
+        if let Some(ref id) = *handler {
+            imp.checkbox.unblock_signal(id);
+        }
     }
 
     fn update_star(&self, item: &MediaItemObject) {


### PR DESCRIPTION
## Summary
- `set_checked()` now blocks the `toggled` signal handler while setting the active state, preventing the handler from firing with a stale position during cell bind/recycling
- `set_selection_mode(false)` now delegates to `set_checked(false)` instead of calling `checkbox.set_active(false)` directly, ensuring signal blocking applies there too

## Root cause
Virtualized `GridView` cells recycle — when a checkbox's active state is set programmatically (during bind or selection mode exit), the `toggled` signal could fire with the closure's captured `position` from the previous bind, causing select/unselect on the wrong item in the `MultiSelection` model.

## Test plan
- [ ] `make run-dev` — enter selection mode, select several photos via checkboxes, verify count matches
- [ ] Scroll while in selection mode, verify no phantom selections
- [ ] Exit selection mode, re-enter, verify clean state
- [x] `make lint` passes
- [x] `make fmt` clean

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)