### PR TITLE
refactor: simplify list_people to always return all people

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,11 +156,11 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -326,15 +326,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -1859,25 +1850,25 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libflate"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.1",
+ "no_std_io2",
  "rle-decode-fast",
 ]
 
@@ -2181,6 +2172,15 @@ name = "mutate_once"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2575,7 +2575,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2924,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src/client/people/client_v2.rs
+++ b/src/client/people/client_v2.rs
@@ -180,8 +180,8 @@ impl PeopleClientV2 {
 
     /// Fetch all people and splice into the given model.
     ///
-    /// Loads every person (hidden, unnamed, all) from the service and
-    /// replaces the model contents. Views should call this on realize.
+    /// Loads every person from the service and replaces the model
+    /// contents. Views apply their own filtering via `FilterListModel`.
     #[instrument(skip(self, model))]
     pub fn list_people(&self, model: &gio::ListStore) {
         let (library, tokio) = self.deps();
@@ -189,10 +189,9 @@ impl PeopleClientV2 {
 
         glib::MainContext::default().spawn_local(async move {
             let lib = library.clone();
-            let result = crate::client::spawn_on(&tokio, async move {
-                lib.faces().list_people(true, true).await
-            })
-            .await;
+            let result =
+                crate::client::spawn_on(&tokio, async move { lib.faces().list_people().await })
+                    .await;
 
             match result {
                 Ok(people) => {

--- a/src/library/db/faces.rs
+++ b/src/library/db/faces.rs
@@ -14,14 +14,8 @@ use super::Database;
 
 impl Database {
     /// Forwarding shim — delegates to `FacesRepository`.
-    pub async fn list_people(
-        &self,
-        include_hidden: bool,
-        include_unnamed: bool,
-    ) -> Result<Vec<crate::library::faces::Person>, LibraryError> {
-        FacesRepository::new(self.clone())
-            .list_people(include_hidden, include_unnamed)
-            .await
+    pub async fn list_people(&self) -> Result<Vec<crate::library::faces::Person>, LibraryError> {
+        FacesRepository::new(self.clone()).list_people().await
     }
 
     /// Forwarding shim — delegates to `FacesRepository`.

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -42,35 +42,17 @@ impl FacesRepository {
 
     // ── Read queries ────────────────────────────────────────────────
 
-    /// List people, ordered by face count descending.
-    pub async fn list_people(
-        &self,
-        include_hidden: bool,
-        include_unnamed: bool,
-    ) -> Result<Vec<Person>, LibraryError> {
-        let mut conditions = Vec::new();
-        if !include_hidden {
-            conditions.push("is_hidden = 0");
-        }
-        if !include_unnamed {
-            conditions.push("name != ''");
-        }
-
-        let where_clause = if conditions.is_empty() {
-            String::new()
-        } else {
-            format!("WHERE {}", conditions.join(" AND "))
-        };
-
-        let sql = format!(
-            "SELECT id, name, face_count, is_hidden FROM people {} ORDER BY face_count DESC, name ASC",
-            where_clause
-        );
-
-        let rows: Vec<PersonRow> = sqlx::query_as(&sql)
-            .fetch_all(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
+    /// List all people, ordered by face count descending.
+    ///
+    /// Returns every person (hidden, unnamed, all). Filtering is done
+    /// at the widget layer via `gtk::FilterListModel`.
+    pub async fn list_people(&self) -> Result<Vec<Person>, LibraryError> {
+        let rows: Vec<PersonRow> = sqlx::query_as(
+            "SELECT id, name, face_count, is_hidden FROM people ORDER BY face_count DESC, name ASC",
+        )
+        .fetch_all(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
 
         Ok(rows
             .into_iter()
@@ -300,7 +282,7 @@ mod tests {
             .await
             .unwrap();
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert_eq!(people.len(), 2);
     }
 
@@ -316,13 +298,13 @@ mod tests {
             .await
             .unwrap();
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert_eq!(people.len(), 1);
         assert_eq!(people[0].name, "Alice Smith");
     }
 
     #[tokio::test]
-    async fn list_people_excludes_hidden() {
+    async fn list_people_includes_hidden_and_unnamed() {
         let dir = tempdir().unwrap();
         let (repo, _media, _db) = test_repo(dir.path()).await;
 
@@ -332,33 +314,12 @@ mod tests {
         repo.upsert_person("p2", "Hidden", None, true, false, None, None, None)
             .await
             .unwrap();
-
-        let visible = repo.list_people(false, true).await.unwrap();
-        assert_eq!(visible.len(), 1);
-        assert_eq!(visible[0].name, "Alice");
-
-        let all = repo.list_people(true, true).await.unwrap();
-        assert_eq!(all.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn list_people_excludes_unnamed() {
-        let dir = tempdir().unwrap();
-        let (repo, _media, _db) = test_repo(dir.path()).await;
-
-        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
-            .await
-            .unwrap();
-        repo.upsert_person("p2", "", None, false, false, None, None, None)
+        repo.upsert_person("p3", "", None, false, false, None, None, None)
             .await
             .unwrap();
 
-        let named = repo.list_people(true, false).await.unwrap();
-        assert_eq!(named.len(), 1);
-        assert_eq!(named[0].name, "Alice");
-
-        let all = repo.list_people(true, true).await.unwrap();
-        assert_eq!(all.len(), 2);
+        let all = repo.list_people().await.unwrap();
+        assert_eq!(all.len(), 3);
     }
 
     #[tokio::test]
@@ -421,7 +382,7 @@ mod tests {
         repo.update_face_count("p1").await.unwrap();
         repo.update_face_count("p2").await.unwrap();
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert_eq!(people[0].name, "Bob"); // 2 faces
         assert_eq!(people[0].face_count, 2);
         assert_eq!(people[1].name, "Alice"); // 1 face
@@ -438,7 +399,7 @@ mod tests {
             .unwrap();
         repo.delete_person("p1").await.unwrap();
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert!(people.is_empty());
     }
 
@@ -452,7 +413,7 @@ mod tests {
             .unwrap();
         repo.rename_person("p1", "Alice Smith").await.unwrap();
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert_eq!(people[0].name, "Alice Smith");
     }
 
@@ -466,10 +427,7 @@ mod tests {
             .unwrap();
         repo.set_person_hidden("p1", true).await.unwrap();
 
-        let visible = repo.list_people(false, true).await.unwrap();
-        assert!(visible.is_empty());
-
-        let all = repo.list_people(true, true).await.unwrap();
+        let all = repo.list_people().await.unwrap();
         assert_eq!(all.len(), 1);
         assert!(all[0].is_hidden);
     }
@@ -509,7 +467,7 @@ mod tests {
         let media = repo.list_media_for_person("p1").await.unwrap();
         assert!(media.is_empty());
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert_eq!(people[0].face_count, 0);
     }
 
@@ -589,7 +547,7 @@ mod tests {
         repo.clear_asset_faces().await.unwrap();
         repo.clear_people().await.unwrap();
 
-        let people = repo.list_people(true, true).await.unwrap();
+        let people = repo.list_people().await.unwrap();
         assert!(people.is_empty());
 
         let media = repo.list_media_for_person("p1").await.unwrap();

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -143,12 +143,8 @@ impl FacesService {
 
     // ── Query methods ───────────────────────────────────────────────
 
-    pub async fn list_people(
-        &self,
-        include_hidden: bool,
-        include_unnamed: bool,
-    ) -> Result<Vec<Person>, LibraryError> {
-        self.repo.list_people(include_hidden, include_unnamed).await
+    pub async fn list_people(&self) -> Result<Vec<Person>, LibraryError> {
+        self.repo.list_people().await
     }
 
     pub async fn get_person(&self, person_id: &PersonId) -> Result<Option<Person>, LibraryError> {

--- a/src/ui/people_grid/mod.rs
+++ b/src/ui/people_grid/mod.rs
@@ -148,7 +148,12 @@ impl PeopleGridView {
             let cf = custom_filter.clone();
             imp.unnamed_toggle.connect_toggled(move |btn| {
                 fs.include_unnamed.set(btn.is_active());
-                cf.changed(gtk::FilterChange::Different);
+                let change = if btn.is_active() {
+                    gtk::FilterChange::LessStrict
+                } else {
+                    gtk::FilterChange::MoreStrict
+                };
+                cf.changed(change);
             });
         }
         {
@@ -156,7 +161,12 @@ impl PeopleGridView {
             let cf = custom_filter;
             imp.hidden_toggle.connect_toggled(move |btn| {
                 fs.include_hidden.set(btn.is_active());
-                cf.changed(gtk::FilterChange::Different);
+                let change = if btn.is_active() {
+                    gtk::FilterChange::LessStrict
+                } else {
+                    gtk::FilterChange::MoreStrict
+                };
+                cf.changed(change);
             });
         }
 


### PR DESCRIPTION
## Summary
- Removed `include_hidden`/`include_unnamed` params from `FacesRepository::list_people()`, `FacesService::list_people()`, and the `Database` forwarding shim
- Replaced dynamic SQL (`format!` with conditional WHERE clauses) with a simple static query
- Filtering is now entirely at the widget layer via `gtk::FilterListModel` in `people_grid`
- Replaced two filter-specific tests with a single `list_people_includes_hidden_and_unnamed` test

## Test plan
- [x] `make lint` passes (fmt + clippy)
- [ ] `make test` — unit tests pass
- [ ] `make run-dev` — people grid still shows/hides people correctly via toggle buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)