### PR TITLE
refactor: UI-side error toasts via show_toast() (#577)

### DIFF
--- a/src/client/media/client.rs
+++ b/src/client/media/client.rs
@@ -180,7 +180,7 @@ impl MediaClient {
             cursor = tracked.cursor.borrow().clone();
         }
 
-        let (library, tokio, bus) = self.deps();
+        let (library, tokio, _) = self.deps();
         let store = model.clone();
         let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
 
@@ -213,12 +213,12 @@ impl MediaClient {
                 }
                 Ok(Err(e)) => {
                     error!(elapsed_ms = elapsed.as_millis(), "list_media failed: {e}");
-                    bus.send(AppEvent::Error("Could not load photos".into()));
+                    crate::client::show_toast("Could not load photos");
                     client.with_tracked_model(&store, |t| t.loading.set(false));
                 }
                 Err(e) => {
                     error!(elapsed_ms = elapsed.as_millis(), "tokio join failed: {e}");
-                    bus.send(AppEvent::Error("Could not load photos".into()));
+                    crate::client::show_toast("Could not load photos");
                     client.with_tracked_model(&store, |t| t.loading.set(false));
                 }
             }

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -212,7 +212,6 @@ impl VideoViewer {
 
     fn load_video(&self, gen: u64, id: MediaId) {
         let imp = self.imp();
-        let bus_sender = imp.bus_sender().clone();
 
         debug!(%id, "load_video: resolving path");
 
@@ -233,7 +232,7 @@ impl VideoViewer {
                     imp.spinner.set_visible(false);
                 }
                 tracing::warn!("load_video: could not resolve original path");
-                bus_sender.send(AppEvent::Error("Could not find original video".into()));
+                crate::client::show_toast("Could not find original video");
                 return;
             };
 

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -247,7 +247,6 @@ impl EditPanel {
             // Don't persist identity state — delete instead if it exists.
             if session.state.is_identity() {
                 let id_log = id.clone();
-                let tx = imp.bus_sender().clone();
                 let mc = crate::application::MomentsApplication::default()
                     .media_client()
                     .expect("media client available");
@@ -255,9 +254,7 @@ impl EditPanel {
                     Ok(()) => debug!(media_id = %id_log, reason, "delete identity edit state"),
                     Err(e) => {
                         error!("delete edit state failed: {e}");
-                        tx.send(crate::app_event::AppEvent::Error(
-                            "Could not revert edits".into(),
-                        ));
+                        crate::client::show_toast("Could not revert edits");
                     }
                 });
                 return;
@@ -273,7 +270,6 @@ impl EditPanel {
 
         imp.save_in_flight.set(true);
         let id_log = id.clone();
-        let tx = imp.bus_sender().clone();
         let mc = crate::application::MomentsApplication::default()
             .media_client()
             .expect("media client available");
@@ -290,9 +286,7 @@ impl EditPanel {
                 }
                 Err(e) => {
                     error!("save edit state failed: {e}");
-                    tx.send(crate::app_event::AppEvent::Error(
-                        "Could not save edits".into(),
-                    ));
+                    crate::client::show_toast("Could not save edits");
                 }
             }
         });
@@ -427,7 +421,6 @@ impl EditPanel {
             let id = imp.media_id.borrow().clone();
             if let Some(id) = id {
                 let id_log = id.clone();
-                let tx = imp.bus_sender().clone();
                 let mc = crate::application::MomentsApplication::default()
                     .media_client()
                     .expect("media client available");
@@ -435,9 +428,7 @@ impl EditPanel {
                     Ok(()) => debug!(media_id = %id_log, "revert edits"),
                     Err(e) => {
                         error!("revert edits failed: {e}");
-                        tx.send(crate::app_event::AppEvent::Error(
-                            "Could not revert edits".into(),
-                        ));
+                        crate::client::show_toast("Could not revert edits");
                     }
                 });
             }

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -3,10 +3,8 @@ use adw::subclass::prelude::*;
 use gtk::{gdk, glib};
 use tracing::{debug, error};
 
-use crate::app_event::AppEvent;
 use crate::renderer::output;
 use crate::renderer::pipeline::{RenderOptions, RenderSize};
-use crate::UserFacingError;
 
 use super::PhotoViewer;
 
@@ -14,7 +12,6 @@ impl PhotoViewer {
     /// Asynchronously load the original file at full resolution.
     pub(super) fn start_full_res_load(&self, gen: u64, id: crate::library::media::MediaId) {
         let imp = self.imp();
-        let bus_sender = imp.bus_sender().clone();
         let tokio = crate::application::MomentsApplication::default().tokio_handle();
 
         imp.spinner.set_spinning(true);
@@ -42,7 +39,7 @@ impl PhotoViewer {
                     imp.spinner.set_spinning(false);
                     imp.spinner.set_visible(false);
                 }
-                bus_sender.send(AppEvent::Error("Could not find original photo".into()));
+                crate::client::show_toast("Could not find original photo");
                 return;
             };
 
@@ -67,7 +64,6 @@ impl PhotoViewer {
             }
 
             let weak2 = viewer.downgrade();
-            let bus = imp.bus_sender().clone();
             drop(viewer);
             glib::MainContext::default().spawn_local(async move {
                 #[allow(clippy::type_complexity)]
@@ -119,7 +115,7 @@ impl PhotoViewer {
                     }
                     Some(Err(e)) => {
                         debug!("full-res decode failed: {e}");
-                        bus.send(AppEvent::Error(e.to_user_facing()));
+                        crate::client::show_error_toast(&e);
                     }
                     None => {
                         debug!("full-res decode failed (task cancelled)");


### PR DESCRIPTION
## Summary

Epic #575 step 2 (partial). Replaces `bus.send(AppEvent::Error(...))` with direct `crate::client::show_toast()` / `show_error_toast()` at the four **UI-layer** call sites:

- `src/client/media/client.rs` — page load failures
- `src/ui/viewer/loading.rs` — missing original, decode failure (uses `show_error_toast(&e)` for the `UserFacingError` case)
- `src/ui/viewer/edit_panel/mod.rs` — save / revert failures
- `src/ui/video_viewer/mod.rs` — missing original video

### Scope decision

The 12 sites in `library/commands/mod.rs` intentionally stay on the bus for now — that module is non-GTK code and shouldn't be calling a GTK-layer `show_toast()` helper. It moves out of the library entirely in #578 (command dispatch → `MediaClient`), at which point these sites transform naturally.

The `AppEvent::Error` variant, the bus subscriber in `application/mod.rs:719-735`, and the event-bus test fixtures stay in place until that migration.

Partial fix for #577.

## Test plan

- [x] `make check` — clean
- [x] `make lint` — clean
- [ ] `make test` — locally
- [ ] `make test-integration` — locally
- [ ] Manual: trigger an error in each migrated path (failed page load, missing original, failed edit save) and confirm toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)