### PR TITLE
refactor: EventEmitter fan-out + MediaEvent/ThumbnailEvent plumbing

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -665,7 +665,7 @@ impl MomentsApplication {
                         // Create the album client (GObject singleton).
                         // Subscribe to AlbumEvent for reactive model updates.
                         {
-                            let albums_rx = library.albums().subscribe().await;
+                            let albums_rx = library.albums().subscribe();
                             let album_client_v2 = crate::client::AlbumClientV2::new();
                             album_client_v2.configure(
                                 Arc::clone(&library),
@@ -678,7 +678,7 @@ impl MomentsApplication {
                         // Create the people client (GObject singleton).
                         // Subscribe to FacesEvent for reactive model updates.
                         {
-                            let faces_rx = library.faces().subscribe().await;
+                            let faces_rx = library.faces().subscribe();
                             let people_client = crate::client::PeopleClientV2::new();
                             people_client.configure(Arc::clone(&library), tokio.clone(), faces_rx);
                             *app.imp().people_client.borrow_mut() = Some(people_client);

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -181,6 +181,11 @@ impl AlbumClientV2 {
                         }
                     });
                 }
+                AlbumEvent::AlbumMediaChanged(_) => {
+                    // Handled by MediaClientV2 (future PR); AlbumClientV2's
+                    // own command methods already emit the
+                    // `album-media-changed` GObject signal for widgets.
+                }
             }
         }
         debug!("album event listener shutting down");

--- a/src/client/people/client_v2.rs
+++ b/src/client/people/client_v2.rs
@@ -158,6 +158,11 @@ impl PeopleClientV2 {
                         }
                     });
                 }
+                FacesEvent::PersonMediaChanged(_) => {
+                    // Handled by MediaClientV2 (future PR) for person-
+                    // filtered media grids. PeopleClientV2 doesn't track
+                    // per-person media membership itself.
+                }
             }
         }
         debug!("faces event listener shutting down");

