### PR TITLE
feat: add AlbumEvent channel for reactive sync updates

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -612,9 +612,15 @@ impl MomentsApplication {
                         }
 
                         // Create the album client (GObject singleton).
+                        // Subscribe to AlbumEvent for reactive model updates.
                         {
+                            let albums_rx = library.albums().subscribe().await;
                             let album_client_v2 = crate::client::AlbumClientV2::new();
-                            album_client_v2.configure(Arc::clone(&library), tokio.clone());
+                            album_client_v2.configure(
+                                Arc::clone(&library),
+                                tokio.clone(),
+                                albums_rx,
+                            );
                             *app.imp().album_client_v2.borrow_mut() = Some(album_client_v2);
                         }
 

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -6,10 +6,11 @@ use gtk::gio;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tracing::{debug, error, instrument};
+use tokio::sync::mpsc;
+use tracing::{debug, error, instrument, warn};
 
 use super::model::AlbumItemObject;
-use crate::library::album::{Album, AlbumId};
+use crate::library::album::{Album, AlbumEvent, AlbumId};
 use crate::library::error::LibraryError;
 use crate::library::media::MediaId;
 use crate::library::Library;
@@ -87,11 +88,23 @@ impl AlbumClientV2 {
         glib::Object::builder().build()
     }
 
-    /// Set the dependencies required for album operations.
+    /// Set the dependencies required for album operations and start
+    /// listening for service events.
     ///
     /// Must be called once after construction, before any other method.
