### PR TITLE
refactor: align ImportClient with v2 channel + listen pattern

### DIFF
--- a/src/app_event/mod.rs
+++ b/src/app_event/mod.rs
@@ -86,10 +86,6 @@ pub enum AppEvent {
     Deleted {
         ids: Vec<MediaId>,
     },
-    /// A local import just persisted a new asset (per-file notification).
-    AssetImported {
-        id: MediaId,
-    },
     AssetSynced {
         item: MediaItem,
     },

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -47,7 +47,7 @@ mod imp {
         pub settings: OnceCell<gio::Settings>,
         pub tokio: OnceCell<tokio::runtime::Handle>,
         pub library: RefCell<Option<Arc<Library>>>,
-        pub import_client: RefCell<Option<crate::client::import_client::ImportClient>>,
+        pub import_client: RefCell<Option<crate::client::ImportClient>>,
         pub album_client_v2: RefCell<Option<crate::client::AlbumClientV2>>,
         pub people_client: RefCell<Option<crate::client::PeopleClientV2>>,
         pub media_client: RefCell<Option<crate::client::MediaClient>>,
@@ -198,7 +198,7 @@ impl MomentsApplication {
     ///
     /// Available from anywhere via `MomentsApplication::default().import_client()`.
     /// Returns `None` if no library is open yet.
-    pub fn import_client(&self) -> Option<crate::client::import_client::ImportClient> {
+    pub fn import_client(&self) -> Option<crate::client::ImportClient> {
         self.imp().import_client.borrow().clone()
     }
 
@@ -614,7 +614,7 @@ impl MomentsApplication {
                             *app.imp().render_pipeline.borrow_mut() =
                                 Some(Arc::clone(&render_pipeline));
 
-                            let import_client = crate::client::import_client::ImportClient::new();
+                            let import_client = crate::client::ImportClient::new();
                             import_client.configure(
                                 Arc::clone(&library),
                                 originals_dir,
@@ -622,7 +622,6 @@ impl MomentsApplication {
                                 Arc::clone(&render_pipeline),
                                 storage_mode,
                                 tokio.clone(),
-                                bus.sender(),
                             );
                             *app.imp().import_client.borrow_mut() = Some(import_client);
                         }

--- a/src/client/import/client.rs
+++ b/src/client/import/client.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
-use tracing::{error, info};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info};
 
-use crate::event_bus::EventSender;
+use super::event::ImportEvent;
 use crate::importer::ImportPipeline;
 use crate::library::config::LocalStorageMode;
 use crate::library::Library;
@@ -31,7 +32,7 @@ struct ImportDeps {
     render_pipeline: Arc<RenderPipeline>,
     mode: LocalStorageMode,
     tokio: tokio::runtime::Handle,
-    bus: EventSender,
+    events_tx: mpsc::UnboundedSender<ImportEvent>,
 }
 
 mod imp {
@@ -112,12 +113,12 @@ mod imp {
 glib::wrapper! {
     /// GObject singleton that manages import state.
     ///
-    /// Holds import progress as GObject properties. UI components access it
-    /// via `MomentsApplication::default().import_client()` and connect to
-    /// `notify::` signals or bind properties.
+    /// Holds import progress as GObject properties. UI components bind to
+    /// `notify::` signals for live updates.
     ///
-    /// The [`ImportPipeline`] is ephemeral — created per import run, writes
-    /// to this client's properties while running, dropped on completion.
+    /// The [`ImportPipeline`] is ephemeral — created per `import()` call.
+    /// Progress flows through an internal channel to a `listen()` loop
+    /// that marshals updates to the GTK main thread.
     pub struct ImportClient(ObjectSubclass<imp::ImportClient>);
 }
 
@@ -132,10 +133,10 @@ impl ImportClient {
         glib::Object::builder().build()
     }
 
-    /// Set the dependencies required for building import pipelines.
+    /// Set the dependencies required for building import pipelines
+    /// and start the event listener.
     ///
     /// Must be called once after construction, before the first `import()` call.
-    #[allow(clippy::too_many_arguments)]
     pub fn configure(
         &self,
         library: Arc<Library>,
@@ -144,17 +145,21 @@ impl ImportClient {
         render_pipeline: Arc<RenderPipeline>,
         mode: LocalStorageMode,
         tokio: tokio::runtime::Handle,
-        bus: EventSender,
     ) {
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+
         *self.imp().deps.borrow_mut() = Some(ImportDeps {
             library,
             originals_dir,
             thumbnails_dir,
             render_pipeline,
             mode,
-            tokio,
-            bus,
+            tokio: tokio.clone(),
+            events_tx,
         });
+
+        let client_weak: glib::SendWeakRef<ImportClient> = self.downgrade().into();
+        tokio.spawn(Self::listen(events_rx, client_weak));
     }
 
     // ── Property accessors ───────────────────────────────────────────
@@ -230,17 +235,51 @@ impl ImportClient {
         self.notify("elapsed-secs");
     }
 
+    // ── Event listener ───────────────────────────────────────────────
+
+    async fn listen(
+        mut rx: mpsc::UnboundedReceiver<ImportEvent>,
+        client_weak: glib::SendWeakRef<ImportClient>,
+    ) {
+        while let Some(event) = rx.recv().await {
+            let weak = client_weak.clone();
+            glib::idle_add_once(move || {
+                let Some(client) = weak.upgrade() else {
+                    return;
+                };
+                match event {
+                    ImportEvent::Progress(p) => {
+                        client.set_current(p.current as u32);
+                        client.set_total(p.total as u32);
+                        client.set_imported(p.imported as u32);
+                        client.set_skipped(p.skipped as u32);
+                        client.set_failed(p.failed as u32);
+                    }
+                    ImportEvent::Complete(summary) => {
+                        client.set_imported(summary.imported as u32);
+                        client.set_skipped(
+                            (summary.skipped_duplicates + summary.skipped_unsupported) as u32,
+                        );
+                        client.set_failed(summary.failed as u32);
+                        client.set_elapsed_secs(summary.elapsed_secs);
+                        client.set_state(ImportState::Complete);
+                    }
+                }
+            });
+        }
+        debug!("import event listener shutting down");
+    }
+
     // ── Import action ────────────────────────────────────────────────
 
     /// Start an import of the given source files/directories.
     ///
     /// Sets `state` to `Running`, resets counters, builds an ephemeral
     /// [`ImportPipeline`], and spawns it on Tokio. Progress and completion
-    /// are reflected as property updates on this GObject (marshalled to the
-    /// GTK main thread via `glib::idle_add_once`).
+    /// flow through the internal event channel to `listen()`.
     pub fn import(&self, sources: Vec<PathBuf>) {
         // Extract dependencies (clone under borrow, then release).
-        let (library, originals_dir, thumbnails_dir, render_pipeline, mode, tokio, bus) = {
+        let (library, originals_dir, thumbnails_dir, render_pipeline, mode, tokio, events_tx) = {
             let deps = self.imp().deps.borrow();
             let deps = match deps.as_ref() {
                 Some(d) => d,
@@ -256,11 +295,11 @@ impl ImportClient {
                 deps.render_pipeline.clone(),
                 deps.mode.clone(),
                 deps.tokio.clone(),
-                deps.bus.clone(),
+                deps.events_tx.clone(),
             )
         };
 
-        // Reset state.
+        // Reset state (called from GTK thread, safe to set directly).
         self.set_state(ImportState::Running);
         self.set_current(0);
         self.set_total(0);
@@ -269,10 +308,7 @@ impl ImportClient {
         self.set_failed(0);
         self.set_elapsed_secs(0.0);
 
-        // Use SendWeakRef for the Tokio-spawned future (GObject is !Send).
-        let progress_weak: glib::SendWeakRef<ImportClient> = self.downgrade().into();
-        let complete_weak: glib::SendWeakRef<ImportClient> = self.downgrade().into();
-
+        let progress_tx = events_tx.clone();
         let pipeline = match ImportPipeline::builder()
             .originals_dir(originals_dir)
             .thumbnails_dir(thumbnails_dir)
@@ -280,21 +316,7 @@ impl ImportClient {
             .render_pipeline(render_pipeline)
             .mode(mode)
             .on_progress(move |p| {
-                let weak = progress_weak.clone();
-                let imported_id = p.imported_id.clone();
-                let bus = bus.clone();
-                glib::idle_add_once(move || {
-                    if let Some(client) = weak.upgrade() {
-                        client.set_current(p.current as u32);
-                        client.set_total(p.total as u32);
-                        client.set_imported(p.imported as u32);
-                        client.set_skipped(p.skipped as u32);
-                        client.set_failed(p.failed as u32);
-                    }
-                    if let Some(id) = imported_id {
-                        bus.send(crate::app_event::AppEvent::AssetImported { id });
-                    }
-                });
+                let _ = progress_tx.send(ImportEvent::Progress(p));
             })
             .build()
         {
@@ -309,19 +331,129 @@ impl ImportClient {
         info!(count = sources.len(), "starting import");
         tokio.spawn(async move {
             let summary = pipeline.run(sources).await;
-
-            // Marshal final state to GTK thread.
-            glib::idle_add_once(move || {
-                if let Some(client) = complete_weak.upgrade() {
-                    client.set_imported(summary.imported as u32);
-                    client.set_skipped(
-                        (summary.skipped_duplicates + summary.skipped_unsupported) as u32,
-                    );
-                    client.set_failed(summary.failed as u32);
-                    client.set_elapsed_secs(summary.elapsed_secs);
-                    client.set_state(ImportState::Complete);
-                }
-            });
+            let _ = events_tx.send(ImportEvent::Complete(summary));
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::importer::{ImportProgress, ImportSummary};
+
+    // ── Construction & defaults ──────────────────────────────────────
+
+    #[test]
+    fn new_client_has_idle_state() {
+        let client = ImportClient::new();
+        assert_eq!(client.state(), ImportState::Idle);
+    }
+
+    #[test]
+    fn new_client_has_zero_counters() {
+        let client = ImportClient::new();
+        assert_eq!(client.current(), 0);
+        assert_eq!(client.total(), 0);
+        assert_eq!(client.imported(), 0);
+        assert_eq!(client.skipped(), 0);
+        assert_eq!(client.failed(), 0);
+        assert_eq!(client.elapsed_secs(), 0.0);
+    }
+
+    // ── Property setters ────────────────────────────────────────────
+
+    #[test]
+    fn set_state_updates_value() {
+        let client = ImportClient::new();
+        client.set_state(ImportState::Running);
+        assert_eq!(client.state(), ImportState::Running);
+
+        client.set_state(ImportState::Complete);
+        assert_eq!(client.state(), ImportState::Complete);
+    }
+
+    #[test]
+    fn set_counters_update_values() {
+        let client = ImportClient::new();
+        client.set_current(5);
+        client.set_total(10);
+        client.set_imported(3);
+        client.set_skipped(1);
+        client.set_failed(1);
+        client.set_elapsed_secs(2.5);
+
+        assert_eq!(client.current(), 5);
+        assert_eq!(client.total(), 10);
+        assert_eq!(client.imported(), 3);
+        assert_eq!(client.skipped(), 1);
+        assert_eq!(client.failed(), 1);
+        assert_eq!(client.elapsed_secs(), 2.5);
+    }
+
+    #[test]
+    fn set_state_no_notify_on_same_value() {
+        let client = ImportClient::new();
+        let notified = std::rc::Rc::new(std::cell::Cell::new(false));
+        let flag = notified.clone();
+        client.connect_notify_local(Some("state"), move |_, _| {
+            flag.set(true);
+        });
+
+        client.set_state(ImportState::Idle);
+        assert!(!notified.get());
+
+        client.set_state(ImportState::Running);
+        assert!(notified.get());
+    }
+
+    // ── GObject property access ─────────────────────────────────────
+
+    #[test]
+    fn gobject_property_reads_match_accessors() {
+        let client = ImportClient::new();
+        client.set_state(ImportState::Running);
+        client.set_current(7);
+        client.set_total(20);
+        client.set_imported(5);
+        client.set_skipped(1);
+        client.set_failed(1);
+
+        let state: ImportState = client.property("state");
+        assert_eq!(state, ImportState::Running);
+
+        let current: u32 = client.property("current");
+        assert_eq!(current, 7);
+
+        let total: u32 = client.property("total");
+        assert_eq!(total, 20);
+    }
+
+    // ── ImportEvent ─────────────────────────────────────────────────
+
+    #[test]
+    fn import_event_progress_wraps_data() {
+        let p = ImportProgress {
+            current: 3,
+            total: 10,
+            imported: 2,
+            skipped: 1,
+            failed: 0,
+            imported_id: None,
+        };
+        let event = ImportEvent::Progress(p.clone());
+        assert!(matches!(event, ImportEvent::Progress(ref inner) if inner.current == 3));
+    }
+
+    #[test]
+    fn import_event_complete_wraps_summary() {
+        let s = ImportSummary {
+            imported: 5,
+            skipped_duplicates: 2,
+            skipped_unsupported: 0,
+            failed: 1,
+            elapsed_secs: 3.5,
+        };
+        let event = ImportEvent::Complete(s);
+        assert!(matches!(event, ImportEvent::Complete(ref inner) if inner.imported == 5));
     }
 }

--- a/src/client/import/event.rs
+++ b/src/client/import/event.rs
@@ -1,0 +1,10 @@
+use crate::importer::{ImportProgress, ImportSummary};
+
+/// Client-internal events for decoupling the import pipeline from
+/// GObject property updates. The pipeline callback sends these on a
+/// channel; the `listen()` loop receives and updates properties.
+#[derive(Debug, Clone)]
+pub(super) enum ImportEvent {
+    Progress(ImportProgress),
+    Complete(ImportSummary),
+}

--- a/src/client/import/mod.rs
+++ b/src/client/import/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+mod event;
+
+pub use client::{ImportClient, ImportState};

--- a/src/client/media/client.rs
+++ b/src/client/media/client.rs
@@ -119,7 +119,7 @@ impl MediaClient {
         {
             let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
             let handler = import_client.connect_notify_local(Some("state"), move |client, _| {
-                if client.state() == crate::client::import_client::ImportState::Complete {
+                if client.state() == crate::client::ImportState::Complete {
                     if let Some(media_client) = client_weak.upgrade() {
                         media_client.reload_all();
                     }
@@ -394,9 +394,6 @@ impl MediaClient {
                     self.on_deleted(id);
                 }
             }
-            AppEvent::AssetImported { id } => {
-                self.on_asset_imported(id);
-            }
             AppEvent::AssetSynced { item } => {
                 self.on_asset_synced(item);
             }
@@ -536,6 +533,8 @@ impl MediaClient {
         }
     }
 
+    // Will be revived when MediaClient v2 subscribes to MediaEvent::Added.
+    #[allow(dead_code)]
     fn on_asset_imported(&self, id: &MediaId) {
         // Collect stores for filters that should show newly imported items.
         let stores: Vec<gio::ListStore> = {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,11 +1,11 @@
 pub mod album;
-pub mod import_client;
+pub mod import;
 pub mod media;
 pub mod people;
 pub mod sync;
 
 pub use album::{AlbumClientV2, AlbumItemObject};
-pub use import_client::{ImportClient, ImportState};
+pub use import::{ImportClient, ImportState};
 pub use media::{MediaClient, MediaItemObject};
 pub use people::{PeopleClientV2, PersonItemObject};
 pub use sync::{SyncClient, SyncState};

--- a/src/ui/import_dialog/mod.rs
+++ b/src/ui/import_dialog/mod.rs
@@ -82,8 +82,7 @@ mod imp {
                     Some("state"),
                     move |client, _| {
                         if let Some(dialog) = weak.upgrade() {
-                            if client.state() == crate::client::import_client::ImportState::Complete
-                            {
+                            if client.state() == crate::client::ImportState::Complete {
                                 let summary = crate::importer::ImportSummary {
                                     imported: client.imported() as usize,
                                     skipped_duplicates: client.skipped() as usize,

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -301,8 +301,7 @@ mod imp {
                     Some("state"),
                     move |client, _| {
                         if let Some(sidebar) = weak.upgrade() {
-                            if client.state() == crate::client::import_client::ImportState::Complete
-                            {
+                            if client.state() == crate::client::ImportState::Complete {
                                 let summary = crate::importer::ImportSummary {
                                     imported: client.imported() as usize,
                                     skipped_duplicates: client.skipped() as usize,

--- a/src/ui/window/mod.rs
+++ b/src/ui/window/mod.rs
@@ -217,7 +217,7 @@ impl MomentsWindow {
         {
             let weak = self.downgrade();
             import_client.connect_notify_local(Some("state"), move |client, _| {
-                if client.state() == crate::client::import_client::ImportState::Complete {
+                if client.state() == crate::client::ImportState::Complete {
                     let weak = weak.clone();
                     glib::idle_add_local_once(move || {
                         if let Some(win) = weak.upgrade() {


### PR DESCRIPTION
## Summary
- Moved `import_client.rs` into `client/import/` directory (matching album/people/sync pattern)
- New `ImportEvent` enum wrapping existing `ImportProgress`/`ImportSummary` types
- `configure()` creates internal channel, spawns `listen()` loop on Tokio
- `import()` sends events on channel — pipeline callback no longer pokes GObject properties directly
- Stripped `EventSender`/bus dependency from ImportClient entirely
- Removed `AppEvent::AssetImported` variant and MediaClient handler

Phase 2 of #569. No UI changes — properties still notify, sidebar/import dialog bindings unchanged.

## Known gap
Newly imported photos won't auto-appear in the grid until navigating away/back. This is fixed when MediaClient v2 subscribes to `MediaEvent::Added` from `MediaService`.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (414 tests, 8 new ImportClient tests)
- [ ] `make run-dev` — import works, progress dialog updates, completion shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)