--- a/src/event_emitter.rs
+++ b/src/event_emitter.rs
@@ -1,0 +1,129 @@
+//! Multi-subscriber event fan-out primitive used by library services.
+//!
+//! Each service holds one `EventEmitter<Event>` as a private field. The
+//! service's own `subscribe()` and `emit()` methods delegate here so the
+//! pattern is identical across Album, Media, Faces, and Thumbnail services.
+
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+
+/// Multi-subscriber wrapper around `tokio::sync::mpsc::UnboundedSender`.
+///
+/// [`subscribe`] hands out a fresh `UnboundedReceiver` per call; [`emit`]
+/// delivers a clone of the event to every live subscriber. Senders whose
+/// receiver has been dropped are pruned on the next emit.
+///
+/// The sender list is `Arc`-wrapped so [`Clone`]d copies of the emitter
+/// (e.g. inside a `#[derive(Clone)]` service) share the same subscriber set:
+/// a subscriber attached on one clone receives events emitted through any
+/// clone.
+///
+/// [`subscribe`]: EventEmitter::subscribe
+/// [`emit`]: EventEmitter::emit
+pub struct EventEmitter<T: Clone> {
+    senders: Arc<Mutex<Vec<mpsc::UnboundedSender<T>>>>,
+}
+
+impl<T: Clone> EventEmitter<T> {
+    pub fn new() -> Self {
+        Self {
+            senders: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Register a new subscriber and return its receiver.
+    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<T> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.senders
+            .lock()
+            .expect("event_emitter mutex poisoned")
+            .push(tx);
+        rx
+    }
+
+    /// Broadcast `event` to every live subscriber.
+    ///
+    /// Senders whose receiver has been dropped are removed in the same pass.
+    pub fn emit(&self, event: T) {
+        let mut senders = self.senders.lock().expect("event_emitter mutex poisoned");
+        senders.retain(|tx| tx.send(event.clone()).is_ok());
+    }
+
+    /// Current subscriber count. Diagnostic/test use only.
+    #[cfg(test)]
+    pub fn subscriber_count(&self) -> usize {
+        self.senders
+            .lock()
+            .expect("event_emitter mutex poisoned")
+            .len()
+    }
+}
+
+impl<T: Clone> Default for EventEmitter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Clone> Clone for EventEmitter<T> {
+    fn clone(&self) -> Self {
+        Self {
+            senders: Arc::clone(&self.senders),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn single_subscriber_receives_event() {
+        let em: EventEmitter<u32> = EventEmitter::new();
+        let mut rx = em.subscribe();
+        em.emit(42);
+        assert_eq!(rx.recv().await, Some(42));
+    }
+
+    #[tokio::test]
+    async fn two_subscribers_both_receive_each_event() {
+        let em: EventEmitter<String> = EventEmitter::new();
+        let mut rx1 = em.subscribe();
+        let mut rx2 = em.subscribe();
+        em.emit("hello".to_string());
+        em.emit("world".to_string());
+        assert_eq!(rx1.recv().await, Some("hello".to_string()));
+        assert_eq!(rx1.recv().await, Some("world".to_string()));
+        assert_eq!(rx2.recv().await, Some("hello".to_string()));
+        assert_eq!(rx2.recv().await, Some("world".to_string()));
+    }
+
+    #[tokio::test]
+    async fn dropped_receiver_is_pruned_on_next_emit() {
+        let em: EventEmitter<u32> = EventEmitter::new();
+        let rx1 = em.subscribe();
+        let mut rx2 = em.subscribe();
+        drop(rx1);
+        em.emit(1);
+        assert_eq!(em.subscriber_count(), 1);
+        assert_eq!(rx2.recv().await, Some(1));
+    }
+
+    #[tokio::test]
+    async fn emit_with_no_subscribers_is_noop() {
+        let em: EventEmitter<u32> = EventEmitter::new();
+        em.emit(1);
+        em.emit(2);
+        assert_eq!(em.subscriber_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn clone_shares_subscriber_list() {
+        let em: EventEmitter<u32> = EventEmitter::new();
+        let twin = em.clone();
+        let mut rx = em.subscribe();
+        twin.emit(7);
+        assert_eq!(rx.recv().await, Some(7));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub use user_facing_error::UserFacingError;
 pub mod client;
 pub mod config;
 pub mod event_bus;
+pub mod event_emitter;
 pub mod importer;
 pub mod library;
 pub mod renderer;

--- a/src/library/album/event.rs
+++ b/src/library/album/event.rs
@@ -2,15 +2,27 @@ use super::model::AlbumId;
 
 /// Events emitted by `AlbumService` after state changes.
 ///
-/// Consumed by `AlbumClientV2` to patch ListStore models in-place.
-/// Sent via `tokio::sync::mpsc` — single producer (service), single
-/// consumer (client).
+/// Consumed by clients (`AlbumClientV2`, and in future `MediaClientV2`
+/// for album-filtered media models) to patch ListStore models in place.
+/// Delivered via an [`EventEmitter`] — single producer (the service),
+/// multiple consumers (fan-out).
+///
+/// [`EventEmitter`]: crate::event_emitter::EventEmitter
 #[derive(Debug, Clone)]
 pub enum AlbumEvent {
-    /// A new album was added (sync upsert, no prior row).
+    /// A new album row was added (sync upsert, no prior row).
     AlbumAdded(AlbumId),
-    /// An existing album was updated (sync upsert, media added/removed).
+    /// An existing album row was updated (sync upsert with an existing row,
+    /// or — transitionally — a membership change; see [`AlbumMediaChanged`]).
+    ///
+    /// [`AlbumMediaChanged`]: AlbumEvent::AlbumMediaChanged
     AlbumUpdated(AlbumId),
-    /// An album was removed (sync delete).
+    /// An album was removed (local delete or sync delete).
     AlbumRemoved(AlbumId),
+    /// An album's media membership changed: photos were added to or removed
+    /// from it. Emitted alongside `AlbumUpdated` today for backward
+    /// compatibility; consumers that care only about membership (e.g. a
+    /// media grid filtered by album) should subscribe to this variant
+    /// specifically to avoid refreshing on unrelated metadata updates.
+    AlbumMediaChanged(AlbumId),
 }

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -7,6 +7,7 @@ use tracing::warn;
 use super::event::AlbumEvent;
 use super::model::{Album, AlbumId};
 use super::repository::AlbumRepository;
+use crate::event_emitter::EventEmitter;
 use crate::library::db::Database;
 use crate::library::error::LibraryError;
 use crate::library::media::{MediaCursor, MediaId, MediaItem};
@@ -15,41 +16,36 @@ use crate::library::recorder::MutationRecorder;
 
 /// Album management service.
 ///
-/// Holds an `mpsc::Sender<AlbumEvent>` to notify the client layer of
-/// state changes. Call `subscribe()` once to obtain the receiver.
+/// Holds an [`EventEmitter<AlbumEvent>`] to notify clients of state changes.
+/// Each call to [`subscribe`] returns a fresh receiver; every emitted event
+/// is delivered to every live subscriber.
+///
+/// [`subscribe`]: AlbumService::subscribe
 #[derive(Clone)]
 pub struct AlbumService {
     repo: AlbumRepository,
     recorder: Arc<dyn MutationRecorder>,
-    events_tx: mpsc::UnboundedSender<AlbumEvent>,
-    /// Held so `subscribe()` can hand it out exactly once.
-    events_rx: Arc<tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<AlbumEvent>>>>,
+    events: EventEmitter<AlbumEvent>,
 }
 
 impl AlbumService {
     pub fn new(db: Database, recorder: Arc<dyn MutationRecorder>) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
         Self {
             repo: AlbumRepository::new(db),
             recorder,
-            events_tx: tx,
-            events_rx: Arc::new(tokio::sync::Mutex::new(Some(rx))),
+            events: EventEmitter::new(),
         }
     }
 
-    /// Take the event receiver. Can only be called once — panics on
-    /// subsequent calls.
-    pub async fn subscribe(&self) -> mpsc::UnboundedReceiver<AlbumEvent> {
-        self.events_rx
-            .lock()
-            .await
-            .take()
-            .expect("AlbumService::subscribe() called more than once")
+    /// Register a new subscriber. Every emitted event is delivered to every
+    /// live subscriber.
+    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<AlbumEvent> {
+        self.events.subscribe()
     }
 
-    /// Send an event, ignoring errors (no subscriber yet, or dropped).
+    /// Broadcast an event to every live subscriber.
     fn emit(&self, event: AlbumEvent) {
-        let _ = self.events_tx.send(event);
+        self.events.emit(event);
     }
 
     // ── Sync upsert (pull from server, no outbox recording) ────────
@@ -143,7 +139,11 @@ impl AlbumService {
         media_ids: &[MediaId],
     ) -> Result<(), LibraryError> {
         self.repo.add_media(album_id, media_ids).await?;
+        // Emit both for now: AlbumUpdated preserves the existing
+        // AlbumClientV2 refresh path; AlbumMediaChanged is the targeted
+        // signal for album-filtered media grids (consumed in a later PR).
         self.emit(AlbumEvent::AlbumUpdated(album_id.clone()));
+        self.emit(AlbumEvent::AlbumMediaChanged(album_id.clone()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AlbumMediaAdded {
@@ -164,6 +164,7 @@ impl AlbumService {
     ) -> Result<(), LibraryError> {
         self.repo.remove_media(album_id, media_ids).await?;
         self.emit(AlbumEvent::AlbumUpdated(album_id.clone()));
+        self.emit(AlbumEvent::AlbumMediaChanged(album_id.clone()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AlbumMediaRemoved {

--- a/src/library/db/faces.rs
+++ b/src/library/db/faces.rs
@@ -82,11 +82,15 @@ impl Database {
             .await
     }
 
-    /// Forwarding shim — delegates to `FacesRepository`.
+    /// Forwarding shim — delegates to `FacesRepository`. The deleted
+    /// `person_id` is dropped; callers that need it should use
+    /// `FacesService::delete_asset_face` (which emits `PersonMediaChanged`)
+    /// or the repository directly.
     pub async fn delete_asset_face(&self, id: &str) -> Result<(), LibraryError> {
         FacesRepository::new(self.clone())
             .delete_asset_face(id)
             .await
+            .map(|_| ())
     }
 
     /// Forwarding shim — delegates to `FacesRepository`.

--- a/src/library/faces/event.rs
+++ b/src/library/faces/event.rs
@@ -2,15 +2,30 @@ use super::model::PersonId;
 
 /// Events emitted by `FacesService` after state changes.
 ///
-/// Consumed by `PeopleClientV2` to patch ListStore models in-place.
-/// Sent via `tokio::sync::mpsc` — multiple producers possible via
-/// `FacesService: Clone`, single consumer (client).
+/// Consumed by clients (`PeopleClientV2`, and in future `MediaClientV2`
+/// for person-filtered media models) to patch ListStore models in place.
+/// Delivered via an [`EventEmitter`] — single producer (the service),
+/// multiple consumers (fan-out).
+///
+/// [`EventEmitter`]: crate::event_emitter::EventEmitter
 #[derive(Debug, Clone)]
 pub enum FacesEvent {
     /// A new person was added (sync upsert, no prior row).
     PersonAdded(PersonId),
-    /// An existing person was updated (sync upsert, rename, hide, face count).
+    /// An existing person row was updated (sync upsert, rename, hide).
+    ///
+    /// Deliberately not emitted from `update_face_count` — `face_count`
+    /// is not a GObject property, and bulk sync would otherwise produce
+    /// O(faces) no-op roundtrips.
     PersonUpdated(PersonId),
     /// A person was removed (sync delete).
     PersonRemoved(PersonId),
+    /// The set of media assigned to this person changed — an asset face
+    /// was created, reassigned to or from this person, or deleted.
+    ///
+    /// Consumed by media grids filtered by person. A reassignment emits
+    /// two `PersonMediaChanged` events (one for the previous person, one
+    /// for the new). On a local backend this never fires — local
+    /// libraries have no face detection.
+    PersonMediaChanged(PersonId),
 }

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -211,14 +211,35 @@ impl FacesRepository {
         Ok(())
     }
 
-    /// Delete an asset face by ID.
-    pub async fn delete_asset_face(&self, id: &str) -> Result<(), LibraryError> {
-        sqlx::query("DELETE FROM asset_faces WHERE id = ?")
-            .bind(id)
-            .execute(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-        Ok(())
+    /// Look up the `person_id` currently assigned to an asset face.
+    ///
+    /// Returns `None` if the face row does not exist, or if the row exists
+    /// with a null `person_id`. Callers that need to distinguish those two
+    /// cases must query separately.
+    pub async fn get_asset_face_person_id(&self, id: &str) -> Result<Option<String>, LibraryError> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT person_id FROM asset_faces WHERE id = ?")
+                .bind(id)
+                .fetch_optional(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
+        Ok(row.and_then(|(p,)| p))
+    }
+
+    /// Delete an asset face by ID, returning the `person_id` of the deleted
+    /// row if any. Returns `None` if no row matched, or if the row existed
+    /// with a null `person_id`.
+    ///
+    /// The returned value lets `FacesService` emit `PersonMediaChanged`
+    /// without a second query.
+    pub async fn delete_asset_face(&self, id: &str) -> Result<Option<String>, LibraryError> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("DELETE FROM asset_faces WHERE id = ? RETURNING person_id")
+                .bind(id)
+                .fetch_optional(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
+        Ok(row.and_then(|(p,)| p))
     }
 
     /// Recount faces for a person and update the denormalised face_count.
@@ -461,7 +482,8 @@ mod tests {
         let media = repo.list_media_for_person("p1").await.unwrap();
         assert_eq!(media, vec!["m1"]);
 
-        repo.delete_asset_face("f1").await.unwrap();
+        let deleted_person = repo.delete_asset_face("f1").await.unwrap();
+        assert_eq!(deleted_person, Some("p1".to_string()));
         repo.update_face_count("p1").await.unwrap();
 
         let media = repo.list_media_for_person("p1").await.unwrap();

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -6,6 +6,7 @@ use tracing::warn;
 use super::event::FacesEvent;
 use super::model::{Person, PersonId};
 use super::repository::FacesRepository;
+use crate::event_emitter::EventEmitter;
 use crate::library::db::Database;
 use crate::library::error::LibraryError;
 use crate::library::media::MediaId;
@@ -14,16 +15,17 @@ use crate::library::recorder::MutationRecorder;
 
 /// Face/people management service.
 ///
-/// Holds an `mpsc::Sender<FacesEvent>` to notify the client layer of
-/// state changes. Call `subscribe()` once to obtain the receiver.
+/// Holds an [`EventEmitter<FacesEvent>`] to notify clients of state changes.
+/// Each call to [`subscribe`] returns a fresh receiver; every emitted event
+/// is delivered to every live subscriber.
+///
+/// [`subscribe`]: FacesService::subscribe
 #[derive(Clone)]
 pub struct FacesService {
     repo: FacesRepository,
     thumbnails_dir: Option<std::path::PathBuf>,
     recorder: Arc<dyn MutationRecorder>,
-    events_tx: mpsc::UnboundedSender<FacesEvent>,
-    /// Held so `subscribe()` can hand it out exactly once.
-    events_rx: Arc<tokio::sync::Mutex<Option<mpsc::UnboundedReceiver<FacesEvent>>>>,
+    events: EventEmitter<FacesEvent>,
 }
 
 impl FacesService {
@@ -36,29 +38,23 @@ impl FacesService {
         thumbnails_dir: Option<std::path::PathBuf>,
         recorder: Arc<dyn MutationRecorder>,
     ) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
         Self {
             repo: FacesRepository::new(db),
             thumbnails_dir,
             recorder,
-            events_tx: tx,
-            events_rx: Arc::new(tokio::sync::Mutex::new(Some(rx))),
+            events: EventEmitter::new(),
         }
     }
 
-    /// Take the event receiver. Can only be called once — panics on
-    /// subsequent calls.
-    pub async fn subscribe(&self) -> mpsc::UnboundedReceiver<FacesEvent> {
-        self.events_rx
-            .lock()
-            .await
-            .take()
-            .expect("FacesService::subscribe() called more than once")
+    /// Register a new subscriber. Every emitted event is delivered to every
+    /// live subscriber.
+    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<FacesEvent> {
+        self.events.subscribe()
     }
 
-    /// Send an event, ignoring errors (no subscriber yet, or dropped).
+    /// Broadcast an event to every live subscriber.
     fn emit(&self, event: FacesEvent) {
-        let _ = self.events_tx.send(event);
+        self.events.emit(event);
     }
 
     // ── Sync upserts (pull from server, no outbox recording) ───────
@@ -100,11 +96,27 @@ impl FacesService {
     }
 
     /// Insert or replace an asset face from the sync stream.
+    ///
+    /// Emits `PersonMediaChanged` for every person whose membership set
+    /// changed. For a reassignment from A to B, two events fire — one for
+    /// A (a media was removed) and one for B (a media was added). If the
+    /// person_id is unchanged, no events fire.
     pub(crate) async fn upsert_asset_face(
         &self,
         face: &super::repository::AssetFaceRow,
     ) -> Result<(), LibraryError> {
-        self.repo.upsert_asset_face(face).await
+        let prev_person_id = self.repo.get_asset_face_person_id(&face.id).await?;
+        self.repo.upsert_asset_face(face).await?;
+        let new_person_id = face.person_id.clone();
+        if prev_person_id != new_person_id {
+            if let Some(p) = prev_person_id {
+                self.emit(FacesEvent::PersonMediaChanged(PersonId::from_raw(p)));
+            }
+            if let Some(p) = new_person_id {
+                self.emit(FacesEvent::PersonMediaChanged(PersonId::from_raw(p)));
+            }
+        }
+        Ok(())
     }
 
     /// Delete a person by ID (sync stream delete).
@@ -117,8 +129,14 @@ impl FacesService {
     }
 
     /// Delete an asset face by ID (sync stream delete).
+    ///
+    /// Emits `PersonMediaChanged` for the deleted face's person, if any.
     pub async fn delete_asset_face(&self, id: &str) -> Result<(), LibraryError> {
-        self.repo.delete_asset_face(id).await
+        let deleted_person_id = self.repo.delete_asset_face(id).await?;
+        if let Some(p) = deleted_person_id {
+            self.emit(FacesEvent::PersonMediaChanged(PersonId::from_raw(p)));
+        }
+        Ok(())
     }
 
     /// Update the denormalized face count for a person.

--- a/src/library/media/event.rs
+++ b/src/library/media/event.rs
@@ -1,0 +1,29 @@
+use super::model::MediaId;
+
+/// Events emitted by `MediaService` after state changes.
+///
+/// Consumed by clients (`MediaClientV2`, in a future PR) to patch ListStore
+/// models in place. Delivered via an [`EventEmitter`] — single producer
+/// (the service), multiple consumers (fan-out).
+///
+/// All variants carry a `Vec<MediaId>` so batch operations (trash, restore,
+/// bulk favourite) can emit one aggregate event instead of one per id.
+/// Single-item callers emit `vec![id]`. Consumers should loop over the vec
+/// when patching models.
+///
+/// [`EventEmitter`]: crate::event_emitter::EventEmitter
+#[derive(Debug, Clone)]
+pub enum MediaEvent {
+    /// Media rows were inserted — local imports (`insert_media`) or new
+    /// rows from the sync stream (`upsert_media` with no prior row).
+    Added(Vec<MediaId>),
+    /// Media rows changed — `set_favorite`, `trash`, `restore`, or a sync
+    /// upsert that matched an existing row. Consumers should re-query the
+    /// affected rows and either patch fields in their tracked models or
+    /// remove rows that no longer match the model's filter (e.g. a trashed
+    /// item drops out of a "all non-trashed" model).
+    Updated(Vec<MediaId>),
+    /// Media rows were permanently deleted (`delete_permanently`, either
+    /// from local user action or from the sync stream).
+    Removed(Vec<MediaId>),
+}

--- a/src/library/media/mod.rs
+++ b/src/library/media/mod.rs
@@ -1,6 +1,8 @@
+pub mod event;
 mod model;
 pub mod repository;
 mod service;
 
+pub use event::MediaEvent;
 pub use model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, MediaType};
 pub use service::MediaService;

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -1,10 +1,13 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use tokio::sync::mpsc;
 use tracing::warn;
 
+use super::event::MediaEvent;
 use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord};
 use super::repository::MediaRepository;
+use crate::event_emitter::EventEmitter;
 use crate::library::config::LocalStorageMode;
 use crate::library::db::{Database, LibraryStats};
 use crate::library::error::LibraryError;
@@ -16,6 +19,12 @@ use crate::library::resolver::OriginalResolver;
 ///
 /// Owns all media-table operations and the filesystem knowledge needed
 /// to resolve original-file paths and clean up files on deletion.
+///
+/// Holds an [`EventEmitter<MediaEvent>`] to notify clients of state
+/// changes. Each call to [`subscribe`] returns a fresh receiver; every
+/// emitted event is delivered to every live subscriber.
+///
+/// [`subscribe`]: MediaService::subscribe
 #[derive(Clone)]
 pub struct MediaService {
     repo: MediaRepository,
@@ -23,6 +32,7 @@ pub struct MediaService {
     mode: LocalStorageMode,
     recorder: Arc<dyn MutationRecorder>,
     resolver: Arc<dyn OriginalResolver>,
+    events: EventEmitter<MediaEvent>,
 }
 
 impl MediaService {
@@ -39,7 +49,19 @@ impl MediaService {
             mode,
             recorder,
             resolver,
+            events: EventEmitter::new(),
         }
+    }
+
+    /// Register a new subscriber. Every emitted event is delivered to every
+    /// live subscriber.
+    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<MediaEvent> {
+        self.events.subscribe()
+    }
+
+    /// Broadcast an event to every live subscriber.
+    fn emit(&self, event: MediaEvent) {
+        self.events.emit(event);
     }
 
     // ── Path resolution ─────────────────────────────────────────────
@@ -80,8 +102,19 @@ impl MediaService {
     // ── Sync upsert (pull from server, no outbox recording) ────────
 
     /// Insert or replace a media record from the sync stream.
+    ///
+    /// Pre-queries existence so the emitted event distinguishes a new row
+    /// (`Added`) from a refreshed row (`Updated`).
     pub async fn upsert_media(&self, record: &MediaRecord) -> Result<(), LibraryError> {
-        self.repo.upsert(record).await
+        let existed = self.repo.exists(&record.id).await?;
+        self.repo.upsert(record).await?;
+        let ids = vec![record.id.clone()];
+        if existed {
+            self.emit(MediaEvent::Updated(ids));
+        } else {
+            self.emit(MediaEvent::Added(ids));
+        }
+        Ok(())
     }
 
     // ── Delegating methods ──────────────────────────────────────────
@@ -101,6 +134,7 @@ impl MediaService {
 
     pub async fn insert_media(&self, record: &MediaRecord) -> Result<(), LibraryError> {
         self.repo.insert(record).await?;
+        self.emit(MediaEvent::Added(vec![record.id.clone()]));
         let file_path = match self.mode {
             LocalStorageMode::Managed => self.originals_dir.join(&record.relative_path),
             LocalStorageMode::Referenced => PathBuf::from(&record.relative_path),
@@ -129,6 +163,7 @@ impl MediaService {
 
     pub async fn set_favorite(&self, ids: &[MediaId], favorite: bool) -> Result<(), LibraryError> {
         self.repo.set_favorite(ids, favorite).await?;
+        self.emit(MediaEvent::Updated(ids.to_vec()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AssetFavorited {
@@ -144,6 +179,7 @@ impl MediaService {
 
     pub async fn trash(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
         self.repo.trash(ids).await?;
+        self.emit(MediaEvent::Updated(ids.to_vec()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AssetTrashed { ids: ids.to_vec() })
@@ -156,6 +192,7 @@ impl MediaService {
 
     pub async fn restore(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
         self.repo.restore(ids).await?;
+        self.emit(MediaEvent::Updated(ids.to_vec()));
         if let Err(e) = self
             .recorder
             .record(&Mutation::AssetRestored { ids: ids.to_vec() })
@@ -170,6 +207,7 @@ impl MediaService {
         // Capture external_ids before the DB delete removes the rows.
         let ext_map = self.repo.external_ids(ids).await.unwrap_or_default();
         self.repo.delete_permanently(ids).await?;
+        self.emit(MediaEvent::Removed(ids.to_vec()));
         let items: Vec<(MediaId, Option<String>)> = ids
             .iter()
             .map(|id| {
@@ -192,7 +230,9 @@ impl MediaService {
 
     /// Permanently delete without outbox recording (used by pull sync).
     pub async fn delete_permanently_no_record(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
-        self.repo.delete_permanently(ids).await
+        self.repo.delete_permanently(ids).await?;
+        self.emit(MediaEvent::Removed(ids.to_vec()));
+        Ok(())
     }
 
     pub async fn expired_trash(&self, max_age_secs: i64) -> Result<Vec<MediaId>, LibraryError> {

--- a/src/library/thumbnail/event.rs
+++ b/src/library/thumbnail/event.rs
@@ -1,0 +1,19 @@
+use crate::library::media::MediaId;
+
+/// Events emitted by `ThumbnailService` after thumbnail state changes.
+///
+/// Consumed by clients (`MediaClientV2`, in a future PR) to load the
+/// thumbnail texture into grid cells as soon as a thumbnail is written
+/// to disk. Delivered via an [`EventEmitter`] — single producer (the
+/// service), multiple consumers (fan-out).
+///
+/// Single-id variant is intentional: thumbnails are generated one per
+/// asset, both by the local import pipeline and by the Immich sync
+/// download. There is no batch producer.
+///
+/// [`EventEmitter`]: crate::event_emitter::EventEmitter
+#[derive(Debug, Clone)]
+pub enum ThumbnailEvent {
+    /// A thumbnail is now on disk and can be loaded as a texture.
+    Ready(MediaId),
+}

--- a/src/library/thumbnail/mod.rs
+++ b/src/library/thumbnail/mod.rs
@@ -1,7 +1,9 @@
+pub mod event;
 mod model;
 pub mod repository;
 mod service;
 
+pub use event::ThumbnailEvent;
 pub use model::ThumbnailStatus;
 pub use service::{
     sharded_original_path, sharded_original_relative, sharded_thumbnail_path, ThumbnailService,

--- a/src/library/thumbnail/service.rs
+++ b/src/library/thumbnail/service.rs
@@ -1,7 +1,11 @@
 use std::path::PathBuf;
 
+use tokio::sync::mpsc;
+
+use super::event::ThumbnailEvent;
 use super::model::ThumbnailStatus;
 use super::repository::ThumbnailRepository;
+use crate::event_emitter::EventEmitter;
 use crate::library::db::Database;
 use crate::library::error::LibraryError;
 use crate::library::media::MediaId;
@@ -46,10 +50,18 @@ pub fn sharded_original_relative(id: &MediaId) -> String {
 }
 
 /// Thumbnail path resolution and persistence service.
+///
+/// Holds an [`EventEmitter<ThumbnailEvent>`] to notify clients when a
+/// thumbnail becomes ready on disk. Each call to [`subscribe`] returns a
+/// fresh receiver; every emitted event is delivered to every live
+/// subscriber.
+///
+/// [`subscribe`]: ThumbnailService::subscribe
 #[derive(Clone)]
 pub struct ThumbnailService {
     repo: ThumbnailRepository,
     thumbnails_dir: PathBuf,
+    events: EventEmitter<ThumbnailEvent>,
 }
 
 impl ThumbnailService {
@@ -57,7 +69,19 @@ impl ThumbnailService {
         Self {
             repo: ThumbnailRepository::new(db),
             thumbnails_dir,
+            events: EventEmitter::new(),
         }
+    }
+
+    /// Register a new subscriber. Every emitted event is delivered to every
+    /// live subscriber.
+    pub fn subscribe(&self) -> mpsc::UnboundedReceiver<ThumbnailEvent> {
+        self.events.subscribe()
+    }
+
+    /// Broadcast an event to every live subscriber.
+    fn emit(&self, event: ThumbnailEvent) {
+        self.events.emit(event);
     }
 
     pub fn thumbnail_path(&self, id: &MediaId) -> PathBuf {
@@ -74,7 +98,9 @@ impl ThumbnailService {
         file_path: &str,
         generated_at: i64,
     ) -> Result<(), LibraryError> {
-        self.repo.set_ready(id, file_path, generated_at).await
+        self.repo.set_ready(id, file_path, generated_at).await?;
+        self.emit(ThumbnailEvent::Ready(id.clone()));
+        Ok(())
     }
 
     pub async fn set_thumbnail_failed(&self, id: &MediaId) -> Result<(), LibraryError> {


### PR DESCRIPTION
## Summary

- Adds `EventEmitter<T>` fan-out primitive at crate root — services can now have multiple subscribers per event channel, replacing the single-consumer `Arc<Mutex<Option<Receiver>>>` pattern.
- Applies the pattern uniformly across `AlbumService`, `MediaService`, `FacesService`, `ThumbnailService`.
- Plumbs new event types that `MediaClientV2` will consume in step 2: `MediaEvent::{Added,Updated,Removed}` with `Vec<MediaId>` payloads, `ThumbnailEvent::Ready`, `AlbumEvent::AlbumMediaChanged`, `FacesEvent::PersonMediaChanged`.

No client behaviour change: `AlbumClientV2` and `PeopleClientV2` have no-op match arms for the new variants; `MediaEvent` and `ThumbnailEvent` channels have no subscribers yet.

Part of #587 (MediaClientV2 uplift) — step 1 of 4.

## Design notes

- **Fan-out lives at crate root** (`src/event_emitter.rs`), not under `src/library/`: it's a cross-cutting concurrency primitive, same layer as `event_bus/`.
- **mpsc fan-out, not `broadcast`**: unbounded means no `Lagged` events lost during bulk sync bursts; broadcast's bounded buffer would require tuning and silent event loss on overflow is a correctness bug for UI state.
- **`MediaEvent` variants carry `Vec<MediaId>`** while `AlbumEvent`/`FacesEvent` remain single-id. Media operates at 10000s scale — batched events let the future `MediaClientV2` listener amortise one DB roundtrip across N ids instead of emitting one `glib::idle_add_once` per id.
- **Trash/restore/favourite emit `Updated`** (no dedicated variant). Consumers re-query the affected rows and reconcile against their filter predicate — insert/update/remove from tracked models based on whether the row still matches.
- **`delete_asset_face` now uses SQLite `RETURNING`** to get the deleted `person_id` in one query, enabling `PersonMediaChanged` emission without a second roundtrip.
- **Import pipeline kept on its `ProgressFn` callback** — one-shot lifecycle, single caller, `EventEmitter` would be ceremony without benefit. See `src/importer/pipeline.rs`.

## Test plan

- [ ] `make lint` (cargo fmt + clippy `-D warnings`)
- [ ] `make test` (unit tests, including five new `EventEmitter` tests)
- [ ] `make run-dev` smoke test:
  - [ ] App launches
  - [ ] Album add/remove still refreshes grid, album card count, and album detail view
  - [ ] Immich sync completes without error; people appear with correct face counts
  - [ ] Local import adds new rows to grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)