### PR TITLE
refactor: result fan-out via client signals (#579)

### DIFF
--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -57,6 +57,12 @@ mod imp {
                     glib::subclass::Signal::builder("album-deleted")
                         .param_types([String::static_type()])
                         .build(),
+                    // Emitted after an album's media list changes
+                    // (add_to_album or remove_from_album completed).
+                    // Parameter: album ID string.
+                    glib::subclass::Signal::builder("album-media-changed")
+                        .param_types([String::static_type()])
+                        .build(),
                 ]
             })
         }
@@ -280,6 +286,10 @@ impl AlbumClientV2 {
                     debug!(album_id = %album_id, "photos added to album");
                     if let Some(client) = client_weak.upgrade() {
                         client.update_album_in_models(&album);
+                        client.emit_by_name::<()>(
+                            "album-media-changed",
+                            &[&album_id.as_str().to_string()],
+                        );
                     }
                 }
                 Err(e) => {
@@ -315,6 +325,10 @@ impl AlbumClientV2 {
                     debug!(album_id = %album_id, "photos removed from album");
                     if let Some(client) = client_weak.upgrade() {
                         client.update_album_in_models(&album);
+                        client.emit_by_name::<()>(
+                            "album-media-changed",
+                            &[&album_id.as_str().to_string()],
+                        );
                     }
                 }
                 Err(e) => {

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -214,8 +214,15 @@ impl AlbumClientV2 {
                     debug!(album_id = %album.id, name = %album.name, "album created");
                     if let Some(client) = client_weak.upgrade() {
                         let album_id = album.id.clone();
+                        let had_media = album.media_count > 0;
                         client.insert_into_models(album);
                         client.load_cover_thumbnails(&album_id);
+                        if had_media {
+                            client.emit_by_name::<()>(
+                                "album-media-changed",
+                                &[&album_id.as_str().to_string()],
+                            );
+                        }
                     }
                 }
                 Err(e) => {
@@ -286,6 +293,7 @@ impl AlbumClientV2 {
                     debug!(album_id = %album_id, "photos added to album");
                     if let Some(client) = client_weak.upgrade() {
                         client.update_album_in_models(&album);
+                        tracing::debug!(album_id = %album_id, "emitting album-media-changed");
                         client.emit_by_name::<()>(
                             "album-media-changed",
                             &[&album_id.as_str().to_string()],
@@ -325,6 +333,7 @@ impl AlbumClientV2 {
                     debug!(album_id = %album_id, "photos removed from album");
                     if let Some(client) = client_weak.upgrade() {
                         client.update_album_in_models(&album);
+                        tracing::debug!(album_id = %album_id, "emitting album-media-changed");
                         client.emit_by_name::<()>(
                             "album-media-changed",
                             &[&album_id.as_str().to_string()],

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -219,10 +219,6 @@ impl AlbumClientV2 {
                         // Always emit — if create was invoked from "Create &
                         // add", media was added too; subscribers like the
                         // photo grid rely on this to exit selection mode.
-                        tracing::debug!(
-                            album_id = %album_id,
-                            "emitting album-media-changed (create_album)"
-                        );
                         client.emit_by_name::<()>(
                             "album-media-changed",
                             &[&album_id.as_str().to_string()],
@@ -297,7 +293,6 @@ impl AlbumClientV2 {
                     debug!(album_id = %album_id, "photos added to album");
                     if let Some(client) = client_weak.upgrade() {
                         client.update_album_in_models(&album);
-                        tracing::debug!(album_id = %album_id, "emitting album-media-changed");
                         client.emit_by_name::<()>(
                             "album-media-changed",
                             &[&album_id.as_str().to_string()],
@@ -337,7 +332,6 @@ impl AlbumClientV2 {
                     debug!(album_id = %album_id, "photos removed from album");
                     if let Some(client) = client_weak.upgrade() {
                         client.update_album_in_models(&album);
-                        tracing::debug!(album_id = %album_id, "emitting album-media-changed");
                         client.emit_by_name::<()>(
                             "album-media-changed",
                             &[&album_id.as_str().to_string()],
@@ -790,6 +784,21 @@ mod tests {
         // Should not panic on the dead ref.
         client.insert_into_models(test_album("a1", "Alpha"));
         assert_eq!(_live.n_items(), 1);
+    }
+
+    #[test]
+    fn insert_into_models_is_idempotent() {
+        let client = AlbumClientV2::new();
+        let store = client.create_model();
+
+        client.insert_into_models(test_album("a1", "Alpha"));
+        client.insert_into_models(test_album("a1", "Alpha"));
+
+        assert_eq!(
+            store.n_items(),
+            1,
+            "second insert of same ID should be a no-op"
+        );
     }
 
     // ── update_in_models ──────────────────────────────────────────────

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -214,15 +214,19 @@ impl AlbumClientV2 {
                     debug!(album_id = %album.id, name = %album.name, "album created");
                     if let Some(client) = client_weak.upgrade() {
                         let album_id = album.id.clone();
-                        let had_media = album.media_count > 0;
                         client.insert_into_models(album);
                         client.load_cover_thumbnails(&album_id);
-                        if had_media {
-                            client.emit_by_name::<()>(
-                                "album-media-changed",
-                                &[&album_id.as_str().to_string()],
-                            );
-                        }
+                        // Always emit — if create was invoked from "Create &
+                        // add", media was added too; subscribers like the
+                        // photo grid rely on this to exit selection mode.
+                        tracing::debug!(
+                            album_id = %album_id,
+                            "emitting album-media-changed (create_album)"
+                        );
+                        client.emit_by_name::<()>(
+                            "album-media-changed",
+                            &[&album_id.as_str().to_string()],
+                        );
                     }
                 }
                 Err(e) => {

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -614,9 +614,17 @@ impl AlbumClientV2 {
 
     /// Insert a new album into all tracked models.
     fn insert_into_models(&self, album: Album) {
+        let id_str = album.id.as_str().to_owned();
         let models = self.imp().models.borrow();
         for weak in models.iter() {
             if let Some(store) = weak.upgrade() {
+                // Idempotent: skip if an item with this ID is already in the
+                // store. Both the command path and the AlbumEvent listener
+                // insert on album creation; without this guard they race to
+                // produce duplicate rows.
+                if find_by_id(&store, &id_str).is_some() {
+                    continue;
+                }
                 store.append(&AlbumItemObject::new(album.clone()));
             }
         }

--- a/src/client/media/client.rs
+++ b/src/client/media/client.rs
@@ -67,7 +67,33 @@ mod imp {
         type ParentType = glib::Object;
     }
 
-    impl ObjectImpl for MediaClient {}
+    impl ObjectImpl for MediaClient {
+        fn signals() -> &'static [glib::subclass::Signal] {
+            static SIGNALS: std::sync::OnceLock<Vec<glib::subclass::Signal>> =
+                std::sync::OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![
+                    // Emitted after N items are moved to trash.
+                    glib::subclass::Signal::builder("items-trashed")
+                        .param_types([u32::static_type()])
+                        .build(),
+                    // Emitted after N items are restored from trash.
+                    glib::subclass::Signal::builder("items-restored")
+                        .param_types([u32::static_type()])
+                        .build(),
+                    // Emitted after N items are permanently deleted.
+                    glib::subclass::Signal::builder("items-deleted")
+                        .param_types([u32::static_type()])
+                        .build(),
+                    // Emitted after a favourite toggle completes.
+                    // Params: (count, is_favorite).
+                    glib::subclass::Signal::builder("favorite-changed")
+                        .param_types([u32::static_type(), bool::static_type()])
+                        .build(),
+                ]
+            })
+        }
+    }
 }
 
 glib::wrapper! {
@@ -361,6 +387,7 @@ impl MediaClient {
                         for id in &ids {
                             client.on_trashed(id, true);
                         }
+                        client.emit_by_name::<()>("items-trashed", &[&(ids.len() as u32)]);
                     }
                 }
                 Err(e) => {
@@ -389,6 +416,7 @@ impl MediaClient {
                         for id in &ids {
                             client.on_trashed(id, false);
                         }
+                        client.emit_by_name::<()>("items-restored", &[&(ids.len() as u32)]);
                     }
                 }
                 Err(e) => {
@@ -417,6 +445,7 @@ impl MediaClient {
                         for id in &ids {
                             client.on_deleted(id);
                         }
+                        client.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
                     }
                 }
                 Err(e) => {
@@ -445,6 +474,8 @@ impl MediaClient {
                         for id in &ids {
                             client.on_favorite_changed(id, state);
                         }
+                        client
+                            .emit_by_name::<()>("favorite-changed", &[&(ids.len() as u32), &state]);
                     }
                 }
                 Err(e) => {
@@ -483,6 +514,7 @@ impl MediaClient {
                         for id in &ids {
                             client.on_deleted(id);
                         }
+                        client.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
                     }
                 }
                 Err(e) => {
@@ -521,6 +553,7 @@ impl MediaClient {
                         for id in &ids {
                             client.on_trashed(id, false);
                         }
+                        client.emit_by_name::<()>("items-restored", &[&(ids.len() as u32)]);
                     }
                 }
                 Err(e) => {
@@ -559,30 +592,16 @@ impl MediaClient {
 
     // ── Event handling (centralized) ───────────────────────────────────
 
+    /// Handle sync-originated bus events.
+    ///
+    /// Command-result events (Trashed/Restored/Deleted/FavoriteChanged) are
+    /// no longer routed through the bus — MediaClient's own command methods
+    /// update models directly and emit GObject signals. Only events that
+    /// originate outside MediaClient are handled here.
     fn handle_event(&self, event: &AppEvent) {
         match event {
             AppEvent::ThumbnailReady { media_id } => {
                 self.on_thumbnail_ready(media_id);
-            }
-            AppEvent::FavoriteChanged { ids, is_favorite } => {
-                for id in ids {
-                    self.on_favorite_changed(id, *is_favorite);
-                }
-            }
-            AppEvent::Trashed { ids } => {
-                for id in ids {
-                    self.on_trashed(id, true);
-                }
-            }
-            AppEvent::Restored { ids } => {
-                for id in ids {
-                    self.on_trashed(id, false);
-                }
-            }
-            AppEvent::Deleted { ids } => {
-                for id in ids {
-                    self.on_deleted(id);
-                }
             }
             AppEvent::AssetSynced { item } => {
                 self.on_asset_synced(item);

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -467,17 +467,12 @@ mod view_imp {
                 }
 
                 if let Some(ac) = app.album_client_v2() {
-                    tracing::debug!("photo_grid: subscribing to album-media-changed");
                     let ac_obj: glib::Object = ac.clone().upcast();
                     let exit = exit.clone();
                     let h = ac.connect_closure(
                         "album-media-changed",
                         false,
-                        glib::closure_local!(move |_: crate::client::AlbumClientV2, id: String| {
-                            tracing::debug!(
-                                %id,
-                                "photo_grid: album-media-changed received, exiting selection"
-                            );
+                        glib::closure_local!(move |_: crate::client::AlbumClientV2, _: String| {
                             exit.activate(None);
                         }),
                     );

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -361,8 +361,9 @@ mod view_imp {
         pub selection_title: OnceCell<gtk::Label>,
         pub bar_box: OnceCell<gtk::Box>,
         pub fav_btn: RefCell<Option<gtk::Button>>,
-        /// Keeps the event bus subscription alive for this view's lifetime.
-        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
+        /// Signal handler IDs — disconnected on unrealize.
+        /// Stores (client_object, handler_id) pairs for later disconnect.
+        pub _signal_handlers: RefCell<Vec<(glib::Object, glib::SignalHandlerId)>>,
     }
 
     impl PhotoGridView {
@@ -434,25 +435,58 @@ mod view_imp {
                 mc.populate(store);
             }
 
-            // Subscribe for exit-selection on result events.
+            // Exit selection mode on any relevant mutation.
             if let Some(exit) = self.exit_selection.get() {
-                let exit = exit.clone();
-                let sub = crate::event_bus::subscribe(move |event| match event {
-                    crate::app_event::AppEvent::Trashed { .. }
-                    | crate::app_event::AppEvent::Deleted { .. }
-                    | crate::app_event::AppEvent::Restored { .. }
-                    | crate::app_event::AppEvent::AlbumMediaChanged { .. }
-                    | crate::app_event::AppEvent::FavoriteChanged { .. } => {
-                        exit.activate(None);
+                let app = crate::application::MomentsApplication::default();
+                let mut handlers: Vec<(glib::Object, glib::SignalHandlerId)> = Vec::new();
+
+                if let Some(mc) = app.media_client() {
+                    let mc_obj: glib::Object = mc.clone().upcast();
+                    for sig in ["items-trashed", "items-restored", "items-deleted"] {
+                        let exit = exit.clone();
+                        let h = mc.connect_closure(
+                            sig,
+                            false,
+                            glib::closure_local!(move |_: crate::client::MediaClient, _: u32| {
+                                exit.activate(None);
+                            }),
+                        );
+                        handlers.push((mc_obj.clone(), h));
                     }
-                    _ => {}
-                });
-                *self._subscription.borrow_mut() = Some(sub);
+                    let exit = exit.clone();
+                    let h = mc.connect_closure(
+                        "favorite-changed",
+                        false,
+                        glib::closure_local!(
+                            move |_: crate::client::MediaClient, _: u32, _: bool| {
+                                exit.activate(None);
+                            }
+                        ),
+                    );
+                    handlers.push((mc_obj, h));
+                }
+
+                if let Some(ac) = app.album_client_v2() {
+                    let ac_obj: glib::Object = ac.clone().upcast();
+                    let exit = exit.clone();
+                    let h = ac.connect_closure(
+                        "album-media-changed",
+                        false,
+                        glib::closure_local!(move |_: crate::client::AlbumClientV2, _: String| {
+                            exit.activate(None);
+                        }),
+                    );
+                    handlers.push((ac_obj, h));
+                }
+
+                *self._signal_handlers.borrow_mut() = handlers;
             }
         }
 
         fn unrealize(&self) {
-            self._subscription.borrow_mut().take();
+            for (obj, h) in self._signal_handlers.borrow_mut().drain(..) {
+                obj.disconnect(h);
+            }
             self.parent_unrealize();
         }
     }

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -467,12 +467,17 @@ mod view_imp {
                 }
 
                 if let Some(ac) = app.album_client_v2() {
+                    tracing::debug!("photo_grid: subscribing to album-media-changed");
                     let ac_obj: glib::Object = ac.clone().upcast();
                     let exit = exit.clone();
                     let h = ac.connect_closure(
                         "album-media-changed",
                         false,
-                        glib::closure_local!(move |_: crate::client::AlbumClientV2, _: String| {
+                        glib::closure_local!(move |_: crate::client::AlbumClientV2, id: String| {
+                            tracing::debug!(
+                                %id,
+                                "photo_grid: album-media-changed received, exiting selection"
+                            );
                             exit.activate(None);
                         }),
                     );

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -39,8 +39,10 @@ mod imp {
         pub trash_badge: OnceCell<gtk::Label>,
         pub trash_count: Cell<u32>,
 
-        /// Signal handler IDs on MediaClient — disconnected on unrealize.
-        pub _signal_handlers: RefCell<Vec<glib::SignalHandlerId>>,
+        /// Signal handlers — disconnected on unrealize.
+        /// Stores (client_object, handler_id) pairs so disconnect works
+        /// even if the client singleton is unreachable at shutdown.
+        pub _signal_handlers: RefCell<Vec<(glib::Object, glib::SignalHandlerId)>>,
     }
 
     #[glib::object_subclass]
@@ -195,6 +197,7 @@ mod imp {
             let Some(mc) = crate::application::MomentsApplication::default().media_client() else {
                 return;
             };
+            let mc_obj: glib::Object = mc.clone().upcast();
 
             let weak1 = self.obj().downgrade();
             let h1 = mc.connect_closure(
@@ -229,14 +232,13 @@ mod imp {
                 }),
             );
 
-            *self._signal_handlers.borrow_mut() = vec![h1, h2, h3];
+            *self._signal_handlers.borrow_mut() =
+                vec![(mc_obj.clone(), h1), (mc_obj.clone(), h2), (mc_obj, h3)];
         }
 
         fn unrealize(&self) {
-            if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
-                for h in self._signal_handlers.borrow_mut().drain(..) {
-                    mc.disconnect(h);
-                }
+            for (obj, h) in self._signal_handlers.borrow_mut().drain(..) {
+                obj.disconnect(h);
             }
             self.parent_unrealize();
         }

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -39,8 +39,8 @@ mod imp {
         pub trash_badge: OnceCell<gtk::Label>,
         pub trash_count: Cell<u32>,
 
-        /// Keeps the event bus subscription alive for this sidebar's lifetime.
-        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
+        /// Signal handler IDs on MediaClient — disconnected on unrealize.
+        pub _signal_handlers: RefCell<Vec<glib::SignalHandlerId>>,
     }
 
     #[glib::object_subclass]
@@ -192,29 +192,52 @@ mod imp {
         fn realize(&self) {
             self.parent_realize();
 
-            let weak = self.obj().downgrade();
-            let sub = crate::event_bus::subscribe(move |event| {
-                let Some(sidebar) = weak.upgrade() else {
-                    return;
-                };
-                match event {
-                    crate::app_event::AppEvent::Trashed { ids } => {
-                        sidebar.adjust_trash_count(ids.len() as i32);
+            let Some(mc) = crate::application::MomentsApplication::default().media_client() else {
+                return;
+            };
+
+            let weak1 = self.obj().downgrade();
+            let h1 = mc.connect_closure(
+                "items-trashed",
+                false,
+                glib::closure_local!(move |_: crate::client::MediaClient, count: u32| {
+                    if let Some(sidebar) = weak1.upgrade() {
+                        sidebar.adjust_trash_count(count as i32);
                     }
-                    crate::app_event::AppEvent::Restored { ids } => {
-                        sidebar.adjust_trash_count(-(ids.len() as i32));
+                }),
+            );
+
+            let weak2 = self.obj().downgrade();
+            let h2 = mc.connect_closure(
+                "items-restored",
+                false,
+                glib::closure_local!(move |_: crate::client::MediaClient, count: u32| {
+                    if let Some(sidebar) = weak2.upgrade() {
+                        sidebar.adjust_trash_count(-(count as i32));
                     }
-                    crate::app_event::AppEvent::Deleted { ids } => {
-                        sidebar.adjust_trash_count(-(ids.len() as i32));
+                }),
+            );
+
+            let weak3 = self.obj().downgrade();
+            let h3 = mc.connect_closure(
+                "items-deleted",
+                false,
+                glib::closure_local!(move |_: crate::client::MediaClient, count: u32| {
+                    if let Some(sidebar) = weak3.upgrade() {
+                        sidebar.adjust_trash_count(-(count as i32));
                     }
-                    _ => {}
-                }
-            });
-            *self._subscription.borrow_mut() = Some(sub);
+                }),
+            );
+
+            *self._signal_handlers.borrow_mut() = vec![h1, h2, h3];
         }
 
         fn unrealize(&self) {
-            self._subscription.borrow_mut().take();
+            if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                for h in self._signal_handlers.borrow_mut().drain(..) {
+                    mc.disconnect(h);
+                }
+            }
             self.parent_unrealize();
         }
     }

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -53,10 +53,6 @@ mod imp {
         /// value captured at launch to discard stale results.
         pub load_gen: Cell<u64>,
         pub current_metadata: RefCell<Option<MediaMetadataRecord>>,
-        /// Tracks a pending optimistic favourite toggle for rollback on failure.
-        pub pending_fav: RefCell<Option<(MediaId, bool)>>,
-        /// Keeps the event bus subscription alive for this viewer's lifetime.
-        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     impl VideoViewer {
@@ -85,33 +81,7 @@ mod imp {
             self.dispose_template();
         }
     }
-    impl WidgetImpl for VideoViewer {
-        fn realize(&self) {
-            self.parent_realize();
-
-            let weak = self.obj().downgrade();
-            let sub = crate::event_bus::subscribe(move |event| {
-                if let crate::app_event::AppEvent::FavoriteChanged { ids, .. } = event {
-                    let Some(viewer) = weak.upgrade() else {
-                        return;
-                    };
-                    let imp = viewer.imp();
-                    let mut pf = imp.pending_fav.borrow_mut();
-                    if let Some((ref pending_id, _)) = *pf {
-                        if ids.contains(pending_id) {
-                            *pf = None;
-                        }
-                    }
-                }
-            });
-            *self._subscription.borrow_mut() = Some(sub);
-        }
-
-        fn unrealize(&self) {
-            self._subscription.borrow_mut().take();
-            self.parent_unrealize();
-        }
-    }
+    impl WidgetImpl for VideoViewer {}
     impl NavigationPageImpl for VideoViewer {}
 }
 
@@ -361,14 +331,11 @@ impl VideoViewer {
                 let idx = imp.current_index.get();
                 let Some(obj) = items.get(idx) else { return };
 
-                let was_fav = obj.is_favorite();
-                let new_fav = !was_fav;
+                let new_fav = !obj.is_favorite();
                 crate::ui::widgets::update_star_button(btn, new_fav);
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();
-                *imp.pending_fav.borrow_mut() = Some((id.clone(), was_fav));
-
                 if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
                     mc.set_favorite(vec![id], new_fav);
                 }

--- a/src/ui/viewer/mod.rs
+++ b/src/ui/viewer/mod.rs
@@ -72,11 +72,6 @@ mod imp {
         pub pending_load: RefCell<Option<MediaId>>,
         /// Cached metadata for the currently displayed item.
         pub current_metadata: RefCell<Option<MediaMetadataRecord>>,
-        /// Tracks a pending optimistic favourite toggle for rollback on failure.
-        /// Contains `(media_id, previous_favourite_state)`.
-        pub pending_fav: RefCell<Option<(MediaId, bool)>>,
-        /// Keeps the event bus subscription alive for this viewer's lifetime.
-        pub _subscription: RefCell<Option<crate::event_bus::Subscription>>,
     }
 
     impl PhotoViewer {
@@ -105,33 +100,7 @@ mod imp {
             self.dispose_template();
         }
     }
-    impl WidgetImpl for PhotoViewer {
-        fn realize(&self) {
-            self.parent_realize();
-
-            let viewer = self.obj().downgrade();
-            let sub = crate::event_bus::subscribe(move |event| {
-                if let crate::app_event::AppEvent::FavoriteChanged { ids, .. } = event {
-                    let Some(viewer) = viewer.upgrade() else {
-                        return;
-                    };
-                    let imp = viewer.imp();
-                    let mut pf = imp.pending_fav.borrow_mut();
-                    if let Some((ref pending_id, _)) = *pf {
-                        if ids.contains(pending_id) {
-                            *pf = None;
-                        }
-                    }
-                }
-            });
-            *self._subscription.borrow_mut() = Some(sub);
-        }
-
-        fn unrealize(&self) {
-            self._subscription.borrow_mut().take();
-            self.parent_unrealize();
-        }
-    }
+    impl WidgetImpl for PhotoViewer {}
     impl NavigationPageImpl for PhotoViewer {}
 }
 
@@ -352,16 +321,13 @@ impl PhotoViewer {
                 let idx = imp.current_index.get();
                 let Some(obj) = items.get(idx) else { return };
 
-                let was_fav = obj.is_favorite();
-                let new_fav = !was_fav;
+                let new_fav = !obj.is_favorite();
 
                 // Optimistic: update icon and current item immediately.
                 crate::ui::widgets::update_star_button(btn, new_fav);
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();
-                *imp.pending_fav.borrow_mut() = Some((id.clone(), was_fav));
-
                 if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
                     mc.set_favorite(vec![id], new_fav);
                 }

--- a/src/ui/window/mod.rs
+++ b/src/ui/window/mod.rs
@@ -56,8 +56,9 @@ mod imp {
         /// GSettings instance for persisting window geometry.
         pub settings: OnceCell<gio::Settings>,
 
-        /// Event bus subscriptions kept alive for the window's lifetime.
-        pub _subscriptions: RefCell<Vec<crate::event_bus::Subscription>>,
+        /// Signal handlers on client singletons — kept alive for the
+        /// window's lifetime. (Window is a singleton, never unrealized.)
+        pub _signal_handlers: RefCell<Vec<(glib::Object, glib::SignalHandlerId)>>,
     }
 
     #[glib::object_subclass]
@@ -198,23 +199,20 @@ impl MomentsWindow {
 
         self.install_show_toast_action();
         self.install_toggle_sidebar_action();
-        self.subscribe_bus_events(bus);
+        self.connect_client_signals();
 
         debug!("switching main window to content page");
         imp.main_stack.set_visible_child_name("content");
     }
 
-    /// Subscribe to event bus events that the window handles directly.
-    fn subscribe_bus_events(&self, bus: &crate::event_bus::EventBus) {
-        use crate::app_event::AppEvent;
-        let mut subs = self.imp()._subscriptions.borrow_mut();
+    /// Connect to client singletons for events the window handles directly.
+    fn connect_client_signals(&self) {
+        let app = crate::application::MomentsApplication::default();
 
         // Navigate to Recent Imports when an import completes.
         // Deferred via idle_add_local_once because navigate() can materialise
         // a lazy view, which triggers realize → subscribe() on the new widget.
-        if let Some(import_client) =
-            crate::application::MomentsApplication::default().import_client()
-        {
+        if let Some(import_client) = app.import_client() {
             let weak = self.downgrade();
             import_client.connect_notify_local(Some("state"), move |client, _| {
                 if client.state() == crate::client::ImportState::Complete {
@@ -230,17 +228,25 @@ impl MomentsWindow {
 
         // Unregister deleted album routes from the coordinator before
         // AlbumGridView processes the event (avoids a navigation race).
-        let weak = self.downgrade();
-        subs.push(bus.subscribe(move |event| {
-            if let AppEvent::AlbumDeleted { id } = event {
-                if let Some(win) = weak.upgrade() {
-                    if let Some(coord) = win.imp().coordinator.get() {
-                        let route = format!("album:{}", id.as_str());
-                        coord.borrow_mut().unregister(&route);
+        if let Some(ac) = app.album_client_v2() {
+            let weak = self.downgrade();
+            let h = ac.connect_closure(
+                "album-deleted",
+                false,
+                glib::closure_local!(move |_: crate::client::AlbumClientV2, id: String| {
+                    if let Some(win) = weak.upgrade() {
+                        if let Some(coord) = win.imp().coordinator.get() {
+                            let route = format!("album:{}", id);
+                            coord.borrow_mut().unregister(&route);
+                        }
                     }
-                }
-            }
-        }));
+                }),
+            );
+            self.imp()
+                ._signal_handlers
+                .borrow_mut()
+                .push((ac.upcast(), h));
+        }
     }
 
     fn setup_sidebar(&self) -> MomentsSidebar {

--- a/src/ui/window/mod.rs
+++ b/src/ui/window/mod.rs
@@ -152,9 +152,8 @@ impl MomentsWindow {
 
     /// Wire the full shell: sidebar, coordinator, views.
     ///
-    /// All models subscribe to the [`EventBus`] for event delivery.
-    /// The caller does not need to forward events — components are
-    /// self-contained.
+    /// Components react to mutations via GObject signals on the client
+    /// singletons (`MediaClient`, `AlbumClientV2`), not via the event bus.
     pub fn setup(&self, settings: gio::Settings, bus: &crate::event_bus::EventBus) {
         let imp = self.imp();
         let bus_sender = bus.sender();


### PR DESCRIPTION
## Summary

Epic #575 step 4. Replaces EventBus result-event subscriptions with GObject signals on \`MediaClient\` and \`AlbumClientV2\`, removing the UI's dependency on the event bus.

**Restores the selection auto-exit regression from #578.**

## New signals

**MediaClient** (\`src/client/media/client.rs\`):
- \`items-trashed(u32)\` — N items moved to trash
- \`items-restored(u32)\` — N items restored
- \`items-deleted(u32)\` — N items permanently deleted
- \`favorite-changed(u32, bool)\` — favourite toggle completed

Emitted from each command method's \`Ok\` arm.

**AlbumClientV2**:
- \`album-media-changed(String)\` — emitted from \`add_to_album\` / \`remove_from_album\` success

## Subscriber migrations

| File | Before | After |
|---|---|---|
| \`sidebar/mod.rs\` | bus: Trashed/Restored/Deleted | MediaClient 3 signals → adjust trash count |
| \`photo_grid/mod.rs\` (realize) | bus: 5 variants | MediaClient 4 signals + AlbumClientV2 album-media-changed → exit selection |
| \`window/mod.rs\` | bus: AlbumDeleted | AlbumClientV2 album-deleted |
| \`viewer/mod.rs\` | bus: FavoriteChanged (dead code) | **deleted** + \`pending_fav\` field removed |
| \`video_viewer/mod.rs\` | same | same |

The \`pending_fav\` subscription was never acted on — rollback was never implemented. Claude-review on #583 flagged it as stale; deleted entirely here.

## Internal cleanup

\`MediaClient::handle_event\` trimmed to sync-originated events only (\`ThumbnailReady\`, \`AssetSynced\`, \`AssetDeletedRemote\`, \`AlbumMediaChanged\`). The command-result arms (\`Trashed\`, \`Restored\`, \`Deleted\`, \`FavoriteChanged\`) are gone — nothing emits them anymore.

## Post-state

- Zero UI subscribers to the event bus
- Only \`MediaClient\`'s internal \`event_bus::subscribe\` remains, for sync-originated events. To be replaced during the v2 uplift.
- #580 (final cleanup) now deletes: \`library/commands/mod.rs\`, \`AppEvent\`, \`EventBus\`, and the last internal subscription.

## Test plan

- [x] \`make check\` — clean
- [x] \`make lint\` — clean
- [ ] \`make test\` — locally
- [ ] Manual: confirm selection auto-exit works after Trash / Favourite / Delete / Restore / Remove-from-Album. Confirm sidebar trash count updates. Confirm route cleanup on album delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)