### PR TITLE
docs: update event bus design doc

### DIFF
--- a/docs/design-event-bus.md
+++ b/docs/design-event-bus.md
@@ -23,7 +23,7 @@ via the `Send + Clone` `EventSender` and delivered via `glib::idle_add_once`.
 ┌──────────────────────────────────────────────────────┐
 │         Event Translator (application.rs)             │
 │                                                       │
-│  LibraryEvent → AppEvent (1:1 mapping)               │
+│  LibraryEvent → AppEvent (mostly 1:1, see Known Issues)│
 │  Runs on glib::timeout_add_local (16ms poll)         │
 └──────────────────────────────────────────────────────┘
                        │
@@ -134,7 +134,9 @@ effects that bypass the bus:
 
 - **Import dialog updates** — `ImportProgress` and `ImportComplete` arms
   call `app.imp().import_dialog` directly instead of letting the dialog
-  subscribe to the bus (#517).
+  subscribe to the bus. The `ImportComplete` arm also calls
+  `win.navigate("recent")` directly to switch to the Recent Imports view
+  after import finishes (#517).
 - **`PeopleSyncComplete`** — calls `win.reload_people()` directly after
   bus dispatch. Should be a bus subscriber on the people view.
 - **`AlbumDeleted`** — synchronously unregisters the coordinator route

--- a/docs/design-event-bus.md
+++ b/docs/design-event-bus.md
@@ -1,649 +1,221 @@
 # Design: Centralised Event Bus (#230)
 
-**Status:** Proposed (revised after external review)
+**Status:** Implemented (phase 1–6 complete), future evolution planned (#518)
 **Issue:** [#230](https://github.com/justinf555/Moments/issues/230)
 
 ---
 
-## Problem
+## Current Architecture (implemented)
 
-The current architecture routes all library events through a single `std::sync::mpsc` channel consumed by an idle loop in `application.rs`. This loop manually dispatches every event variant to the appropriate models and UI components. As the app grows, this creates two problems:
-
-### 1. God dispatcher
-
-The idle loop in `application.rs` (lines 489–616) knows about every model, every sidebar method, every dialog, and every event type. Adding a new event or subscriber means modifying this centralised switch statement.
-
-### 2. Clone chains
-
-UI action handlers (buttons, context menus, action bars) need `library`, `tokio`, `registry`, and various widget references to perform async work and broadcast results. These are cloned through multiple closure layers:
-
-```
-Button clicked
-  → clone library, tokio, registry, exit_selection
-    → spawn_local
-      → clone library, tokio, registry again
-        → tokio.spawn
-          → call library method
-        → on success: registry.on_trashed()
-        → exit_selection.activate()
-```
-
-A single "trash selected items" action requires **12+ clones** across 3 nested closure layers. The `ActionBarFactory` passes `exit_selection` through 4 function signatures just so the trash handler can exit selection mode after completion.
-
----
-
-## Current Architecture
+The event bus provides push-based fan-out delivery of `AppEvent` values to
+all subscribers on the GTK main thread. Events are produced from any thread
+via the `Send + Clone` `EventSender` and delivered via `glib::idle_add_once`.
 
 ```
 ┌──────────────────────────────────────────────────────┐
 │                    Library Backend                     │
 │  ImportJob · SyncManager · Thumbnailer                │
 │                      │                                │
-│              Sender<LibraryEvent>                     │
+│          Sender<LibraryEvent>  (std::sync::mpsc)      │
 └──────────────────────────────────────────────────────┘
                        │
                        ▼
 ┌──────────────────────────────────────────────────────┐
-│              application.rs idle loop                  │
+│         Event Translator (application.rs)             │
 │                                                       │
-│  match event {                                        │
-│    ThumbnailReady => registry.on_thumbnail_ready()    │
-│    ImportProgress => sidebar.show_upload_progress()   │
-│    ImportComplete => registry.reload_all()            │
-│    AssetSynced    => registry.on_asset_synced()       │
-│    SyncStarted    => sidebar.show_sync_started()      │
-│    SyncComplete   => sidebar.show_sync_complete()     │
-│    AlbumCreated   => sidebar.add_album()              │
-│    ... (18 variants, each hand-routed)                │
-│  }                                                    │
-└──────────────────────────────────────────────────────┘
-                       │
-                       ▼
-┌──────────────────────────────────────────────────────┐
-│                  ModelRegistry                         │
-│                                                       │
-│  Vec<Rc<PhotoGridModel>>                              │
-│  on_thumbnail_ready() → all models                    │
-│  on_favorite_changed() → all models                   │
-│  on_trashed() → all models                            │
-│  on_deleted() → all models                            │
-│  on_asset_synced() → all models                       │
-│  reload_all() → all models                            │
-└──────────────────────────────────────────────────────┘
-```
-
-**Event producers:** `sync.rs`, `importer.rs`, `immich_importer.rs`, `thumbnailer.rs`, `local.rs`, `immich.rs` — all send `LibraryEvent` via the shared `Sender`.
-
-**Event consumers:** `application.rs` (the only consumer) routes to `ModelRegistry`, `Sidebar`, `ImportDialog`, and `Window`.
-
-**UI actions:** Button handlers in `action_bar.rs`, `actions.rs`, and `photo_grid.rs` call library methods directly, then broadcast results via `ModelRegistry`. They don't use the event channel at all — they clone `library` + `registry` into closures.
-
----
-
-## Proposed Architecture
-
-### Channel primitive: `glib::MainContext::channel`
-
-Use GLib's native async channel — **not** `tokio::sync::broadcast`. GLib channels deliver events directly into the main loop via its native dispatch mechanism. No polling timers, no wasted CPU when idle, no lagged receivers.
-
-```rust
-let (tx, rx) = glib::MainContext::channel::<AppEvent>(glib::Priority::DEFAULT);
-
-// Background sender (any thread):
-tx.send(AppEvent::ThumbnailReady { media_id }).unwrap();
-
-// GTK main thread — push-based, zero latency:
-rx.attach(None, move |event| {
-    // handle event
-    glib::ControlFlow::Continue
-});
-```
-
-Key properties:
-- **Push, not poll** — events delivered via the main loop's native dispatch, not a 16ms timer
-- **Unbounded** — correctness-critical events (trash, delete, favourite) are never dropped
-- **Thread-safe sender** — `glib::Sender` is `Send`, can be used from Tokio tasks
-- **Single receiver** — each channel has one consumer (see multi-subscriber pattern below)
-
-### Multi-subscriber pattern
-
-`glib::MainContext::channel` has one receiver per channel. To support multiple subscribers, we use a **fan-out dispatcher**: one channel receives all events, one dispatcher callback routes to registered subscribers.
-
-```rust
-pub struct EventBus {
-    tx: glib::Sender<AppEvent>,
-    subscribers: Rc<RefCell<Vec<Box<dyn Fn(&AppEvent)>>>>,
-}
-
-impl EventBus {
-    pub fn new() -> Self {
-        let (tx, rx) = glib::MainContext::channel::<AppEvent>(glib::Priority::DEFAULT);
-        let subscribers: Rc<RefCell<Vec<Box<dyn Fn(&AppEvent)>>>> =
-            Rc::new(RefCell::new(Vec::new()));
-
-        let subs = Rc::clone(&subscribers);
-        rx.attach(None, move |event| {
-            for handler in subs.borrow().iter() {
-                handler(&event);
-            }
-            glib::ControlFlow::Continue
-        });
-
-        Self { tx, subscribers }
-    }
-
-    /// Get a sender for producing events (thread-safe, cloneable).
-    pub fn sender(&self) -> glib::Sender<AppEvent> {
-        self.tx.clone()
-    }
-
-    /// Register a subscriber callback. Called on the GTK main thread.
-    pub fn subscribe(&self, handler: impl Fn(&AppEvent) + 'static) {
-        self.subscribers.borrow_mut().push(Box::new(handler));
-    }
-}
-```
-
-Each component calls `bus.subscribe(...)` with a closure that handles the events it cares about. The fan-out happens in one place — no per-component timers.
-
-### Layer boundary: LibraryEvent stays in the library
-
-The library layer continues to send `LibraryEvent` via `std::sync::mpsc` (or `glib::Sender<LibraryEvent>` if we migrate the channel type). A thin **event translator** at the application boundary converts `LibraryEvent` → `AppEvent` and forwards to the bus:
-
-```
-┌──────────────────────────────────────────────────────┐
-│                    Library Backend                     │
-│  ImportJob · SyncManager · Thumbnailer                │
-│                      │                                │
-│          Sender<LibraryEvent>  (library-layer type)   │
-└──────────────────────────────────────────────────────┘
-                       │
-                       ▼
-┌──────────────────────────────────────────────────────┐
-│              Event Translator (application.rs)        │
-│                                                       │
-│  LibraryEvent::ThumbnailReady → AppEvent::ThumbnailReady
-│  LibraryEvent::SyncStarted   → AppEvent::SyncStarted │
-│  (thin mapping, no routing logic)                     │
+│  LibraryEvent → AppEvent (1:1 mapping)               │
+│  Runs on glib::timeout_add_local (16ms poll)         │
 └──────────────────────────────────────────────────────┘
                        │
                        ▼
 ┌──────────────────────────────────────────────────────┐
 │                    EventBus                            │
-│              glib::MainContext::channel                │
+│          mpsc channel + glib::idle_add_once            │
 │                      │                                │
-│              fan-out to subscribers                    │
+│  Thread-local subscriber list with fan-out            │
+│  All subscribers receive every event (match to filter)│
 └──────────────────────────────────────────────────────┘
               │        │        │        │
               ▼        ▼        ▼        ▼
-          PhotoGrid  Sidebar  Command   Selection
-          Model      Status   Dispatch  Controller
+          PhotoGrid  Sidebar  Command   Viewers
+          Model      Status   Dispatch
 ```
 
-This preserves the dependency hierarchy: **library knows nothing about `AppEvent`**. The translator is a simple match that maps variants 1:1. It replaces the god dispatcher's routing logic with pure translation — no references to models, sidebar, or dialogs.
+### Key components
 
-```rust
-// In application.rs — replaces the idle loop.
-// The library sends LibraryEvent via glib::Sender<LibraryEvent> (migrated
-// from std::sync::mpsc), so delivery is push-based all the way through —
-// no polling timer needed.
-fn start_event_translator(
-    library_rx: glib::Receiver<LibraryEvent>,
-    bus: &EventBus,
-) {
-    let tx = bus.sender();
-    // Push-based: rx.attach runs the callback whenever an event arrives,
-    // driven by the GLib main loop — no polling, no wasted cycles at idle.
-    library_rx.attach(None, move |event| {
-        let app_event = match event {
-            LibraryEvent::ThumbnailReady { media_id } => AppEvent::ThumbnailReady { media_id },
-            LibraryEvent::SyncStarted => AppEvent::SyncStarted,
-            LibraryEvent::ImportComplete(summary) => AppEvent::ImportComplete { summary },
-            // ... 1:1 mapping, no routing logic
-            _ => return glib::ControlFlow::Continue,
-        };
-        let _ = tx.send(app_event);
-        glib::ControlFlow::Continue
-    });
-}
-```
+| File | Role |
+|------|------|
+| `src/event_bus.rs` | `EventBus`, `EventSender`, `Subscription` (RAII unsubscribe), thread-local subscriber list |
+| `src/app_event.rs` | `AppEvent` enum — commands, results, lifecycle (~30 variants) |
+| `src/commands/dispatcher.rs` | `CommandDispatcher` — routes `*Requested` events to `CommandHandler` impls on Tokio |
+| `src/commands/*.rs` | Individual command handlers (trash, restore, delete, favorite, album operations) |
+| `src/library/event.rs` | `LibraryEvent` — library-layer event type, sent via `mpsc` |
 
-### AppEvent enum
+### Subscriber contract
 
-```rust
-pub enum AppEvent {
-    // ── Lifecycle ────────────────────────────────────
-    Ready,
-    ShutdownComplete,
-    Error(String),
+- Subscriptions can be created and dropped at any time, including during
+  event dispatch (e.g. from `WidgetImpl::realize` / `unrealize`)
+- Drops during dispatch are deferred via `PENDING_REMOVALS` and flushed
+  after the dispatch loop (#512)
+- `Subscription` is `!Send` — must be dropped on the GTK thread
 
-    // ── Import ───────────────────────────────────────
-    ImportProgress { current: usize, total: usize, imported: usize, skipped: usize, failed: usize },
-    ImportComplete { summary: ImportSummary },
+### Widget lifecycle pattern (#512)
 
-    // ── Thumbnails ───────────────────────────────────
-    ThumbnailReady { media_id: MediaId },
-    ThumbnailDownloadProgress { completed: usize, total: usize },
-    ThumbnailDownloadsComplete { total: usize },
+All widget subscribers use `WidgetImpl::realize` / `unrealize` to manage
+subscription lifetime:
 
-    // ── Commands (UI intent → CommandDispatcher) ─────
-    TrashRequested { ids: Vec<MediaId> },
-    RestoreRequested { ids: Vec<MediaId> },
-    DeleteRequested { ids: Vec<MediaId> },
-    FavoriteRequested { ids: Vec<MediaId>, state: bool },
-    RemoveFromAlbumRequested { album_id: AlbumId, ids: Vec<MediaId> },
+| Component | realize | unrealize |
+|-----------|---------|-----------|
+| `PhotoGridView` | subscribe (exit-selection) + `model.activate()` | `model.deactivate()` + drop subscription |
+| `AlbumGridView` | subscribe (album changes) + `reload_albums()` | drop subscription |
+| `PhotoViewer` | subscribe (favorite rollback) | drop subscription |
+| `VideoViewer` | subscribe (favorite rollback) | drop subscription |
+| `MomentsSidebar` | subscribe (sync, import, trash count) | drop subscription |
 
-    // ── Results (CommandDispatcher → subscribers) ────
-    FavoriteChanged { ids: Vec<MediaId>, is_favorite: bool },
-    Trashed { ids: Vec<MediaId> },
-    Restored { ids: Vec<MediaId> },
-    Deleted { ids: Vec<MediaId> },
-    AssetSynced { item: MediaItem },
-    AssetDeletedRemote { media_id: MediaId },
-
-    // ── Albums ───────────────────────────────────────
-    AlbumCreated { id: AlbumId, name: String },
-    AlbumRenamed { id: AlbumId, name: String },
-    AlbumDeleted { id: AlbumId },
-    AlbumMediaChanged { album_id: AlbumId },
-
-    // ── Sync ─────────────────────────────────────────
-    SyncStarted,
-    SyncProgress { assets: usize, people: usize, faces: usize },
-    SyncComplete { assets: usize, people: usize, faces: usize, errors: usize },
-    PeopleSyncComplete,
-}
-```
-
-Key design decisions:
-- **No `ExitSelectionMode`** — selection mode is pure view state. Use the existing `view.exit-selection` GAction directly. Components that need to exit selection mode after an action (e.g. after `Trashed`) call the GAction in their subscriber, not via the bus.
-- **`LibraryEvent` stays** as the library-layer type. `AppEvent` is application-layer only.
-- **`AppEvent` must be `Clone`** — the `CommandDispatcher` clones the event before spawning a Tokio task (`let evt = event.clone()`). `MediaItem`, `MediaId`, `AlbumId`, and `ImportSummary` all need `#[derive(Clone)]`.
-- **Library channel migrated to `glib::Sender`** — the library sends `LibraryEvent` via `glib::Sender` (not `std::sync::mpsc`), so the translator uses push-based `rx.attach()` with no polling timer. Push delivery all the way through.
-
----
-
-### Design principle: self-contained components
-
-**Event handlers must live inside the component that owns the behaviour, never in a parent.**
-
-Parent components (`window.rs`, `application.rs`) are responsible for **assembly only** — creating child components and placing them in the layout. They must never route events to children or wire callbacks between siblings. Each component subscribes to the bus in its own constructor and handles its own events internally.
-
-This ensures separation of concerns: adding a new event or changing how a component reacts to an event requires modifying only that component's file, not the parent that assembled it.
-
-```rust
-// ✅ CORRECT — component subscribes internally
-let sidebar = MomentsSidebar::new(&bus);
-// Done. Parent has no knowledge of what events sidebar handles.
-
-// ❌ WRONG — parent routes events to child
-let sidebar = MomentsSidebar::new();
-// ...later in an idle loop or callback in window.rs:
-match event {
-    SyncStarted => sidebar.show_sync_started(),  // parent knows too much
-}
-```
-
-Every component constructor takes `bus: &EventBus` and calls `bus.subscribe(...)` internally. The subscriber closure captures a weak reference to the component — when the component is dropped, the callback becomes a no-op.
-
-```rust
-impl MomentsSidebar {
-    pub fn new(bus: &EventBus) -> Self {
-        let sidebar = Self { /* build UI */ };
-
-        let weak = sidebar.downgrade();
-        bus.subscribe(move |event| {
-            let Some(s) = weak.upgrade() else { return };
-            match event {
-                AppEvent::SyncStarted => s.show_sync_started(),
-                AppEvent::SyncProgress { .. } => s.show_sync_progress(..),
-                AppEvent::AlbumCreated { id, name } => s.add_album(id, name),
-                AppEvent::ImportProgress { .. } => s.show_upload_progress(..),
-                _ => {}
-            }
-        });
-
-        sidebar
-    }
-}
-```
-
-This pattern applies to every component that reacts to events:
-
-| Component | Constructor | Events handled internally |
-|-----------|------------|--------------------------|
-| `MomentsSidebar::new(bus)` | Sync, import, album events | Yes |
-| `PhotoGridModel::new(lib, tk, filter, bus)` | Thumbnail, media state events | Yes |
-| `PhotoGridView::new(lib, tk, bus)` | `Trashed`/`Deleted` → activates `view.exit-selection` GAction | Yes |
-| `ImportDialog::new(bus)` | Import progress/complete | Yes |
-
-`window.rs` becomes pure assembly — create components, place in layout, done.
-
----
+Non-widget subscribers (`CommandDispatcher`, `MomentsApplication`) hold
+subscriptions for the app lifetime.
 
 ### Command / result event pattern
 
-Events are split into two categories:
-
-- **Command events** (`*Requested`) — UI intent. Emitted by buttons. Carry the minimum data the UI can resolve (e.g. selected IDs).
-- **Result events** (`*Changed`, `*Completed`) — outcomes. Emitted by the command dispatcher after the library operation succeeds. Consumed by models, sidebar, selection controller.
-
-This separates concerns cleanly: **UI resolves UI state → command dispatcher does library work → result event drives all downstream effects.**
-
-#### Command dispatcher: trait-based dispatch
-
-Each command is its own struct implementing the `CommandHandler` trait. A `CommandDispatcher` owns `library` and `tokio`, subscribes to the bus, and routes each event to the handler that claims it.
-
-This follows the Strategy/Command pattern: adding a new command means creating one struct in one file and registering one line. Zero modification to existing commands.
-
-```rust
-// src/commands/mod.rs
-
-/// Trait for a single command handler.
-#[async_trait]
-pub trait CommandHandler: Send + Sync {
-    /// Returns true if this handler can process the given event.
-    fn handles(&self, event: &AppEvent) -> bool;
-
-    /// Execute the command. Called on the Tokio runtime.
-    /// On success, sends the result event via the bus sender.
-    /// On failure, sends AppEvent::Error with a user-facing message.
-    async fn execute(
-        &self,
-        event: AppEvent,
-        library: &Arc<dyn Library>,
-        bus: &glib::Sender<AppEvent>,
-    );
-}
 ```
-
-Each command is a small, single-responsibility struct:
-
-```rust
-// src/commands/trash.rs
-pub struct TrashCommand;
-
-#[async_trait]
-impl CommandHandler for TrashCommand {
-    fn handles(&self, event: &AppEvent) -> bool {
-        matches!(event, AppEvent::TrashRequested { .. })
-    }
-
-    async fn execute(&self, event: AppEvent, library: &Arc<dyn Library>, bus: &glib::Sender<AppEvent>) {
-        let AppEvent::TrashRequested { ids } = event else { return };
-        match library.trash(&ids).await {
-            Ok(()) => { let _ = bus.send(AppEvent::Trashed { ids }); }
-            Err(e) => { let _ = bus.send(AppEvent::Error(format!("Failed to move to trash: {e}"))); }
-        }
-    }
-}
-```
-
-The dispatcher subscribes to the bus and routes commands to handlers. Each command is spawned as an independent Tokio task — this is concurrent, not sequential. The burst rate for commands is user-driven (button clicks), so unbounded spawning is acceptable in practice. If burst concerns arise (e.g. batch operations), a `tokio::sync::mpsc` queue drained by a single worker can be added later.
-
-```rust
-// src/commands/dispatcher.rs
-pub struct CommandDispatcher;
-
-impl CommandDispatcher {
-    pub fn new(
-        library: Arc<dyn Library>,
-        tokio: tokio::runtime::Handle,
-        bus: &EventBus,
-    ) -> Self {
-        let handlers: Vec<Box<dyn CommandHandler>> = vec![
-            Box::new(TrashCommand),
-            Box::new(RestoreCommand),
-            Box::new(DeleteCommand),
-            Box::new(FavoriteCommand),
-            Box::new(AddToAlbumCommand),
-            Box::new(RemoveFromAlbumCommand),
-            // Adding a new command = one line here + one file.
-        ];
-
-        let tx = bus.sender();
-
-        bus.subscribe(move |event| {
-            for handler in &handlers {
-                if handler.handles(event) {
-                    let lib = Arc::clone(&library);
-                    let bus_tx = tx.clone();
-                    let evt = event.clone();
-                    tokio.spawn(async move {
-                        handler.execute(evt, &lib, &bus_tx).await;
-                    });
-                    break;
-                }
-            }
-        });
-
-        Self
-    }
-}
-```
-
-**Scaling:** Adding sharing support means creating `ShareCommand`, `CreateSharedAlbumCommand`, etc. — one file each, one registration line, zero changes to existing commands.
-
-```
-src/commands/
-  mod.rs              — CommandHandler trait + CommandDispatcher
-  trash.rs            — TrashCommand
-  restore.rs          — RestoreCommand
-  delete.rs           — DeleteCommand
-  favorite.rs         — FavoriteCommand
-  add_to_album.rs     — AddToAlbumCommand
-  remove_from_album.rs — RemoveFromAlbumCommand
-  share.rs            — ShareCommand (future)
-  shared_album.rs     — CreateSharedAlbumCommand (future)
-```
-
-`library` and `tokio` exist in exactly **one place** — the dispatcher. No other component needs them for action execution.
-
-#### Error handling
-
-Every command handler must handle failure explicitly. On error, the handler sends `AppEvent::Error(message)` with a user-facing message. The `Application` component subscribes and shows a toast:
-
-```rust
-// In application.rs subscriber:
-AppEvent::Error(msg) => {
-    if let Some(win) = app.active_window() {
-        win.activate_action("win.show-toast", Some(&msg.to_variant()));
-    }
-}
-```
-
-No command failure is ever silently swallowed.
-
-#### Button handlers become trivial
-
-Buttons resolve UI state (selection → IDs) and emit a command. Nothing else.
-
-```rust
-// Before (12+ clones, 3 closure layers, 25 lines):
-fn wire_trash(btn, selection, library, tokio, registry, exit_selection) { ... }
-
-// After (2 clones, 1 closure layer, 6 lines):
-fn wire_trash(btn: &gtk::Button, selection: &gtk::MultiSelection, bus: &EventBus) {
-    let sel = selection.clone();
-    let tx = bus.sender();
-    btn.connect_clicked(move |_| {
-        let ids = collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            let _ = tx.send(AppEvent::TrashRequested { ids });
-        }
-    });
-}
-```
-
-#### ActionBarFactory simplified
-
-The factory needs only `selection` (UI state) and `bus` (communication). No `library`, no `tokio`, no `registry`, no `exit_selection`:
-
-```rust
-pub fn build_for_filter(
-    filter: &MediaFilter,
-    selection: &gtk::MultiSelection,
-    bus: &EventBus,
-) -> ActionBarButtons {
-    match filter {
-        MediaFilter::Trashed => build_trash_bar(selection, bus),
-        MediaFilter::Album { album_id } => build_album_bar(selection, bus, album_id),
-        _ => build_standard_bar(selection, bus),
-    }
-}
-```
-
-#### Full event flow for "trash 3 selected items"
-
-```
-User clicks "Delete" button
+User clicks "Delete"
 │
-├─ Button handler (action_bar.rs):
-│   ids = collect_selected_ids(selection)        // [id_1, id_2, id_3]
-│   tx.send(TrashRequested { ids })              // done, 2 lines
+├─ Button handler:
+│   ids = collect_selected_ids(selection)
+│   bus_sender.send(TrashRequested { ids })
 │
 ├─ CommandDispatcher receives TrashRequested:
 │   TrashCommand.execute() on Tokio:
-│     library.trash(&ids).await                  // async DB call
-│     tx.send(Trashed { ids })                   // emit result
-│     (or on failure: tx.send(Error("..."))      // emit error
+│     library.trash(&ids).await
+│     bus_sender.send(Trashed { ids })       // or Error on failure
 │
-├─ PhotoGridModel (Photos) receives Trashed:
-│   for id in ids { self.remove_item(id) }       // items disappear
-│
-├─ PhotoGridModel (Trash) receives Trashed:
-│   for id in ids { self.fetch_and_insert(id) }  // items appear in trash
+├─ PhotoGridModel receives Trashed:
+│   removes items from store
 │
 ├─ PhotoGridView receives Trashed:
-│   view.exit-selection GAction activated         // exits selection mode
-│
-├─ Application receives Error (if failed):
-│   shows toast via win.show-toast GAction
+│   exits selection mode
 │
 └─ Sidebar receives Trashed:
-    (could update trash count badge)
+    updates trash count badge
 ```
 
-No component knows about any other. The button doesn't know about models. The model doesn't know about the button. The command handler doesn't know about selection mode. Selection mode exit uses the GAction — not the bus.
+No component knows about any other. The button doesn't know about models.
+The model doesn't know about selection mode.
 
 ---
 
-## What gets replaced
+## Known issues with current architecture
 
-| Current | Replaced by |
-|---------|-------------|
-| `std::sync::mpsc` channel | `glib::MainContext::channel` (push-based, unbounded) |
-| `application.rs` idle loop (120 lines of routing) | Event translator (thin 1:1 mapping) + per-component subscriptions |
-| `ModelRegistry` (100 lines, 8 methods) | Direct subscriptions via `EventBus` |
-| `ActionContext` struct | `bus: &EventBus` — 2 params instead of 7 |
-| `exit_selection` passthrough | `PhotoGridView` subscribes to `Trashed`/`Deleted`, activates `view.exit-selection` GAction |
-| `library` + `tokio` in every action handler | `CommandDispatcher` — single component owns both, routes to `CommandHandler` impls |
-| `registry.on_trashed()` calls in action handlers | `tx.send(TrashRequested { ids })` — handler emits intent only |
-| `win.album-created` GAction hack | `AppEvent::AlbumCreated` — sidebar subscribes directly |
+### 1. Translation loop (~140 lines of boilerplate)
 
----
+`application.rs` contains a `LibraryEvent` → `AppEvent` translation loop
+(lines 600–737) that maps variants 1:1. This exists because the library
+sends `LibraryEvent` via a separate `mpsc` channel, but the bus uses
+`AppEvent`. Most variants are identical field-for-field copies.
 
-## What stays
+### 2. Coupled enum
 
-| Component | Why |
-|-----------|-----|
-| `win.show-toast` GAction | Simple fire-and-forget UI notification |
-| `view.zoom-in/out` GActions | View-scoped state, not cross-component |
-| `view.enter/exit-selection` GActions | View-scoped state — selection mode is not an application event |
-| `LibraryEvent` enum | Library-layer type — library must not depend on `AppEvent` |
+All events (library results, UI commands, lifecycle) live in a single
+`AppEvent` enum. Adding any event requires modifying this central type.
+Both the library layer and UI layer depend on it.
+
+### 3. Import dialog bypasses the bus
+
+The import dialog progress is updated directly from the translation loop
+instead of subscribing to the bus like every other component (#517).
 
 ---
 
-## Subscribers
+## Future: Trait-based event bus (#518)
 
-Each component subscribes to the events it cares about:
+The planned evolution replaces the `AppEvent` enum with type-erased events,
+enabling full decoupling between library and UI.
 
-| Subscriber | Events consumed |
-|------------|----------------|
-| `CommandDispatcher` | `TrashRequested`, `RestoreRequested`, `DeleteRequested`, `FavoriteRequested`, `RemoveFromAlbumRequested` → executes library calls, emits result events |
-| `PhotoGridModel` | `ThumbnailReady`, `FavoriteChanged`, `Trashed`, `Restored`, `Deleted`, `AssetSynced`, `AssetDeletedRemote`, `AlbumMediaChanged` |
-| `Sidebar` | `SyncStarted`, `SyncProgress`, `SyncComplete`, `ThumbnailDownloadProgress`, `ThumbnailDownloadsComplete`, `ImportProgress`, `ImportComplete`, `AlbumCreated`, `AlbumRenamed`, `AlbumDeleted` |
-| `PhotoGridView` | `Trashed`, `Deleted` → activates `view.exit-selection` GAction |
-| `PeopleGrid` | `PeopleSyncComplete` → reloads |
-| `Application` | `Ready`, `ShutdownComplete`, `Error` → lifecycle + error toasts |
+### Three-module architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Library Backend                     │
+│  Defines event structs: ThumbnailReady, Trashed, etc  │
+│  Sends directly via EventSender (no translation)      │
+└──────────────────────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────┐
+│                EventBus (standalone)                   │
+│                                                       │
+│  Type-erased transport: dyn Any + TypeId routing      │
+│  Send input (any thread) / !Send output (GTK thread)  │
+│  Knows nothing about library or UI                    │
+│                                                       │
+│  send<E: Event>(event: E)                             │
+│  subscribe<E: Event>(Fn(&E)) -> Subscription          │
+└──────────────────────────────────────────────────────┘
+                       │
+              ┌────────┼────────┐
+              ▼        ▼        ▼
+          PhotoGrid  Sidebar  Command
+          Model      Status   Dispatch
+```
+
+### Event trait
+
+```rust
+// bus module — knows nothing about library or UI
+pub trait Event: Any + Send + 'static {}
+
+// library module — defines its own events
+pub struct ThumbnailReady { pub media_id: MediaId }
+impl Event for ThumbnailReady {}
+
+pub struct TrashRequested { pub ids: Vec<MediaId> }
+impl Event for TrashRequested {}
+```
+
+### What changes
+
+| Current | Future |
+|---------|--------|
+| Single `AppEvent` enum (30+ variants) | Small structs, each `impl Event` |
+| `LibraryEvent` → `AppEvent` translation loop | Library sends directly via bus |
+| `match event { ... }` in each subscriber | `subscribe::<ThumbnailReady>(\|e\| ...)` per type |
+| Separate `mpsc` channel for library events | Single bus, library uses `EventSender` directly |
+| Adding event = modify central enum | Adding event = one struct + `impl Event` |
+
+### Trade-offs
+
+| Gain | Cost |
+|------|------|
+| Library and UI evolve independently | Loss of exhaustive `match` checking |
+| No translation loop | Events scattered across modules |
+| UI-to-UI events work without changes | Runtime `TypeId` matching (negligible) |
+| Adding events doesn't touch existing code | More verbose subscriber setup (`Vec<Subscription>`) |
+
+### Why three modules?
+
+The library can't own `subscribe` because subscriber closures hold `!Send`
+GTK widget references. The bus bridges `Send` events from Tokio to `!Send`
+subscribers on the GTK thread. Neither the library nor the UI should own
+this thread-crossing logic.
+
+### Entry point
+
+```rust
+fn main() {
+    let tokio = tokio::runtime::Runtime::new();
+    let bus = EventBus::new();
+    let library = LibraryFactory::create(bundle, config, bus.sender());
+    let app = MomentsApplication::new(bus, library);
+    app.run();
+}
+```
 
 ---
 
-## Migration strategy
+## Related issues
 
-Incremental, one event at a time. Each step is a single PR:
-
-### Phase 1: Infrastructure
-- Create `src/app_event.rs` with `AppEvent` enum
-- Create `EventBus` with `glib::MainContext::channel` + fan-out dispatcher
-- Create event translator in `application.rs` (LibraryEvent → AppEvent)
-- Keep the idle loop as fallback for unmigrated events
-
-### Phase 2: Thumbnail events
-- Migrate `ThumbnailReady` — `PhotoGridModel` subscribes via bus
-- Remove `ThumbnailReady` arm from idle loop
-- Remove `ModelRegistry::on_thumbnail_ready()`
-
-### Phase 3: Command dispatcher + media commands
-- Create `CommandHandler` trait and `CommandDispatcher`
-- Implement `TrashCommand`, `RestoreCommand`, `DeleteCommand`, `FavoriteCommand`
-- Action handlers emit `*Requested` instead of calling library directly
-- Remove `ModelRegistry::on_favorite_changed()`, `on_trashed()`, `on_deleted()`
-- `PhotoGridView` subscribes to `Trashed`/`Deleted` → activates `view.exit-selection`
-
-### Phase 4: Sync and import events
-- Sidebar subscribes directly to sync/import events
-- Remove sync/import routing from idle loop
-
-### Phase 5: Album events + commands
-- Implement `AddToAlbumCommand`, `RemoveFromAlbumCommand`
-- Sidebar subscribes to album events
-- Remove `win.album-created` GAction hack
-
-### Phase 6: Cleanup
-- Remove `ModelRegistry` entirely
-- Remove idle loop (reduce to translator only)
-- Remove `ActionContext` struct — handlers take `bus: &EventBus` only
-
----
-
-## Risks and mitigations
-
-| Risk | Mitigation |
-|------|------------|
-| `glib::MainContext::channel` is unbounded | Photo apps don't generate unbounded events; sync bursts are ~100 events max |
-| Fan-out dispatcher iterates all subscribers for every event | Subscribers do a cheap `match` and ignore irrelevant events; ~6 subscribers total |
-| `AppEvent` must be `Clone` for the command dispatcher | `MediaItem` and `MediaId` are already `Clone`; `ImportSummary` and `AlbumId` need `#[derive(Clone)]` |
-| Migration breaks existing functionality | Incremental — one event at a time, old path as fallback |
-| Circular event loops (handler emits event, subscriber handles it, emits again) | Convention: command handlers emit result events only, subscribers never emit commands in response |
-| Command handler errors silently swallowed | Every `CommandHandler::execute` must send `AppEvent::Error` on failure — enforced by code review |
-
----
-
-## Files affected (full migration)
-
-| File | Change |
-|------|--------|
-| `src/app_event.rs` | **New** — `AppEvent` enum (commands + results) |
-| `src/event_bus.rs` | **New** — `EventBus` (glib channel + fan-out subscriber registry) |
-| `src/commands/mod.rs` | **New** — `CommandHandler` trait + `CommandDispatcher` |
-| `src/commands/trash.rs` | **New** — `TrashCommand` |
-| `src/commands/restore.rs` | **New** — `RestoreCommand` |
-| `src/commands/delete.rs` | **New** — `DeleteCommand` |
-| `src/commands/favorite.rs` | **New** — `FavoriteCommand` |
-| `src/commands/add_to_album.rs` | **New** — `AddToAlbumCommand` |
-| `src/commands/remove_from_album.rs` | **New** — `RemoveFromAlbumCommand` |
-| `src/main.rs` | Create `EventBus`, pass to application |
-| `src/application.rs` | Replace idle loop with event translator (LibraryEvent → AppEvent); subscribe for lifecycle + errors |
-| `src/ui/model_registry.rs` | **Delete** — replaced by direct subscriptions |
-| `src/ui/photo_grid/model.rs` | Subscribe to bus in constructor |
-| `src/ui/photo_grid/action_bar.rs` | Replace `library` + `tokio` + `registry` + `exit_selection` with `bus` |
-| `src/ui/photo_grid/actions.rs` | Replace `ActionContext` with `bus` |
-| `src/ui/photo_grid.rs` | Pass `bus` instead of `registry`; subscribe for `Trashed`/`Deleted` → GAction |
-| `src/ui/sidebar.rs` | Subscribe to bus in constructor |
-| `src/ui/window.rs` | Remove `win.album-created` action, pass `bus` to components |
-| `src/library/event.rs` | **Unchanged** — `LibraryEvent` stays as library-layer type |
-| `src/library/sync.rs` | Migrate `std::sync::mpsc::Sender` → `glib::Sender<LibraryEvent>` |
-| `src/library/importer.rs` | Migrate `std::sync::mpsc::Sender` → `glib::Sender<LibraryEvent>` |
-| `src/library/thumbnailer.rs` | Migrate `std::sync::mpsc::Sender` → `glib::Sender<LibraryEvent>` |
-| `src/library/providers/*.rs` | Migrate `std::sync::mpsc::Sender` → `glib::Sender<LibraryEvent>` |
+- [#512](https://github.com/justinf555/Moments/issues/512) — Widget lifecycle (realize/unrealize) for subscriptions ✅
+- [#434](https://github.com/justinf555/Moments/issues/434) — RAII unsubscribe ✅
+- [#516](https://github.com/justinf555/Moments/issues/516) — Move library init to main (superseded by #518)
+- [#517](https://github.com/justinf555/Moments/issues/517) — Import dialog self-contained with bus-based progress
+- [#518](https://github.com/justinf555/Moments/issues/518) — Trait-based event bus with three-module architecture

--- a/docs/design-event-bus.md
+++ b/docs/design-event-bus.md
@@ -53,11 +53,19 @@ via the `Send + Clone` `EventSender` and delivered via `glib::idle_add_once`.
 
 ### Subscriber contract
 
-- Subscriptions can be created and dropped at any time, including during
-  event dispatch (e.g. from `WidgetImpl::realize` / `unrealize`)
-- Drops during dispatch are deferred via `PENDING_REMOVALS` and flushed
-  after the dispatch loop (#512)
-- `Subscription` is `!Send` — must be dropped on the GTK thread
+- Subscriptions can be created and dropped at any time *outside* dispatch.
+  Drops during dispatch are deferred via `PENDING_REMOVALS` and flushed
+  after the dispatch loop (#512).
+- `Subscription` is `!Send` — must be dropped on the GTK thread.
+- **Subscribers must not call `event_bus::subscribe()` from within a handler.**
+  `drain_events()` holds a shared borrow of `SUBSCRIBERS` for the entire
+  event batch; `subscribe()` calls `borrow_mut()` and will panic with
+  `BorrowMutError`. Register all subscribers during component construction
+  (or in `realize()`, which never fires synchronously from within a handler).
+- **Subscribers must not call `sender.send()` from within a handler.**
+  Events sent during dispatch are picked up by the same `while let Ok(event) = rx.try_recv()`
+  loop in `drain_events()`. Any cycle (A emits B, B emits A) will loop
+  forever and hang the UI.
 
 ### Widget lifecycle pattern (#512)
 
@@ -106,10 +114,10 @@ The model doesn't know about selection mode.
 
 ## Known issues with current architecture
 
-### 1. Translation loop (~140 lines of boilerplate)
+### 1. Translation loop boilerplate
 
 `application.rs` contains a `LibraryEvent` → `AppEvent` translation loop
-(lines 600–737) that maps variants 1:1. This exists because the library
+that maps variants 1:1 (~140 lines). This exists because the library
 sends `LibraryEvent` via a separate `mpsc` channel, but the bus uses
 `AppEvent`. Most variants are identical field-for-field copies.
 
@@ -119,10 +127,23 @@ All events (library results, UI commands, lifecycle) live in a single
 `AppEvent` enum. Adding any event requires modifying this central type.
 Both the library layer and UI layer depend on it.
 
-### 3. Import dialog bypasses the bus
+### 3. Translation loop side effects (not a pure translator)
 
-The import dialog progress is updated directly from the translation loop
-instead of subscribing to the bus like every other component (#517).
+While the translation loop is mostly 1:1 mapping, two arms have side
+effects that bypass the bus:
+
+- **Import dialog updates** — `ImportProgress` and `ImportComplete` arms
+  call `app.imp().import_dialog` directly instead of letting the dialog
+  subscribe to the bus (#517).
+- **`PeopleSyncComplete`** — calls `win.reload_people()` directly after
+  bus dispatch. Should be a bus subscriber on the people view.
+- **`AlbumDeleted`** — synchronously unregisters the coordinator route
+  *before* bus dispatch. This is intentional (avoids a navigation race
+  with the sidebar), but it's worth noting that the translator is not
+  purely translation.
+
+These coupling points mean the translator can't simply be replaced with
+a thin adapter — they need to migrate to bus subscribers first.
 
 ---
 

--- a/docs/plan-event-bus-migration.md
+++ b/docs/plan-event-bus-migration.md
@@ -1,0 +1,78 @@
+# Migration Plan: Event Bus Architecture Evolution
+
+**Issue:** [#518](https://github.com/justinf555/Moments/issues/518)
+**Goal:** Move from a single `AppEvent` enum with a translation loop and command dispatcher to a trait-based event bus with CQRS separation.
+
+---
+
+## Phase 1: Eliminate the translation loop
+
+Remove the `LibraryEvent` → `AppEvent` middleman. The library sends `AppEvent` directly via `EventSender` instead of going through a separate `mpsc` channel.
+
+**What changes:**
+- Library backends use `EventSender` instead of `mpsc::Sender<LibraryEvent>`
+- `LibraryEvent` enum is deleted
+- The ~140 line translation loop in `application.rs` is deleted
+- The 16ms polling timer becomes unnecessary (bus is already push-based)
+
+**Depends on:** #517 (import dialog must use the bus first, otherwise it still needs direct access in the translation loop)
+
+---
+
+## Phase 2: Library subscribes to commands (eliminate CommandDispatcher)
+
+The library subscribes to `*Requested` events directly instead of routing through `CommandDispatcher`.
+
+**What changes:**
+- Library registers command handlers during initialisation
+- `CommandDispatcher`, `CommandHandler` trait, and all command handler files are deleted
+- Error handling moves into the library's command subscription
+
+---
+
+## Phase 3: Split Library trait into read-only queries + bus commands
+
+Separate the `Library` trait into a read-only query interface and mutation commands.
+
+**What changes:**
+- New `LibraryQuery` trait (or similar) with read-only methods: `list_media`, `thumbnail_path`, `original_path`, `media_metadata`, `list_albums`, `list_people`, `library_stats`
+- Mutation methods (`trash`, `restore`, `favorite`, `create_album`, etc.) removed from the trait — they're handled via bus commands from Phase 2
+- UI components receive `Arc<dyn LibraryQuery>` instead of `Arc<dyn Library>`
+
+---
+
+## Phase 4: Trait-based events (replace AppEvent enum)
+
+Replace the `AppEvent` enum with individual event structs and type-erased bus routing.
+
+**What changes:**
+- `Event` trait defined in the bus module
+- Each event becomes its own struct with `impl Event`
+- `EventBus` uses `TypeId` for routing — `subscribe::<T>()` / `send::<T>()`
+- `AppEvent` enum is deleted
+- All subscribers update from `match event { ... }` to typed `subscribe` calls
+
+---
+
+## Phase 5: Move library initialisation to main
+
+Clean entry point with dependency injection.
+
+**What changes:**
+- `main.rs` creates Tokio runtime, event bus, and library
+- `MomentsApplication` receives bus + query handle — doesn't create them
+- `application.rs` shrinks to GTK lifecycle only (activate, shutdown, GActions)
+
+---
+
+## Suggested scheduling
+
+| Phase | Size | Dependencies | Notes |
+|-------|------|-------------|-------|
+| 1 | M | #517 | Biggest immediate code reduction |
+| 2 | S | Phase 1 | Small once phase 1 is done |
+| 3 | M | Phase 2 | Trait split, update all UI call sites |
+| 4 | L | Phase 3 | Touches every subscriber — do last |
+| 5 | S | Phase 1 | Can be done anytime after phase 1 |
+
+Phases 1 and 2 deliver the most value (eliminate boilerplate, remove middleman). Phase 3 is the architectural win (CQRS). Phase 4 is the largest change but is optional — the architecture works with or without it. Phase 5 is a small cleanup.

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -125,7 +125,7 @@ fn drain_events() {
             // NOTE: subscribers must not call sender.send() from within a handler.
             // Events sent during dispatch are picked up by this same while loop —
             // any cycle (A emits B, B emits A) will loop forever and hang the UI.
-            // See the circular event loop risk in docs/design-event-bus.md.
+            // See the subscriber contract in docs/design-event-bus.md.
             while let Ok(event) = rx.try_recv() {
                 for entry in subs.iter() {
                     (entry.handler)(&event);


### PR DESCRIPTION
## Summary
- Replace the original proposal (fully implemented) with documentation of current architecture
- Document the widget lifecycle pattern (#512), re-entrancy safety, subscriber contract
- Add future vision section: trait-based events, three-module architecture (#518)
- Link related issues (#434, #512, #516, #517, #518)

🤖 Generated with [Claude Code](https://claude.com/claude-code)