### PR TITLE
refactor: remove dead AppEvent variants (#576)

### DIFF
--- a/src/app_event/mod.rs
+++ b/src/app_event/mod.rs
@@ -18,22 +18,7 @@ use crate::library::media::{MediaId, MediaItem};
 #[derive(Debug, Clone)]
 pub enum AppEvent {
     // ── Lifecycle ────────────────────────────────────────────────────────────
-    Ready,
-    ShutdownComplete,
     Error(String),
-
-    // ── Import (legacy — used by ImmichImportJob, will be removed when
-    //    Immich import moves to sync) ─────────────────────────────────────────
-    ImportProgress {
-        current: usize,
-        total: usize,
-        imported: usize,
-        skipped: usize,
-        failed: usize,
-    },
-    ImportComplete {
-        summary: crate::importer::ImportSummary,
-    },
 
     // ── Thumbnails ───────────────────────────────────────────────────────────
     ThumbnailReady {

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -641,9 +641,6 @@ impl MomentsApplication {
                         // Store library on the application.
                         *app.imp().library.borrow_mut() = Some(Arc::clone(&library));
 
-                        // Notify the UI that the library is ready.
-                        bus.sender().send(AppEvent::Ready);
-
                         // Create the import client (GObject singleton).
                         let sync_thumbnails_dir = thumbnails_dir.clone();
                         {

--- a/src/library/metadata/exif.rs
+++ b/src/library/metadata/exif.rs
@@ -146,9 +146,7 @@ fn rational_or_short_u32(exif: &exif::Exif, tag: exif::Tag) -> Option<u32> {
     match &field.value {
         exif::Value::Long(v) => v.first().copied(),
         exif::Value::Short(v) => v.first().map(|&x| x as u32),
-        exif::Value::Rational(v) => v
-            .first()
-            .map(|r| if r.denom != 0 { r.num / r.denom } else { 0 }),
+        exif::Value::Rational(v) => v.first().map(|r| r.num.checked_div(r.denom).unwrap_or(0)),
         _ => None,
     }
 }

--- a/src/ui/import_dialog/mod.rs
+++ b/src/ui/import_dialog/mod.rs
@@ -18,7 +18,7 @@ mod imp {
         pub counts_label: TemplateChild<gtk::Label>,
         #[template_child]
         pub action_button: TemplateChild<gtk::Button>,
-        /// True once `ImportComplete` has been received.
+        /// True once the import has finished.
         pub complete: Cell<bool>,
         /// Signal handler IDs for ImportClient property notifications.
         pub _import_handlers: RefCell<Vec<glib::SignalHandlerId>>,

--- a/tests/event_bus.rs
+++ b/tests/event_bus.rs
@@ -19,6 +19,10 @@ fn flush_events() {
     while glib::MainContext::default().iteration(false) {}
 }
 
+fn error_event() -> AppEvent {
+    AppEvent::Error("test".to_string())
+}
+
 // ── Fan-out delivery ────────────────────────────────────────────────────────
 
 #[gtk::test]
@@ -28,12 +32,12 @@ fn single_subscriber_receives_event() {
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
     let _sub = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             r.set(true);
         }
     });
 
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
 
     assert!(received.get());
@@ -48,13 +52,13 @@ fn multiple_subscribers_all_receive() {
     for _ in 0..3 {
         let c = Rc::clone(&count);
         subs.push(bus.subscribe(move |event| {
-            if matches!(event, AppEvent::Ready) {
+            if matches!(event, AppEvent::Error(_)) {
                 c.set(c.get() + 1);
             }
         }));
     }
 
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
 
     assert_eq!(count.get(), 3);
@@ -67,12 +71,12 @@ fn subscribers_ignore_unmatched_events() {
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
     let _sub = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             r.set(true);
         }
     });
 
-    bus.sender().send(AppEvent::ShutdownComplete);
+    bus.sender().send(AppEvent::EmptyTrashRequested);
     flush_events();
 
     assert!(
@@ -89,8 +93,8 @@ fn multiple_events_delivered_in_order() {
     let l = Rc::clone(&log);
     let _sub = bus.subscribe(move |event| {
         let name = match event {
-            AppEvent::Ready => "ready",
-            AppEvent::ShutdownComplete => "shutdown",
+            AppEvent::Error(_) => "error",
+            AppEvent::EmptyTrashRequested => "empty_trash",
             AppEvent::ThumbnailReady { .. } => "thumb",
             _ => return,
         };
@@ -98,18 +102,18 @@ fn multiple_events_delivered_in_order() {
     });
 
     let tx = bus.sender();
-    tx.send(AppEvent::Ready);
+    tx.send(error_event());
     tx.send(AppEvent::ThumbnailReady {
         media_id: MediaId::new("abc".to_string()),
     });
-    tx.send(AppEvent::ShutdownComplete);
+    tx.send(AppEvent::EmptyTrashRequested);
     flush_events();
 
     let entries = log.borrow();
     assert_eq!(entries.len(), 3);
-    assert_eq!(entries[0], "ready");
+    assert_eq!(entries[0], "error");
     assert_eq!(entries[1], "thumb");
-    assert_eq!(entries[2], "shutdown");
+    assert_eq!(entries[2], "empty_trash");
 }
 
 // ── Cross-thread delivery ───────────────────────────────────────────────────
@@ -121,14 +125,14 @@ fn sender_works_from_another_thread() {
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
     let _sub = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             r.set(true);
         }
     });
 
     let tx = bus.sender();
     std::thread::spawn(move || {
-        tx.send(AppEvent::Ready);
+        tx.send(error_event());
     })
     .join()
     .unwrap();
@@ -205,12 +209,12 @@ fn drop_cleans_up_thread_local_state() {
     let received = Rc::new(Cell::new(false));
     let r = Rc::clone(&received);
     let _sub = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             r.set(true);
         }
     });
 
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
 
     assert!(received.get(), "new bus after drop should work");
@@ -230,7 +234,7 @@ fn dropping_subscription_during_dispatch_does_not_panic() {
     let b_count = Rc::new(Cell::new(0u32));
     let bc = Rc::clone(&b_count);
     let sub = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             bc.set(bc.get() + 1);
         }
     });
