### PR TITLE
refactor: MediaClient owns command dispatch (#578)

### DIFF
--- a/src/client/media/client.rs
+++ b/src/client/media/client.rs
@@ -341,6 +341,196 @@ impl MediaClient {
         });
     }
 
+    // ── Commands ───────────────────────────────────────────────────────
+
+    /// Move items to trash.
+    pub fn trash(&self, ids: Vec<MediaId>) {
+        let (library, tokio, _) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.media().trash(&ids_for_call).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        for id in &ids {
+                            client.on_trashed(id, true);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("trash failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Restore items from trash.
+    pub fn restore(&self, ids: Vec<MediaId>) {
+        let (library, tokio, _) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.media().restore(&ids_for_call).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        for id in &ids {
+                            client.on_trashed(id, false);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("restore failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Permanently delete items.
+    pub fn delete(&self, ids: Vec<MediaId>) {
+        let (library, tokio, _) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.delete_permanently(&ids_for_call).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        for id in &ids {
+                            client.on_deleted(id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("delete permanently failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Set the favorite flag on items.
+    pub fn set_favorite(&self, ids: Vec<MediaId>, state: bool) {
+        let (library, tokio, _) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.media().set_favorite(&ids_for_call, state).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        for id in &ids {
+                            client.on_favorite_changed(id, state);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("set_favorite failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Permanently delete all trashed items.
+    pub fn empty_trash(&self) {
+        let (library, tokio, _) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let result = crate::client::spawn_on(&tokio, async move {
+                let items = library
+                    .media()
+                    .list_media(MediaFilter::Trashed, None, u32::MAX)
+                    .await?;
+                let ids: Vec<_> = items.into_iter().map(|i| i.id).collect();
+                if ids.is_empty() {
+                    return Ok(Vec::new());
+                }
+                library.delete_permanently(&ids).await?;
+                Ok(ids)
+            })
+            .await;
+
+            match result {
+                Ok(ids) if ids.is_empty() => {}
+                Ok(ids) => {
+                    tracing::info!(count = ids.len(), "trash emptied");
+                    if let Some(client) = client_weak.upgrade() {
+                        for id in &ids {
+                            client.on_deleted(id);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("empty trash failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Restore all trashed items.
+    pub fn restore_all_trash(&self) {
+        let (library, tokio, _) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClient> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let result = crate::client::spawn_on(&tokio, async move {
+                let items = library
+                    .media()
+                    .list_media(MediaFilter::Trashed, None, u32::MAX)
+                    .await?;
+                let ids: Vec<_> = items.into_iter().map(|i| i.id).collect();
+                if ids.is_empty() {
+                    return Ok(Vec::new());
+                }
+                library.media().restore(&ids).await?;
+                Ok(ids)
+            })
+            .await;
+
+            match result {
+                Ok(ids) if ids.is_empty() => {}
+                Ok(ids) => {
+                    tracing::info!(count = ids.len(), "all trash restored");
+                    if let Some(client) = client_weak.upgrade() {
+                        for id in &ids {
+                            client.on_trashed(id, false);
+                        }
+                    }
+                }
+                Err(e) => {
+                    error!("restore all trash failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
     // ── Stats ──────────────────────────────────────────────────────────
 
     /// Fetch library statistics.

--- a/src/ui/photo_grid/action_bar.rs
+++ b/src/ui/photo_grid/action_bar.rs
@@ -4,15 +4,9 @@
 //! - **Standard** (Photos, Favourites, Recent, People): Favourite, Add to album, Delete
 //! - **Trash**: Restore, Delete permanently
 //! - **Album**: Favourite, Remove from album, Delete
-//!
-//! Button handlers emit command events via the [`EventBus`] — they resolve
-//! UI state (selection → IDs) and nothing else. The library's command
-//! handler handles execution and emits result events.
 
 use adw::prelude::*;
 
-use crate::app_event::AppEvent;
-use crate::event_bus::EventSender;
 use crate::library::album::AlbumId;
 use crate::library::media::MediaFilter;
 
@@ -33,28 +27,24 @@ pub struct ActionBarButtons {
 /// Build action bar buttons appropriate for the given filter.
 ///
 /// Returns wired buttons ready to be placed in a `gtk::ActionBar`.
-pub fn build_for_filter(
-    filter: &MediaFilter,
-    selection: &gtk::MultiSelection,
-    bus: &EventSender,
-) -> ActionBarButtons {
+pub fn build_for_filter(filter: &MediaFilter, selection: &gtk::MultiSelection) -> ActionBarButtons {
     match filter {
-        MediaFilter::Trashed => build_trash_bar(selection, bus),
-        MediaFilter::Album { album_id } => build_album_bar(selection, bus, album_id),
-        _ => build_standard_bar(selection, bus),
+        MediaFilter::Trashed => build_trash_bar(selection),
+        MediaFilter::Album { album_id } => build_album_bar(selection, album_id),
+        _ => build_standard_bar(selection),
     }
 }
 
 // ── Standard: Favourite, Add to album, Delete ────────────────────────────────
 
-fn build_standard_bar(selection: &gtk::MultiSelection, bus: &EventSender) -> ActionBarButtons {
+fn build_standard_bar(selection: &gtk::MultiSelection) -> ActionBarButtons {
     let fav_btn = make_button("starred-symbolic", "Favourite");
     fav_btn.set_width_request(150);
     let album_btn = make_button("folder-new-symbolic", "Add to album");
     let trash_btn = make_button("user-trash-symbolic", "Delete");
 
-    wire_favourite(&fav_btn, selection, bus);
-    wire_trash(&trash_btn, selection, bus);
+    wire_favourite(&fav_btn, selection);
+    wire_trash(&trash_btn, selection);
 
     let container = bar_container();
     container.append(&fav_btn);
@@ -70,12 +60,12 @@ fn build_standard_bar(selection: &gtk::MultiSelection, bus: &EventSender) -> Act
 
 // ── Trash: Restore, Delete permanently ───────────────────────────────────────
 
-fn build_trash_bar(selection: &gtk::MultiSelection, bus: &EventSender) -> ActionBarButtons {
+fn build_trash_bar(selection: &gtk::MultiSelection) -> ActionBarButtons {
     let restore_btn = make_button("edit-undo-symbolic", "Restore");
     let delete_btn = make_button("edit-delete-symbolic", "Delete permanently");
 
-    wire_restore(&restore_btn, selection, bus);
-    wire_delete_permanently(&delete_btn, selection, bus);
+    wire_restore(&restore_btn, selection);
+    wire_delete_permanently(&delete_btn, selection);
 
     let container = bar_container();
     container.append(&restore_btn);
@@ -90,19 +80,15 @@ fn build_trash_bar(selection: &gtk::MultiSelection, bus: &EventSender) -> Action
 
 // ── Album: Favourite, Remove from album, Delete ──────────────────────────────
 
-fn build_album_bar(
-    selection: &gtk::MultiSelection,
-    bus: &EventSender,
-    album_id: &AlbumId,
-) -> ActionBarButtons {
+fn build_album_bar(selection: &gtk::MultiSelection, album_id: &AlbumId) -> ActionBarButtons {
     let fav_btn = make_button("starred-symbolic", "Favourite");
     fav_btn.set_width_request(150);
     let remove_btn = make_button("list-remove-symbolic", "Remove from album");
     let trash_btn = make_button("user-trash-symbolic", "Delete");
 
-    wire_favourite(&fav_btn, selection, bus);
-    wire_remove_from_album(&remove_btn, selection, bus, album_id);
-    wire_trash(&trash_btn, selection, bus);
+    wire_favourite(&fav_btn, selection);
+    wire_remove_from_album(&remove_btn, selection, album_id);
+    wire_trash(&trash_btn, selection);
 
     let container = bar_container();
     container.append(&fav_btn);
@@ -142,9 +128,8 @@ fn bar_container() -> gtk::Box {
 
 // ── Wiring ───────────────────────────────────────────────────────────────────
 
-fn wire_favourite(btn: &gtk::Button, selection: &gtk::MultiSelection, bus: &EventSender) {
+fn wire_favourite(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     let sel = selection.clone();
-    let tx = bus.clone();
     let btn_ref = btn.clone();
     btn.connect_clicked(move |_| {
         let ids = super::collect_selected_ids(&sel);
@@ -159,39 +144,41 @@ fn wire_favourite(btn: &gtk::Button, selection: &gtk::MultiSelection, bus: &Even
             .unwrap_or(false);
         let new_state = !first_fav;
 
-        tx.send(AppEvent::FavoriteRequested {
-            ids,
-            state: new_state,
-        });
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            mc.set_favorite(ids, new_state);
+        }
         actions::update_fav_button(&btn_ref, new_state);
     });
 }
 
-fn wire_trash(btn: &gtk::Button, selection: &gtk::MultiSelection, bus: &EventSender) {
+fn wire_trash(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     let sel = selection.clone();
-    let tx = bus.clone();
     btn.connect_clicked(move |_| {
         let ids = super::collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            tx.send(AppEvent::TrashRequested { ids });
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            mc.trash(ids);
         }
     });
 }
 
-fn wire_restore(btn: &gtk::Button, selection: &gtk::MultiSelection, bus: &EventSender) {
+fn wire_restore(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     let sel = selection.clone();
-    let tx = bus.clone();
     btn.connect_clicked(move |_| {
         let ids = super::collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            tx.send(AppEvent::RestoreRequested { ids });
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            mc.restore(ids);
         }
     });
 }
 
-fn wire_delete_permanently(btn: &gtk::Button, selection: &gtk::MultiSelection, bus: &EventSender) {
+fn wire_delete_permanently(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     let sel = selection.clone();
-    let tx = bus.clone();
     btn.connect_clicked(move |btn| {
         let ids = super::collect_selected_ids(&sel);
         if ids.is_empty() {
@@ -214,36 +201,33 @@ fn wire_delete_permanently(btn: &gtk::Button, selection: &gtk::MultiSelection, b
         dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
         dialog.set_default_response(Some("cancel"));
 
-        let tx = tx.clone();
         let window = btn.root().and_downcast::<gtk::Window>();
         dialog.choose(
             window.as_ref(),
             gtk::gio::Cancellable::NONE,
             move |response| {
                 if response == "delete" {
-                    tx.send(AppEvent::DeleteRequested { ids });
+                    if let Some(mc) =
+                        crate::application::MomentsApplication::default().media_client()
+                    {
+                        mc.delete(ids);
+                    }
                 }
             },
         );
     });
 }
 
-fn wire_remove_from_album(
-    btn: &gtk::Button,
-    selection: &gtk::MultiSelection,
-    bus: &EventSender,
-    album_id: &AlbumId,
-) {
+fn wire_remove_from_album(btn: &gtk::Button, selection: &gtk::MultiSelection, album_id: &AlbumId) {
     let sel = selection.clone();
-    let tx = bus.clone();
     let aid = album_id.clone();
     btn.connect_clicked(move |_| {
         let ids = super::collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            tx.send(AppEvent::RemoveFromAlbumRequested {
-                album_id: aid.clone(),
-                ids,
-            });
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(ac) = crate::application::MomentsApplication::default().album_client_v2() {
+            ac.remove_from_album(aid.clone(), ids);
         }
     });
 }

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -4,21 +4,17 @@ use adw::prelude::*;
 use gtk::glib;
 use tracing::debug;
 
-use crate::app_event::AppEvent;
-use crate::event_bus::EventSender;
 use crate::library::media::MediaFilter;
 
 use crate::client::MediaItemObject;
 
 /// Context passed to wiring functions.
 ///
-/// Carries the bus sender for commands and view references for
-/// context menus and action bar actions.
+/// Carries view references for context menus and action bar actions.
 pub(super) struct ActionContext {
     pub selection: gtk::MultiSelection,
     pub filter: MediaFilter,
     pub grid_view: gtk::GridView,
-    pub bus_sender: EventSender,
 }
 
 /// Wire the "Add to Album" button to open the album picker dialog.
@@ -37,7 +33,7 @@ pub(super) fn wire_album_controls(ctx: &ActionContext, album_btn: &gtk::Button) 
 
 /// Wire the right-click context menu on grid cells.
 ///
-/// All actions emit command events via the bus — no direct library calls.
+/// Actions invoke `MediaClient` / `AlbumClientV2` methods directly.
 pub(super) fn wire_context_menu(ctx: &ActionContext) {
     let gesture = gtk::GestureClick::new();
     gesture.set_button(3);
@@ -45,7 +41,6 @@ pub(super) fn wire_context_menu(ctx: &ActionContext) {
     let grid_view = ctx.grid_view.clone();
     let selection = ctx.selection.clone();
     let filter = ctx.filter.clone();
-    let bus_tx = ctx.bus_sender.clone();
 
     gesture.connect_pressed(move |gesture, _, x, y| {
         let Some(pos) = find_clicked_position(&grid_view, &selection, x, y) else {
@@ -81,9 +76,9 @@ pub(super) fn wire_context_menu(ctx: &ActionContext) {
         let pop_ref: glib::WeakRef<gtk::Popover> = popover.downgrade();
 
         if is_trash {
-            build_trash_menu(&vbox, &pop_ref, &selection, &bus_tx);
+            build_trash_menu(&vbox, &pop_ref, &selection);
         } else {
-            build_standard_menu(&vbox, &pop_ref, &selection, &bus_tx, &filter, is_favorite);
+            build_standard_menu(&vbox, &pop_ref, &selection, &filter, is_favorite);
         }
 
         popover.set_child(Some(&vbox));
@@ -142,7 +137,6 @@ fn build_trash_menu(
     vbox: &gtk::Box,
     pop_ref: &glib::WeakRef<gtk::Popover>,
     selection: &gtk::MultiSelection,
-    bus_tx: &EventSender,
 ) {
     let restore_btn = gtk::Button::with_label("Restore");
     restore_btn.add_css_class("flat");
@@ -153,8 +147,8 @@ fn build_trash_menu(
     delete_btn.add_css_class("error");
     vbox.append(&delete_btn);
 
-    wire_restore_button(&restore_btn, pop_ref, selection, bus_tx);
-    wire_permanent_delete_button(&delete_btn, pop_ref, selection, bus_tx);
+    wire_restore_button(&restore_btn, pop_ref, selection);
+    wire_permanent_delete_button(&delete_btn, pop_ref, selection);
 }
 
 /// Build the standard/album context menu: Favourite, Move to Trash,
@@ -163,7 +157,6 @@ fn build_standard_menu(
     vbox: &gtk::Box,
     pop_ref: &glib::WeakRef<gtk::Popover>,
     selection: &gtk::MultiSelection,
-    bus_tx: &EventSender,
     filter: &MediaFilter,
     is_favorite: bool,
 ) {
@@ -188,24 +181,23 @@ fn build_standard_menu(
 
         let pw = pop_ref.clone();
         let sel = selection.clone();
-        let tx = bus_tx.clone();
         let aid = album_id.clone();
         remove_btn.connect_clicked(move |_| {
             if let Some(p) = pw.upgrade() {
                 p.popdown();
             }
             let ids = super::collect_selected_ids(&sel);
-            if !ids.is_empty() {
-                tx.send(AppEvent::RemoveFromAlbumRequested {
-                    album_id: aid.clone(),
-                    ids,
-                });
+            if ids.is_empty() {
+                return;
+            }
+            if let Some(ac) = crate::application::MomentsApplication::default().album_client_v2() {
+                ac.remove_from_album(aid.clone(), ids);
             }
         });
     }
 
-    wire_favourite_button(&fav_btn, pop_ref, selection, bus_tx, !is_favorite);
-    wire_trash_button(&trash_btn, pop_ref, selection, bus_tx);
+    wire_favourite_button(&fav_btn, pop_ref, selection, !is_favorite);
+    wire_trash_button(&trash_btn, pop_ref, selection);
 }
 
 /// Wire the Restore button to send a restore command.
@@ -213,18 +205,19 @@ fn wire_restore_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
     selection: &gtk::MultiSelection,
-    bus_tx: &EventSender,
 ) {
     let pw = pop_ref.clone();
     let sel = selection.clone();
-    let tx = bus_tx.clone();
     btn.connect_clicked(move |_| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
         let ids = super::collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            tx.send(AppEvent::RestoreRequested { ids });
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            mc.restore(ids);
         }
     });
 }
@@ -234,11 +227,9 @@ fn wire_permanent_delete_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
     selection: &gtk::MultiSelection,
-    bus_tx: &EventSender,
 ) {
     let pw = pop_ref.clone();
     let sel = selection.clone();
-    let tx = bus_tx.clone();
     btn.connect_clicked(move |btn| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
@@ -264,14 +255,17 @@ fn wire_permanent_delete_button(
         dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
         dialog.set_default_response(Some("cancel"));
 
-        let tx = tx.clone();
         let window = btn.root().and_downcast::<gtk::Window>();
         dialog.choose(
             window.as_ref(),
             gtk::gio::Cancellable::NONE,
             move |response| {
                 if response == "delete" {
-                    tx.send(AppEvent::DeleteRequested { ids });
+                    if let Some(mc) =
+                        crate::application::MomentsApplication::default().media_client()
+                    {
+                        mc.delete(ids);
+                    }
                 }
             },
         );
@@ -283,22 +277,20 @@ fn wire_favourite_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
     selection: &gtk::MultiSelection,
-    bus_tx: &EventSender,
     new_fav: bool,
 ) {
     let pw = pop_ref.clone();
     let sel = selection.clone();
-    let tx = bus_tx.clone();
     btn.connect_clicked(move |_| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
         let ids = super::collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            tx.send(AppEvent::FavoriteRequested {
-                ids,
-                state: new_fav,
-            });
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            mc.set_favorite(ids, new_fav);
         }
     });
 }
@@ -308,18 +300,19 @@ fn wire_trash_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
     selection: &gtk::MultiSelection,
-    bus_tx: &EventSender,
 ) {
     let pw = pop_ref.clone();
     let sel = selection.clone();
-    let tx = bus_tx.clone();
     btn.connect_clicked(move |_| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
         let ids = super::collect_selected_ids(&sel);
-        if !ids.is_empty() {
-            tx.send(AppEvent::TrashRequested { ids });
+        if ids.is_empty() {
+            return;
+        }
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            mc.trash(ids);
         }
     });
 }

--- a/src/ui/photo_grid/factory.rs
+++ b/src/ui/photo_grid/factory.rs
@@ -7,9 +7,7 @@ use gtk::{gio, glib, prelude::*, subclass::prelude::*};
 use tokio::sync::Semaphore;
 use tracing::debug;
 
-use crate::app_event::AppEvent;
 use crate::client::{MediaClient, MediaItemObject};
-use crate::event_bus::EventSender;
 use crate::library::media::{MediaFilter, MediaItem};
 
 use super::cell::PhotoGridCell;
@@ -29,7 +27,6 @@ fn max_decode_workers() -> usize {
 pub fn build_factory(
     cell_size: i32,
     media_client: MediaClient,
-    bus_sender: EventSender,
     filter: MediaFilter,
     cache: Rc<TextureCache>,
     selection_mode: Rc<Cell<bool>>,
@@ -52,8 +49,6 @@ pub fn build_factory(
         media_client,
         #[strong]
         tokio,
-        #[strong]
-        bus_sender,
         #[strong]
         cache,
         #[strong]
@@ -169,10 +164,10 @@ pub fn build_factory(
             } else {
                 cell.imp().days_label.set_visible(false);
 
-                // Wire star button click → optimistic toggle + bus command.
+                // Wire star button click → optimistic toggle + MediaClient command.
                 let star_btn = cell.imp().star_btn.clone();
                 let item_weak = item.downgrade();
-                let tx = bus_sender.clone();
+                let mc = media_client.clone();
                 let handler_id = star_btn.connect_clicked(move |_| {
                     let Some(item) = item_weak.upgrade() else {
                         return;
@@ -180,10 +175,7 @@ pub fn build_factory(
                     let new_fav = !item.is_favorite();
                     item.set_is_favorite(new_fav);
                     let id = item.item().id.clone();
-                    tx.send(AppEvent::FavoriteRequested {
-                        ids: vec![id],
-                        state: new_fav,
-                    });
+                    mc.set_favorite(vec![id], new_fav);
                 });
 
                 cell.imp()

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -7,7 +7,6 @@ use gettextrs::gettext;
 use gtk::{gio, glib};
 use tracing::instrument;
 
-use crate::app_event::AppEvent;
 use crate::client::MediaItemObject;
 use crate::library::media::{MediaFilter, MediaType};
 use crate::ui::video_viewer::VideoViewer;
@@ -209,7 +208,6 @@ impl PhotoGrid {
         let imp = self.imp();
         let grid_view = imp.grid_view();
         let media_client = imp.media_client().clone();
-        let bus_sender = imp.bus_sender().clone();
         let filter = imp.filter.borrow().clone();
         let cache = imp.texture_cache().clone();
         let sm = Rc::clone(&imp.selection_mode);
@@ -218,7 +216,6 @@ impl PhotoGrid {
         grid_view.set_factory(Some(&factory::build_factory(
             self.current_cell_size(),
             media_client,
-            bus_sender,
             filter,
             cache,
             sm,
@@ -257,7 +254,6 @@ impl PhotoGrid {
         grid_view.set_factory(Some(&factory::build_factory(
             self.current_cell_size(),
             media_client.clone(),
-            bus_sender,
             filter.clone(),
             cache,
             sm,
@@ -736,7 +732,6 @@ impl PhotoGridView {
             selection: selection.clone(),
             filter: filter.clone(),
             grid_view,
-            bus_sender: bus_sender.clone(),
         };
 
         actions::wire_context_menu(&ctx);
@@ -747,7 +742,7 @@ impl PhotoGridView {
             bar_box.remove(&child);
         }
 
-        let bar_buttons = action_bar::build_for_filter(&filter, &ctx.selection, &bus_sender);
+        let bar_buttons = action_bar::build_for_filter(&filter, &ctx.selection);
         bar_box.append(&bar_buttons.container);
         *imp.fav_btn.borrow_mut() = bar_buttons.fav_btn;
 
@@ -774,55 +769,54 @@ impl PhotoGridView {
                 store.connect_items_changed(move |_, _, _, _| update());
             }
 
-            {
-                let bs = bus_sender.clone();
-                imp.restore_all_btn.connect_clicked(move |b| {
-                    let bs = bs.clone();
-                    let win = b.root().and_then(|r| r.downcast::<gtk::Window>().ok());
-                    let dialog = adw::AlertDialog::new(
-                        Some(&gettext("Restore all photos?")),
-                        Some(&gettext(
-                            "All trashed photos will be moved back to the library.",
-                        )),
-                    );
-                    dialog.add_response("cancel", &gettext("Cancel"));
-                    dialog.add_response("restore", &gettext("Restore All"));
-                    dialog.set_default_response(Some("cancel"));
-                    dialog.set_close_response("cancel");
-                    dialog.connect_response(None, move |_, response| {
-                        if response == "restore" {
-                            bs.send(AppEvent::RestoreAllTrashRequested);
+            imp.restore_all_btn.connect_clicked(move |b| {
+                let win = b.root().and_then(|r| r.downcast::<gtk::Window>().ok());
+                let dialog = adw::AlertDialog::new(
+                    Some(&gettext("Restore all photos?")),
+                    Some(&gettext(
+                        "All trashed photos will be moved back to the library.",
+                    )),
+                );
+                dialog.add_response("cancel", &gettext("Cancel"));
+                dialog.add_response("restore", &gettext("Restore All"));
+                dialog.set_default_response(Some("cancel"));
+                dialog.set_close_response("cancel");
+                dialog.connect_response(None, move |_, response| {
+                    if response == "restore" {
+                        if let Some(mc) =
+                            crate::application::MomentsApplication::default().media_client()
+                        {
+                            mc.restore_all_trash();
                         }
-                    });
-                    dialog.present(win.as_ref());
+                    }
                 });
-            }
+                dialog.present(win.as_ref());
+            });
 
-            {
-                let bs = bus_sender.clone();
-                imp.empty_trash_btn.connect_clicked(move |b| {
-                    let bs = bs.clone();
-                    let win = b.root().and_then(|r| r.downcast::<gtk::Window>().ok());
-                    let dialog = adw::AlertDialog::new(
-                        Some(&gettext("Empty Trash?")),
-                        Some(&gettext("All trashed photos will be permanently deleted. This cannot be undone.")),
-                    );
-                    dialog.add_response("cancel", &gettext("Cancel"));
-                    dialog.add_response("delete", &gettext("Empty Trash"));
-                    dialog.set_response_appearance(
-                        "delete",
-                        adw::ResponseAppearance::Destructive,
-                    );
-                    dialog.set_default_response(Some("cancel"));
-                    dialog.set_close_response("cancel");
-                    dialog.connect_response(None, move |_, response| {
-                        if response == "delete" {
-                            bs.send(AppEvent::EmptyTrashRequested);
+            imp.empty_trash_btn.connect_clicked(move |b| {
+                let win = b.root().and_then(|r| r.downcast::<gtk::Window>().ok());
+                let dialog = adw::AlertDialog::new(
+                    Some(&gettext("Empty Trash?")),
+                    Some(&gettext(
+                        "All trashed photos will be permanently deleted. This cannot be undone.",
+                    )),
+                );
+                dialog.add_response("cancel", &gettext("Cancel"));
+                dialog.add_response("delete", &gettext("Empty Trash"));
+                dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
+                dialog.set_default_response(Some("cancel"));
+                dialog.set_close_response("cancel");
+                dialog.connect_response(None, move |_, response| {
+                    if response == "delete" {
+                        if let Some(mc) =
+                            crate::application::MomentsApplication::default().media_client()
+                        {
+                            mc.empty_trash();
                         }
-                    });
-                    dialog.present(win.as_ref());
+                    }
                 });
-            }
+                dialog.present(win.as_ref());
+            });
         }
 
         // ── Selection changed → update count, auto-exit ─────────────────

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -3,7 +3,6 @@ use adw::subclass::prelude::*;
 use gtk::{gdk, gio, glib};
 use tracing::debug;
 
-use crate::app_event::AppEvent;
 use crate::client::MediaItemObject;
 use crate::event_bus::EventSender;
 use crate::library::media::MediaId;
@@ -370,10 +369,9 @@ impl VideoViewer {
                 let id = obj.item().id.clone();
                 *imp.pending_fav.borrow_mut() = Some((id.clone(), was_fav));
 
-                imp.bus_sender().send(AppEvent::FavoriteRequested {
-                    ids: vec![id],
-                    state: new_fav,
-                });
+                if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                    mc.set_favorite(vec![id], new_fav);
+                }
             });
         }
 
@@ -513,8 +511,9 @@ fn wire_overflow_menu(
                 items.get(idx).map(|obj| obj.item().id.clone())
             };
             let Some(id) = id else { return };
-            imp.bus_sender()
-                .send(AppEvent::TrashRequested { ids: vec![id] });
+            if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                mc.trash(vec![id]);
+            }
             if let Some(nav_view) = viewer
                 .parent()
                 .and_then(|p| p.downcast::<adw::NavigationView>().ok())

--- a/src/ui/viewer/menu.rs
+++ b/src/ui/viewer/menu.rs
@@ -1,8 +1,6 @@
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 
-use crate::app_event::AppEvent;
-
 use super::PhotoViewer;
 
 /// Named references to all buttons in the viewer overflow menu.
@@ -175,8 +173,9 @@ pub(super) fn wire_overflow_menu(
                 items.get(idx).map(|obj| obj.item().id.clone())
             };
             let Some(id) = id else { return };
-            imp.bus_sender()
-                .send(AppEvent::TrashRequested { ids: vec![id] });
+            if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                mc.trash(vec![id]);
+            }
             if let Some(nav_view) = viewer
                 .parent()
                 .and_then(|p| p.downcast::<adw::NavigationView>().ok())

--- a/src/ui/viewer/mod.rs
+++ b/src/ui/viewer/mod.rs
@@ -2,7 +2,6 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::{gdk, glib};
 
-use crate::app_event::AppEvent;
 use crate::client::MediaItemObject;
 use crate::event_bus::EventSender;
 use crate::library::media::MediaId;
@@ -363,10 +362,9 @@ impl PhotoViewer {
                 let id = obj.item().id.clone();
                 *imp.pending_fav.borrow_mut() = Some((id.clone(), was_fav));
 
-                imp.bus_sender().send(AppEvent::FavoriteRequested {
-                    ids: vec![id],
-                    state: new_fav,
-                });
+                if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                    mc.set_favorite(vec![id], new_fav);
+                }
             });
         }
 


### PR DESCRIPTION
## Summary

Epic #575 step 3 (partial — #578 part A+B). Moves media command dispatch off the event bus onto direct methods on `MediaClient`, matching the `AlbumClientV2` pattern.

**New MediaClient methods** (in \`src/client/media/client.rs\`):

- \`trash(ids)\`, \`restore(ids)\`, \`delete(ids)\`
- \`set_favorite(ids, state)\`
- \`empty_trash()\`, \`restore_all_trash()\`

Each spawns on Tokio via \`crate::client::spawn_on\`, runs the library call, and on success updates tracked models via existing \`on_*\` helpers. On failure: \`show_error_toast\`.

**UI callers migrated** (14 sites → client method calls):

| File | Sites |
|---|---|
| \`photo_grid/action_bar.rs\` | 5 |
| \`photo_grid/actions.rs\` | 5 |
| \`photo_grid/mod.rs\` | 2 |
| \`photo_grid/factory.rs\` | 1 |
| \`viewer/mod.rs\` | 1 |
| \`viewer/menu.rs\` | 1 |
| \`video_viewer/mod.rs\` | 2 |

## What's left for the follow-up PR

- Delete \`library/commands/mod.rs\` (now dormant — no UI senders)
- Remove \`*Requested\` variants and unused result variants from \`AppEvent\`
- Remove the \`subscribe_commands\` call in \`application/mod.rs\`
- Update \`tests/event_bus.rs\` fixtures one more time
- Tear out the event bus itself (epic target)

## Known regression

\`PhotoGridView\`'s 'exit selection on mutation' subscription listens for result events (\`Trashed\`, \`Deleted\`, \`Restored\`, \`FavoriteChanged\`, \`AlbumMediaChanged\`) that \`library/commands/mod.rs\` used to emit. With that dispatcher now dormant, selection mode no longer auto-exits after trash/delete/favorite/restore. To be reinstated via a \`MediaClient\` signal during the v2 uplift.

## Test plan

- [x] \`make check\` — clean
- [x] \`make lint\` — clean
- [ ] \`make test\` — locally
- [ ] \`make test-integration\` — locally
- [ ] Manual: verify toolbar + context-menu + viewer actions all work (trash, restore, delete, favourite, empty trash, restore all, remove from album, etc.)

Partial fix for #578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)