### PR TITLE
refactor: MediaClientV2 owns commands (#587 step 3)

### DIFF
--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -726,16 +726,6 @@ impl MomentsApplication {
                             .clone();
                         window.setup(settings, &bus);
 
-                        // Subscribe for command events — routes *Requested
-                        // events to library calls on the Tokio runtime.
-                        let Some(lib) = app.imp().library.borrow().as_ref().map(Arc::clone) else {
-                            tracing::error!("library not initialised when subscribing commands");
-                            return;
-                        };
-                        let cmd_sub =
-                            crate::library::commands::subscribe_commands(lib, tokio.clone(), &bus);
-                        app.imp().subscriptions.borrow_mut().push(cmd_sub);
-
                         // Subscribe for error toasts — centralised error
                         // handling for all command failures.
                         {

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -68,7 +68,32 @@ mod imp {
         type ParentType = glib::Object;
     }
 
-    impl ObjectImpl for MediaClientV2 {}
+    impl ObjectImpl for MediaClientV2 {
+        fn signals() -> &'static [glib::subclass::Signal] {
+            static SIGNALS: std::sync::OnceLock<Vec<glib::subclass::Signal>> =
+                std::sync::OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![
+                    // Emitted after N items are moved to trash.
+                    glib::subclass::Signal::builder("items-trashed")
+                        .param_types([u32::static_type()])
+                        .build(),
+                    // Emitted after N items are restored from trash.
+                    glib::subclass::Signal::builder("items-restored")
+                        .param_types([u32::static_type()])
+                        .build(),
+                    // Emitted after N items are permanently deleted.
+                    glib::subclass::Signal::builder("items-deleted")
+                        .param_types([u32::static_type()])
+                        .build(),
+                    // Emitted after a favourite toggle completes. (count, is_favorite).
+                    glib::subclass::Signal::builder("favorite-changed")
+                        .param_types([u32::static_type(), bool::static_type()])
+                        .build(),
+                ]
+            })
+        }
+    }
 }
 
 glib::wrapper! {
@@ -316,6 +341,191 @@ impl MediaClientV2 {
     pub fn thumbnail_path(&self, id: &MediaId) -> PathBuf {
         let (library, _) = self.deps();
         library.thumbnails().thumbnail_path(id)
+    }
+
+    // ── Commands ───────────────────────────────────────────────────────
+    //
+    // Each command spawns the library call on Tokio, then on success emits
+    // a result signal on the GTK thread. Model reconciliation is driven by
+    // the service-emitted `MediaEvent::Updated`/`Removed` events flowing
+    // through `listen_media`, so the commands themselves do not patch
+    // tracked models directly.
+
+    /// Move items to trash.
+    pub fn trash(&self, ids: Vec<MediaId>) {
+        let (library, tokio) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.media().trash(&ids_for_call).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        client.emit_by_name::<()>("items-trashed", &[&(ids.len() as u32)]);
+                    }
+                }
+                Err(e) => {
+                    error!("trash failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Restore items from trash.
+    pub fn restore(&self, ids: Vec<MediaId>) {
+        let (library, tokio) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.media().restore(&ids_for_call).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        client.emit_by_name::<()>("items-restored", &[&(ids.len() as u32)]);
+                    }
+                }
+                Err(e) => {
+                    error!("restore failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Permanently delete items.
+    pub fn delete(&self, ids: Vec<MediaId>) {
+        let (library, tokio) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.delete_permanently(&ids_for_call).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        client.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
+                    }
+                }
+                Err(e) => {
+                    error!("delete permanently failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Set the favourite flag on items.
+    pub fn set_favorite(&self, ids: Vec<MediaId>, state: bool) {
+        let (library, tokio) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let ids_for_call = ids.clone();
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.media().set_favorite(&ids_for_call, state).await
+            })
+            .await;
+
+            match result {
+                Ok(()) => {
+                    if let Some(client) = client_weak.upgrade() {
+                        client
+                            .emit_by_name::<()>("favorite-changed", &[&(ids.len() as u32), &state]);
+                    }
+                }
+                Err(e) => {
+                    error!("set_favorite failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Permanently delete every trashed item.
+    pub fn empty_trash(&self) {
+        let (library, tokio) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let result = crate::client::spawn_on(&tokio, async move {
+                let items = library
+                    .media()
+                    .list_media(MediaFilter::Trashed, None, u32::MAX)
+                    .await?;
+                let ids: Vec<_> = items.into_iter().map(|i| i.id).collect();
+                if ids.is_empty() {
+                    return Ok(Vec::new());
+                }
+                library.delete_permanently(&ids).await?;
+                Ok(ids)
+            })
+            .await;
+
+            match result {
+                Ok(ids) if ids.is_empty() => {}
+                Ok(ids) => {
+                    tracing::info!(count = ids.len(), "trash emptied");
+                    if let Some(client) = client_weak.upgrade() {
+                        client.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
+                    }
+                }
+                Err(e) => {
+                    error!("empty trash failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
+    }
+
+    /// Restore every trashed item.
+    pub fn restore_all_trash(&self) {
+        let (library, tokio) = self.deps();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+
+        glib::MainContext::default().spawn_local(async move {
+            let result = crate::client::spawn_on(&tokio, async move {
+                let items = library
+                    .media()
+                    .list_media(MediaFilter::Trashed, None, u32::MAX)
+                    .await?;
+                let ids: Vec<_> = items.into_iter().map(|i| i.id).collect();
+                if ids.is_empty() {
+                    return Ok(Vec::new());
+                }
+                library.media().restore(&ids).await?;
+                Ok(ids)
+            })
+            .await;
+
+            match result {
+                Ok(ids) if ids.is_empty() => {}
+                Ok(ids) => {
+                    tracing::info!(count = ids.len(), "all trash restored");
+                    if let Some(client) = client_weak.upgrade() {
+                        client.emit_by_name::<()>("items-restored", &[&(ids.len() as u32)]);
+                    }
+                }
+                Err(e) => {
+                    error!("restore all trash failed: {e}");
+                    crate::client::show_error_toast(&e);
+                }
+            }
+        });
     }
 
     // ── Page loading helper ────────────────────────────────────────────

--- a/src/ui/album_grid/actions.rs
+++ b/src/ui/album_grid/actions.rs
@@ -19,7 +19,7 @@ pub(crate) fn open_album_drilldown(
 ) {
     let filter = MediaFilter::Album { album_id };
     let media_client = MomentsApplication::default()
-        .media_client()
+        .media_client_v2()
         .expect("media client available");
     let store = media_client.create_model(filter.clone());
     let view = PhotoGridView::new();

--- a/src/ui/album_grid/mod.rs
+++ b/src/ui/album_grid/mod.rs
@@ -288,27 +288,37 @@ impl AlbumGridView {
         settings: &gio::Settings,
         texture_cache: &Rc<TextureCache>,
         bus_sender: &crate::event_bus::EventSender,
-        store: &gio::ListStore,
+        _store: &gio::ListStore,
     ) {
         let s = settings.clone();
         let tc = Rc::clone(texture_cache);
         let bs = bus_sender.clone();
-        let st = store.clone();
         let nav = self.imp().nav_view.clone();
 
-        self.imp().grid_view.connect_activate(move |_, position| {
-            let Some(obj) = st.item(position) else { return };
-            let Some(item) = obj.downcast_ref::<AlbumItemObject>() else {
-                return;
-            };
-            let album_id_str = item.id();
-            let album_name = item.name();
-            let album_id = AlbumId::from_raw(album_id_str.clone());
+        // Resolve the activated item via the grid's bound model so that
+        // sorted/filtered positions map back to the right AlbumItemObject.
+        // Looking up by position in the raw store would return the wrong
+        // album whenever sort order differs from insertion order.
+        self.imp()
+            .grid_view
+            .connect_activate(move |grid_view, position| {
+                let Some(model) = grid_view.model() else {
+                    return;
+                };
+                let Some(obj) = model.item(position) else {
+                    return;
+                };
+                let Some(item) = obj.downcast_ref::<AlbumItemObject>() else {
+                    return;
+                };
+                let album_id_str = item.id();
+                let album_name = item.name();
+                let album_id = AlbumId::from_raw(album_id_str.clone());
 
-            debug!(album_id = %album_id_str, name = %album_name, "album activated");
+                debug!(album_id = %album_id_str, name = %album_name, "album activated");
 
-            actions::open_album_drilldown(&s, &tc, &bs, &nav, album_id, &album_name);
-        });
+                actions::open_album_drilldown(&s, &tc, &bs, &nav, album_id, &album_name);
+            });
     }
 }
 

--- a/src/ui/people_grid/actions.rs
+++ b/src/ui/people_grid/actions.rs
@@ -42,7 +42,7 @@ pub(super) fn wire_activation(
             person_id: person_id.clone(),
         };
         let mc = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
         let store = mc.create_model(filter.clone());
         let view = PhotoGridView::new();

--- a/src/ui/photo_grid/action_bar.rs
+++ b/src/ui/photo_grid/action_bar.rs
@@ -144,7 +144,7 @@ fn wire_favourite(btn: &gtk::Button, selection: &gtk::MultiSelection) {
             .unwrap_or(false);
         let new_state = !first_fav;
 
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.set_favorite(ids, new_state);
         }
         actions::update_fav_button(&btn_ref, new_state);
@@ -158,7 +158,7 @@ fn wire_trash(btn: &gtk::Button, selection: &gtk::MultiSelection) {
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.trash(ids);
         }
     });
@@ -171,7 +171,7 @@ fn wire_restore(btn: &gtk::Button, selection: &gtk::MultiSelection) {
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.restore(ids);
         }
     });
@@ -208,7 +208,7 @@ fn wire_delete_permanently(btn: &gtk::Button, selection: &gtk::MultiSelection) {
             move |response| {
                 if response == "delete" {
                     if let Some(mc) =
-                        crate::application::MomentsApplication::default().media_client()
+                        crate::application::MomentsApplication::default().media_client_v2()
                     {
                         mc.delete(ids);
                     }

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -216,7 +216,7 @@ fn wire_restore_button(
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.restore(ids);
         }
     });
@@ -262,7 +262,7 @@ fn wire_permanent_delete_button(
             move |response| {
                 if response == "delete" {
                     if let Some(mc) =
-                        crate::application::MomentsApplication::default().media_client()
+                        crate::application::MomentsApplication::default().media_client_v2()
                     {
                         mc.delete(ids);
                     }
@@ -289,7 +289,7 @@ fn wire_favourite_button(
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.set_favorite(ids, new_fav);
         }
     });
@@ -311,7 +311,7 @@ fn wire_trash_button(
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.trash(ids);
         }
     });

--- a/src/ui/photo_grid/factory.rs
+++ b/src/ui/photo_grid/factory.rs
@@ -7,7 +7,7 @@ use gtk::{gio, glib, prelude::*, subclass::prelude::*};
 use tokio::sync::Semaphore;
 use tracing::debug;
 
-use crate::client::{MediaClient, MediaItemObject};
+use crate::client::{MediaClientV2, MediaItemObject};
 use crate::library::media::{MediaFilter, MediaItem};
 
 use super::cell::PhotoGridCell;
@@ -26,7 +26,7 @@ fn max_decode_workers() -> usize {
 #[allow(clippy::too_many_arguments)]
 pub fn build_factory(
     cell_size: i32,
-    media_client: MediaClient,
+    media_client: MediaClientV2,
     filter: MediaFilter,
     cache: Rc<TextureCache>,
     selection_mode: Rc<Cell<bool>>,

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -37,7 +37,7 @@ mod photo_grid_imp {
         pub selection: RefCell<Option<gtk::MultiSelection>>,
         pub store: RefCell<Option<gio::ListStore>>,
         pub zoom_level: Cell<usize>,
-        pub media_client: OnceCell<crate::client::MediaClient>,
+        pub media_client: OnceCell<crate::client::MediaClientV2>,
         pub bus_sender: OnceCell<crate::event_bus::EventSender>,
         pub filter: RefCell<crate::library::media::MediaFilter>,
         pub texture_cache: OnceCell<Rc<super::texture_cache::TextureCache>>,
@@ -94,7 +94,7 @@ mod photo_grid_imp {
                 .get()
                 .expect("content_stack not initialized")
         }
-        pub fn media_client(&self) -> &crate::client::MediaClient {
+        pub fn media_client(&self) -> &crate::client::MediaClientV2 {
             self.media_client
                 .get()
                 .expect("media_client not initialized")
@@ -230,7 +230,7 @@ impl PhotoGrid {
     pub fn set_store(
         &self,
         store: gio::ListStore,
-        media_client: crate::client::MediaClient,
+        media_client: crate::client::MediaClientV2,
         bus_sender: crate::event_bus::EventSender,
         filter: crate::library::media::MediaFilter,
         cache: Rc<texture_cache::TextureCache>,
@@ -440,14 +440,14 @@ mod view_imp {
                 let app = crate::application::MomentsApplication::default();
                 let mut handlers: Vec<(glib::Object, glib::SignalHandlerId)> = Vec::new();
 
-                if let Some(mc) = app.media_client() {
+                if let Some(mc) = app.media_client_v2() {
                     let mc_obj: glib::Object = mc.clone().upcast();
                     for sig in ["items-trashed", "items-restored", "items-deleted"] {
                         let exit = exit.clone();
                         let h = mc.connect_closure(
                             sig,
                             false,
-                            glib::closure_local!(move |_: crate::client::MediaClient, _: u32| {
+                            glib::closure_local!(move |_: crate::client::MediaClientV2, _: u32| {
                                 exit.activate(None);
                             }),
                         );
@@ -458,7 +458,7 @@ mod view_imp {
                         "favorite-changed",
                         false,
                         glib::closure_local!(
-                            move |_: crate::client::MediaClient, _: u32, _: bool| {
+                            move |_: crate::client::MediaClientV2, _: u32, _: bool| {
                                 exit.activate(None);
                             }
                         ),
@@ -710,7 +710,7 @@ impl PhotoGridView {
     pub fn set_store(&self, store: gio::ListStore, filter: MediaFilter) {
         let imp = self.imp();
         let media_client = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
         let bus_sender = imp.bus_sender().clone();
         let texture_cache = Rc::clone(imp.texture_cache());
@@ -818,7 +818,7 @@ impl PhotoGridView {
                 dialog.connect_response(None, move |_, response| {
                     if response == "restore" {
                         if let Some(mc) =
-                            crate::application::MomentsApplication::default().media_client()
+                            crate::application::MomentsApplication::default().media_client_v2()
                         {
                             mc.restore_all_trash();
                         }
@@ -843,7 +843,7 @@ impl PhotoGridView {
                 dialog.connect_response(None, move |_, response| {
                     if response == "delete" {
                         if let Some(mc) =
-                            crate::application::MomentsApplication::default().media_client()
+                            crate::application::MomentsApplication::default().media_client_v2()
                         {
                             mc.empty_trash();
                         }

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -194,7 +194,8 @@ mod imp {
         fn realize(&self) {
             self.parent_realize();
 
-            let Some(mc) = crate::application::MomentsApplication::default().media_client() else {
+            let Some(mc) = crate::application::MomentsApplication::default().media_client_v2()
+            else {
                 return;
             };
             let mc_obj: glib::Object = mc.clone().upcast();
@@ -203,7 +204,7 @@ mod imp {
             let h1 = mc.connect_closure(
                 "items-trashed",
                 false,
-                glib::closure_local!(move |_: crate::client::MediaClient, count: u32| {
+                glib::closure_local!(move |_: crate::client::MediaClientV2, count: u32| {
                     if let Some(sidebar) = weak1.upgrade() {
                         sidebar.adjust_trash_count(count as i32);
                     }
@@ -214,7 +215,7 @@ mod imp {
             let h2 = mc.connect_closure(
                 "items-restored",
                 false,
-                glib::closure_local!(move |_: crate::client::MediaClient, count: u32| {
+                glib::closure_local!(move |_: crate::client::MediaClientV2, count: u32| {
                     if let Some(sidebar) = weak2.upgrade() {
                         sidebar.adjust_trash_count(-(count as i32));
                     }
@@ -225,7 +226,7 @@ mod imp {
             let h3 = mc.connect_closure(
                 "items-deleted",
                 false,
-                glib::closure_local!(move |_: crate::client::MediaClient, count: u32| {
+                glib::closure_local!(move |_: crate::client::MediaClientV2, count: u32| {
                     if let Some(sidebar) = weak3.upgrade() {
                         sidebar.adjust_trash_count(-(count as i32));
                     }

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -336,7 +336,9 @@ impl VideoViewer {
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();
-                if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                if let Some(mc) =
+                    crate::application::MomentsApplication::default().media_client_v2()
+                {
                     mc.set_favorite(vec![id], new_fav);
                 }
             });
@@ -478,7 +480,7 @@ fn wire_overflow_menu(
                 items.get(idx).map(|obj| obj.item().id.clone())
             };
             let Some(id) = id else { return };
-            if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
                 mc.trash(vec![id]);
             }
             if let Some(nav_view) = viewer

--- a/src/ui/viewer/menu.rs
+++ b/src/ui/viewer/menu.rs
@@ -173,7 +173,7 @@ pub(super) fn wire_overflow_menu(
                 items.get(idx).map(|obj| obj.item().id.clone())
             };
             let Some(id) = id else { return };
-            if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+            if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
                 mc.trash(vec![id]);
             }
             if let Some(nav_view) = viewer

--- a/src/ui/viewer/mod.rs
+++ b/src/ui/viewer/mod.rs
@@ -328,7 +328,9 @@ impl PhotoViewer {
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();
-                if let Some(mc) = crate::application::MomentsApplication::default().media_client() {
+                if let Some(mc) =
+                    crate::application::MomentsApplication::default().media_client_v2()
+                {
                     mc.set_favorite(vec![id], new_fav);
                 }
             });

--- a/src/ui/window/mod.rs
+++ b/src/ui/window/mod.rs
@@ -267,7 +267,7 @@ impl MomentsWindow {
         {
             let sb = sidebar.clone();
             let media_client = crate::application::MomentsApplication::default()
-                .media_client()
+                .media_client_v2()
                 .expect("media client available");
             media_client.library_stats(move |result| {
                 if let Ok(stats) = result {
@@ -291,7 +291,7 @@ impl MomentsWindow {
         use crate::library::media::MediaFilter;
 
         let media_client = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let content_stack = gtk::Stack::new();
@@ -333,7 +333,7 @@ impl MomentsWindow {
             let bs = bus_sender.clone();
             coordinator.register_lazy("favorites", move || {
                 let mc = crate::application::MomentsApplication::default()
-                    .media_client()
+                    .media_client_v2()
                     .expect("media client available");
                 let store = mc.create_model(MediaFilter::Favorites);
                 let view = PhotoGridView::new();
@@ -352,7 +352,7 @@ impl MomentsWindow {
                 let since = chrono::Utc::now().timestamp() - days * 86400;
                 let filter = MediaFilter::RecentImports { since };
                 let mc = crate::application::MomentsApplication::default()
-                    .media_client()
+                    .media_client_v2()
                     .expect("media client available");
                 let store = mc.create_model(filter.clone());
                 let view = PhotoGridView::new();
@@ -368,7 +368,7 @@ impl MomentsWindow {
             let bs = bus_sender.clone();
             coordinator.register_lazy("trash", move || {
                 let mc = crate::application::MomentsApplication::default()
-                    .media_client()
+                    .media_client_v2()
                     .expect("media client available");
                 let store = mc.create_model(MediaFilter::Trashed);
                 let view = PhotoGridView::new();
@@ -448,7 +448,7 @@ impl MomentsWindow {
                     let album_id = AlbumId::from_raw(album_id_str.to_owned());
                     let filter = MediaFilter::Album { album_id };
                     let mc = crate::application::MomentsApplication::default()
-                        .media_client()
+                        .media_client_v2()
                         .expect("media client available");
                     let store = mc.create_model(filter.clone());
                     let view = PhotoGridView::new();


### PR DESCRIPTION
## Summary
Step 3 of the EventBus-removal epic (#587). Migrates the six media command methods (trash, restore, delete, set_favorite, empty_trash, restore_all_trash) and their four result signals from \`MediaClient\` v1 to \`MediaClientV2\`, then removes the \`subscribe_commands\` wiring.

- V2 gains \`items-trashed\`, \`items-restored\`, \`items-deleted\`, and \`favorite-changed\` signals + the matching command methods. Each command spawns the library call on Tokio and emits the result signal on the GTK thread; model reconciliation is already covered by the existing service-event listeners (\`MediaEvent::Updated\`/\`Removed\`), so the commands themselves no longer need to patch tracked models.
- 15 command call sites flipped (\`photo_grid/{action_bar,actions,mod}.rs\`, \`viewer/{menu,mod}.rs\`, \`video_viewer/mod.rs\`) and 2 signal-listener sites flipped (\`sidebar/mod.rs\`, \`photo_grid/mod.rs\`) with their closure type annotations updated.
- \`photo_grid\`'s typed \`media_client\` field flipped from \`MediaClient\` → \`MediaClientV2\`, which carries \`factory.rs\` along (only consumes \`thumbnail_path\` and \`set_favorite\`, both on V2).
- \`subscribe_commands(...)\` registration removed from \`application/mod.rs\`. The \`library/commands\` module itself stays — step 4 deletes it together with the EventBus, AppEvent, and \`MediaClient\` v1.

## Out of scope
- \`video_viewer\`'s read calls (\`original_path\`, \`media_metadata\`) intentionally stay on v1; read-path migration finishes when v1 is deleted in step 4.

## Test plan
- [x] \`make lint\` passes
- [ ] CI green (build, test, audit, deny)
- [ ] Smoke test in dev: trash → restore → delete; favourite toggle; empty trash; restore all trash; observe sidebar trash count and selection-mode auto-exit still work