@@ -238,7 +242,7 @@ fn dropping_subscription_during_dispatch_does_not_panic() {
 
     let sb = Rc::clone(&sub_b);
     let _sub_a = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             // Drop subscriber B's subscription from within dispatch.
             sb.borrow_mut().take();
         }
@@ -247,7 +251,7 @@ fn dropping_subscription_during_dispatch_does_not_panic() {
     // First event: A drops B's subscription during dispatch.
     // B still fires because the SUBSCRIBERS immutable borrow is held for the entire
     // dispatch cycle — the removal is deferred until after the loop completes.
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
     assert_eq!(
         b_count.get(),
@@ -256,7 +260,7 @@ fn dropping_subscription_during_dispatch_does_not_panic() {
     );
 
     // Second event: B should no longer fire — it was removed after the first cycle.
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
     assert_eq!(b_count.get(), 1, "B should not fire after being dropped");
 }
@@ -270,19 +274,19 @@ fn dropping_subscription_removes_subscriber() {
     let count = Rc::new(Cell::new(0u32));
     let c = Rc::clone(&count);
     let sub = bus.subscribe(move |event| {
-        if matches!(event, AppEvent::Ready) {
+        if matches!(event, AppEvent::Error(_)) {
             c.set(c.get() + 1);
         }
     });
 
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
     assert_eq!(count.get(), 1);
 
     // Drop the subscription — subscriber should be removed.
     drop(sub);
 
-    bus.sender().send(AppEvent::Ready);
+    bus.sender().send(error_event());
     flush_events();
     assert_eq!(count.get(), 1, "subscriber should not fire after drop");
 }


### PR DESCRIPTION
## Summary

First step of epic #575 (remove EventBus). Deletes four `AppEvent` variants that no longer have real consumers:

- `Ready` — only emit site in `application/mod.rs` had no subscribers
- `ShutdownComplete` — declared but never sent
- `ImportProgress` / `ImportComplete` — replaced by `ImportEvent` channel + `ImportClient` property notifications (#574)

Event bus integration tests swap their fixture events to `Error(_)` and `EmptyTrashRequested` so coverage stays until the bus itself is removed in #580.

Fixes #576.

## Test plan

- [x] `make check` — clean
- [x] `make lint` — clean
- [x] `make test` — passes locally
- [ ] `make test-integration` — event bus tests still pass with new fixture variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)