### PR TITLE
refactor: make import dialog self-contained with bus-based progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test-all: test test-integration
 # ── Linting & Analysis ──────────────────────────────────────────────────────
 
 lint:
-	$(FLATPAK_RUN) -c '$(SDK_INIT) && cargo clippy --all-targets -- -D warnings'
+	$(FLATPAK_RUN) -c '$(SDK_INIT) && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings'
 
 fmt:
 	$(FLATPAK_RUN) -c '$(SDK_INIT) && cargo fmt'

--- a/src/application.rs
+++ b/src/application.rs
@@ -36,7 +36,6 @@ use crate::library::config::LibraryConfig;
 use crate::library::event::LibraryEvent;
 use crate::library::factory::LibraryFactory;
 use crate::library::Library;
-use crate::ui::import_dialog::ImportDialog;
 use crate::ui::MomentsSetupWindow;
 use crate::ui::MomentsWindow;
 
@@ -51,9 +50,6 @@ mod imp {
         pub is_immich: Cell<bool>,
         pub immich_server_url: RefCell<Option<String>>,
         pub library_events: RefCell<Option<Receiver<LibraryEvent>>>,
-        /// Held while an import is in flight so the idle loop can update it.
-        /// Cleared when `ImportComplete` arrives or the user dismisses it.
-        pub import_dialog: RefCell<Option<ImportDialog>>,
         /// The GLib source ID of the library-event idle loop.
         ///
         /// Stored so `shutdown()` can remove it explicitly, which frees the
@@ -110,7 +106,6 @@ mod imp {
             // (and the SqlitePool it wraps) is freed before drop(tokio)
             // in main() tries to shut down the runtime.
             self.event_bus.borrow_mut().take();
-            self.import_dialog.borrow_mut().take();
             self.library.borrow_mut().take();
 
             self.parent_shutdown();
@@ -584,7 +579,7 @@ impl MomentsApplication {
                         let source_id = glib::timeout_add_local(
                             std::time::Duration::from_millis(16),
                             move || {
-                                let app = match app_for_idle.upgrade() {
+                                let _app = match app_for_idle.upgrade() {
                                     Some(a) => a,
                                     None => return glib::ControlFlow::Break,
                                 };
@@ -600,11 +595,6 @@ impl MomentsApplication {
                                             skipped,
                                             failed,
                                         }) => {
-                                            // Import dialog is app-level (not a bus subscriber).
-                                            let borrow = app.imp().import_dialog.borrow();
-                                            if let Some(d) = borrow.as_ref() {
-                                                d.set_progress(current, total);
-                                            }
                                             bus_tx.send(AppEvent::ImportProgress {
                                                 current,
                                                 total,
@@ -614,19 +604,7 @@ impl MomentsApplication {
                                             });
                                         }
                                         Ok(LibraryEvent::ImportComplete(summary)) => {
-                                            // Import dialog is app-level (not a bus subscriber).
-                                            {
-                                                let borrow = app.imp().import_dialog.borrow();
-                                                if let Some(d) = borrow.as_ref() {
-                                                    d.set_complete(&summary);
-                                                }
-                                            }
-                                            app.imp().import_dialog.borrow_mut().take();
                                             bus_tx.send(AppEvent::ImportComplete { summary });
-                                            // Navigate to Recent Imports so the user sees what arrived.
-                                            if let Some(win) = win_for_idle.upgrade() {
-                                                win.navigate("recent");
-                                            }
                                         }
                                         Ok(LibraryEvent::AssetSynced { item }) => {
                                             bus_tx.send(AppEvent::AssetSynced { item });

--- a/src/application.rs
+++ b/src/application.rs
@@ -579,10 +579,9 @@ impl MomentsApplication {
                         let source_id = glib::timeout_add_local(
                             std::time::Duration::from_millis(16),
                             move || {
-                                let _app = match app_for_idle.upgrade() {
-                                    Some(a) => a,
-                                    None => return glib::ControlFlow::Break,
-                                };
+                                if app_for_idle.upgrade().is_none() {
+                                    return glib::ControlFlow::Break;
+                                }
                                 loop {
                                     match receiver.try_recv() {
                                         Ok(LibraryEvent::ThumbnailReady { media_id }) => {

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -68,6 +68,7 @@ fn next_subscriber_id() -> u64 {
 /// Safe to drop during event dispatch (e.g. from a `WidgetImpl::unrealize`
 /// triggered by a handler). The removal is deferred and flushed after
 /// dispatch completes.
+#[derive(Debug)]
 pub struct Subscription {
     id: u64,
     /// Marker to prevent `Send` — `Drop` operates on thread-local state.

--- a/src/ui/import_dialog.rs
+++ b/src/ui/import_dialog.rs
@@ -1,6 +1,6 @@
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 
 use crate::library::import::ImportSummary;
 
@@ -20,6 +20,8 @@ mod imp {
         pub action_button: TemplateChild<gtk::Button>,
         /// True once `ImportComplete` has been received.
         pub complete: Cell<bool>,
+        /// Event bus subscription — alive while the dialog is realized.
+        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     #[glib::object_subclass]
@@ -53,7 +55,35 @@ mod imp {
         }
     }
 
-    impl WidgetImpl for ImportDialog {}
+    impl WidgetImpl for ImportDialog {
+        fn realize(&self) {
+            self.parent_realize();
+
+            let weak = self.obj().downgrade();
+            let sub = crate::event_bus::subscribe(move |event| {
+                let Some(dialog) = weak.upgrade() else {
+                    return;
+                };
+                match event {
+                    crate::app_event::AppEvent::ImportProgress {
+                        current, total, ..
+                    } => {
+                        dialog.set_progress(*current, *total);
+                    }
+                    crate::app_event::AppEvent::ImportComplete { summary } => {
+                        dialog.set_complete(summary);
+                    }
+                    _ => {}
+                }
+            });
+            *self._subscription.borrow_mut() = Some(sub);
+        }
+
+        fn unrealize(&self) {
+            self._subscription.borrow_mut().take();
+            self.parent_unrealize();
+        }
+    }
     impl AdwDialogImpl for ImportDialog {}
 }
 
@@ -69,8 +99,6 @@ impl ImportDialog {
     }
 
     /// Update the dialog with current import progress.
-    ///
-    /// Called for each `LibraryEvent::ImportProgress` while the dialog is open.
     pub fn set_progress(&self, current: usize, total: usize) {
         let imp = self.imp();
         imp.phase_label.set_label("Importing…");
@@ -83,9 +111,6 @@ impl ImportDialog {
     }
 
     /// Transition the dialog to its completed state.
-    ///
-    /// Called once `LibraryEvent::ImportComplete` arrives. Shows a summary
-    /// and changes the action button to "Done".
     pub fn set_complete(&self, summary: &ImportSummary) {
         let imp = self.imp();
         imp.complete.set(true);

--- a/src/ui/import_dialog.rs
+++ b/src/ui/import_dialog.rs
@@ -65,9 +65,7 @@ mod imp {
                     return;
                 };
                 match event {
-                    crate::app_event::AppEvent::ImportProgress {
-                        current, total, ..
-                    } => {
+                    crate::app_event::AppEvent::ImportProgress { current, total, .. } => {
                         dialog.set_progress(*current, *total);
                     }
                     crate::app_event::AppEvent::ImportComplete { summary } => {

--- a/src/ui/import_dialog.rs
+++ b/src/ui/import_dialog.rs
@@ -84,6 +84,7 @@ mod imp {
             self.parent_unrealize();
         }
     }
+
     impl AdwDialogImpl for ImportDialog {}
 }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -88,7 +88,6 @@ mod imp {
         pub people_reload: RefCell<Option<super::ReloadCallback>>,
 
         /// Event bus subscriptions kept alive for the window's lifetime.
-        #[allow(missing_debug_implementations)]
         pub _subscriptions: RefCell<Vec<crate::event_bus::Subscription>>,
     }
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -86,6 +86,10 @@ mod imp {
         /// Callback to reload the People collection grid after sync.
         #[allow(missing_debug_implementations)]
         pub people_reload: RefCell<Option<super::ReloadCallback>>,
+
+        /// Event bus subscriptions kept alive for the window's lifetime.
+        #[allow(missing_debug_implementations)]
+        pub _subscriptions: RefCell<Vec<crate::event_bus::Subscription>>,
     }
 
     #[glib::object_subclass]
@@ -241,9 +245,24 @@ impl MomentsWindow {
 
         self.install_show_toast_action();
         self.install_toggle_sidebar_action();
+        self.subscribe_bus_events(bus);
 
         debug!("switching main window to content page");
         imp.main_stack.set_visible_child_name("content");
+    }
+
+    /// Subscribe to event bus events that the window handles directly.
+    fn subscribe_bus_events(&self, bus: &crate::event_bus::EventBus) {
+        let mut subs = self.imp()._subscriptions.borrow_mut();
+
+        // Navigate to Recent Imports when an import completes.
+        let weak = self.downgrade();
+        subs.push(bus.subscribe(move |event| {
+            let Some(win) = weak.upgrade() else { return };
+            if matches!(event, crate::app_event::AppEvent::ImportComplete { .. }) {
+                win.navigate("recent");
+            }
+        }));
     }
 
     fn setup_sidebar(

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -256,11 +256,18 @@ impl MomentsWindow {
         let mut subs = self.imp()._subscriptions.borrow_mut();
 
         // Navigate to Recent Imports when an import completes.
+        // Deferred via idle_add_local_once because navigate() can materialise
+        // a lazy view, which triggers realize → subscribe() on the new widget,
+        // and the bus's subscriber list is borrowed during dispatch.
         let weak = self.downgrade();
         subs.push(bus.subscribe(move |event| {
-            let Some(win) = weak.upgrade() else { return };
             if matches!(event, crate::app_event::AppEvent::ImportComplete { .. }) {
-                win.navigate("recent");
+                let weak = weak.clone();
+                glib::idle_add_local_once(move || {
+                    if let Some(win) = weak.upgrade() {
+                        win.navigate("recent");
+                    }
+                });
             }
         }));
     }


### PR DESCRIPTION
## Summary
- Import dialog now subscribes to `AppEvent::ImportProgress` and `AppEvent::ImportComplete` via the event bus (`realize`/`unrealize` pattern), matching the sidebar subscription pattern
- "Navigate to recent" on import complete moves to a window-level bus subscriber
- Removes dead `import_dialog` field from `MomentsApplication` and simplifies the translation loop arms to pure 1:1 forwards
- Adds `#[derive(Debug)]` to `Subscription` (needed for window's derive)

Closes #517

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Import photos via local backend — verify progress updates in sidebar and navigation to recent on complete
- [ ] Import via Immich backend — verify upload progress in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)