-    pub fn configure(&self, library: Arc<Library>, tokio: tokio::runtime::Handle) {
-        *self.imp().deps.borrow_mut() = Some(AlbumDeps { library, tokio });
+    pub fn configure(
+        &self,
+        library: Arc<Library>,
+        tokio: tokio::runtime::Handle,
+        events_rx: mpsc::UnboundedReceiver<AlbumEvent>,
+    ) {
+        *self.imp().deps.borrow_mut() = Some(AlbumDeps {
+            library: Arc::clone(&library),
+            tokio: tokio.clone(),
+        });
+
+        let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
+        tokio.spawn(Self::listen(events_rx, library, client_weak));
     }
 
     fn deps(&self) -> (Arc<Library>, tokio::runtime::Handle) {
@@ -100,6 +113,71 @@ impl AlbumClientV2 {
             .as_ref()
             .expect("AlbumClientV2::configure() not called");
         (deps.library.clone(), deps.tokio.clone())
+    }
+
+    // ── Event listener ─────────────────────────────────────────────────
+
+    /// Background task that receives `AlbumEvent`s from the service and
+    /// dispatches model patches on the GTK thread.
+    async fn listen(
+        mut rx: mpsc::UnboundedReceiver<AlbumEvent>,
+        library: Arc<Library>,
+        client_weak: glib::SendWeakRef<AlbumClientV2>,
+    ) {
+        while let Some(event) = rx.recv().await {
+            match event {
+                AlbumEvent::AlbumAdded(id) => {
+                    let album = library.albums().get_album(&id).await;
+                    let weak = client_weak.clone();
+                    glib::idle_add_once(move || {
+                        if let Some(client) = weak.upgrade() {
+                            match album {
+                                Ok(Some(a)) => {
+                                    let album_id = a.id.clone();
+                                    client.insert_into_models(a);
+                                    client.load_cover_thumbnails(&album_id);
+                                }
+                                Ok(None) => {
+                                    warn!(album_id = %id, "album not found after add event")
+                                }
+                                Err(e) => {
+                                    error!("failed to fetch added album: {e}");
+                                    crate::client::show_error_toast(&e);
+                                }
+                            }
+                        }
+                    });
+                }
+                AlbumEvent::AlbumUpdated(id) => {
+                    let album = library.albums().get_album(&id).await;
+                    let weak = client_weak.clone();
+                    glib::idle_add_once(move || {
+                        if let Some(client) = weak.upgrade() {
+                            match album {
+                                Ok(Some(a)) => client.update_album_in_models(&a),
+                                Ok(None) => {
+                                    warn!(album_id = %id, "album not found after update event")
+                                }
+                                Err(e) => {
+                                    error!("failed to fetch updated album: {e}");
+                                    crate::client::show_error_toast(&e);
+                                }
+                            }
+                        }
+                    });
+                }
+                AlbumEvent::AlbumRemoved(id) => {
+                    let weak = client_weak.clone();
+                    glib::idle_add_once(move || {
+                        if let Some(client) = weak.upgrade() {
+                            client.remove_from_models(&id);
+                            client.emit_by_name::<()>("album-deleted", &[&id.as_str().to_string()]);
+                        }
+                    });
+                }
+            }
+        }
+        debug!("album event listener shutting down");
     }
 
     // ── Commands ──────────────────────────────────────────────────────

--- a/src/library/album/event.rs
+++ b/src/library/album/event.rs
@@ -1,0 +1,16 @@
+use super::model::AlbumId;
+
+/// Events emitted by `AlbumService` after state changes.
+///
+/// Consumed by `AlbumClientV2` to patch ListStore models in-place.
+/// Sent via `tokio::sync::mpsc` — single producer (service), single
+/// consumer (client).
+#[derive(Debug, Clone)]
+pub enum AlbumEvent {
+    /// A new album was added (sync upsert, no prior row).
+    AlbumAdded(AlbumId),
+    /// An existing album was updated (sync upsert, media added/removed).
+    AlbumUpdated(AlbumId),
+    /// An album was removed (sync delete).
+    AlbumRemoved(AlbumId),
+}

--- a/src/library/album/mod.rs
+++ b/src/library/album/mod.rs
@@ -1,6 +1,8 @@
+mod event;
 mod model;
 pub mod repository;
 mod service;
 
+pub use event::AlbumEvent;
 pub use model::{Album, AlbumId};
 pub use service::AlbumService;

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -83,6 +83,11 @@ impl AlbumRepository {
         Ok(rows.into_iter().map(album_from_row).collect())
     }
 
+    /// Fetch a single album by raw ID string, including media count and cover.
+    pub async fn get_by_raw_id(&self, id: &str) -> Result<Option<Album>, LibraryError> {
+        self.get(&AlbumId::from_raw(id.to_string())).await
+    }
+
     /// Fetch a single album by ID, including media count and cover.
     pub async fn get(&self, id: &AlbumId) -> Result<Option<Album>, LibraryError> {
         let row: Option<AlbumRow> = sqlx::query_as(

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use tokio::sync::mpsc;
 use tracing::warn;
 
+use super::event::AlbumEvent;
 use super::model::{Album, AlbumId};
 use super::repository::AlbumRepository;
 use crate::library::db::Database;
@@ -12,18 +14,42 @@ use crate::library::mutation::Mutation;
 use crate::library::recorder::MutationRecorder;
 
 /// Album management service.
+///
+/// Holds an `mpsc::Sender<AlbumEvent>` to notify the client layer of
+/// state changes. Call `subscribe()` once to obtain the receiver.
 #[derive(Clone)]
 pub struct AlbumService {
     repo: AlbumRepository,
     recorder: Arc<dyn MutationRecorder>,
+    events_tx: mpsc::UnboundedSender<AlbumEvent>,
+    /// Held so `subscribe()` can hand it out exactly once.
+    events_rx: Arc<tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<AlbumEvent>>>>,
 }
 
 impl AlbumService {
     pub fn new(db: Database, recorder: Arc<dyn MutationRecorder>) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
         Self {
             repo: AlbumRepository::new(db),
             recorder,
+            events_tx: tx,
+            events_rx: Arc::new(tokio::sync::Mutex::new(Some(rx))),
         }
+    }
+
+    /// Take the event receiver. Can only be called once — panics on
+    /// subsequent calls.
+    pub async fn subscribe(&self) -> mpsc::UnboundedReceiver<AlbumEvent> {
+        self.events_rx
+            .lock()
+            .await
+            .take()
+            .expect("AlbumService::subscribe() called more than once")
+    }
+
+    /// Send an event, ignoring errors (no subscriber yet, or dropped).
+    fn emit(&self, event: AlbumEvent) {
+        let _ = self.events_tx.send(event);
     }
 
     // ── Sync upsert (pull from server, no outbox recording) ────────
@@ -37,9 +63,17 @@ impl AlbumService {
         updated_at: i64,
         external_id: Option<&str>,
     ) -> Result<(), LibraryError> {
+        let existed = self.repo.get_by_raw_id(id).await?.is_some();
         self.repo
             .upsert(id, name, created_at, updated_at, external_id)
-            .await
+            .await?;
+        let album_id = AlbumId::from_raw(id.to_string());
+        if existed {
+            self.emit(AlbumEvent::AlbumUpdated(album_id));
+        } else {
+            self.emit(AlbumEvent::AlbumAdded(album_id));
+        }
+        Ok(())
     }
 
     // ── Query methods ───────────────────────────────────────────────
@@ -89,6 +123,7 @@ impl AlbumService {
     pub async fn delete_album(&self, id: &AlbumId) -> Result<(), LibraryError> {
         let external_id = self.repo.external_id(id).await.unwrap_or(None);
         self.repo.delete(id).await?;
+        self.emit(AlbumEvent::AlbumRemoved(id.clone()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AlbumDeleted {
@@ -108,6 +143,7 @@ impl AlbumService {
         media_ids: &[MediaId],
     ) -> Result<(), LibraryError> {
         self.repo.add_media(album_id, media_ids).await?;
+        self.emit(AlbumEvent::AlbumUpdated(album_id.clone()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AlbumMediaAdded {
@@ -127,6 +163,7 @@ impl AlbumService {
         media_ids: &[MediaId],
     ) -> Result<(), LibraryError> {
         self.repo.remove_media(album_id, media_ids).await?;
+        self.emit(AlbumEvent::AlbumUpdated(album_id.clone()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AlbumMediaRemoved {


### PR DESCRIPTION
## Summary
- Add `AlbumEvent` enum (`AlbumAdded`/`AlbumUpdated`/`AlbumRemoved`) and `mpsc` channel on `AlbumService` — same direct service→client pattern as `FacesEvent` on `FacesService` (#566)
- `AlbumService` emits events from `upsert_album`, `delete_album`, `add_to_album`, and `remove_from_album`
- `AlbumClientV2` spawns a listener that patches models reactively when sync adds, updates, or removes albums
- Add `get_by_raw_id()` on `AlbumRepository` for existence checks during upsert

Existing `AppEvent` consumers (window route cleanup, photo_grid viewer exit) remain on the event bus — they serve cross-cutting concerns beyond the album client and will be migrated separately.

## Test plan
- [ ] `make lint` passes (verified locally)
- [ ] `make test` passes — 395 unit tests (verified locally)
- [ ] Test album grid loads correctly after Immich sync
- [ ] Verify new albums appear reactively during sync without manual reload
- [ ] Test album deletion removes from grid reactively
- [ ] Test album media changes (add/remove) update cover thumbnails reactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)