### PR TITLE
refactor: finish v1 → v2 read-path migration (#587 step 4a)

### DIFF
--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -9,7 +9,7 @@ use gtk::glib;
 use gtk::prelude::*;
 use gtk::subclass::prelude::*;
 use tokio::sync::mpsc;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use super::model::MediaItemObject;
 use crate::library::album::{AlbumEvent, AlbumId};
@@ -322,6 +322,40 @@ impl MediaClientV2 {
         });
     }
 
+    /// Persist the non-destructive edit state for a media item.
+    pub fn save_edit_state(
+        &self,
+        id: &MediaId,
+        state: &EditState,
+        cb: impl FnOnce(Result<(), LibraryError>) + 'static,
+    ) {
+        let (library, tokio) = self.deps();
+        let id = id.clone();
+        let state = state.clone();
+
+        glib::MainContext::default().spawn_local(async move {
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.editing().save_edit_state(&id, &state).await
+            })
+            .await;
+            cb(result);
+        });
+    }
+
+    /// Revert edits for a media item (delete edit state from DB).
+    pub fn revert_edits(&self, id: &MediaId, cb: impl FnOnce(Result<(), LibraryError>) + 'static) {
+        let (library, tokio) = self.deps();
+        let id = id.clone();
+
+        glib::MainContext::default().spawn_local(async move {
+            let result = crate::client::spawn_on(&tokio, async move {
+                library.editing().revert_edits(&id).await
+            })
+            .await;
+            cb(result);
+        });
+    }
+
     /// Fetch library statistics (total count, totals by type, etc.).
     pub fn library_stats(&self, cb: impl FnOnce(Result<LibraryStats, LibraryError>) + 'static) {
         let (library, tokio) = self.deps();
@@ -355,18 +389,17 @@ impl MediaClientV2 {
     pub fn trash(&self, ids: Vec<MediaId>) {
         let (library, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+        let count = ids.len() as u32;
 
         glib::MainContext::default().spawn_local(async move {
-            let ids_for_call = ids.clone();
-            let result = crate::client::spawn_on(&tokio, async move {
-                library.media().trash(&ids_for_call).await
-            })
-            .await;
+            let result =
+                crate::client::spawn_on(&tokio, async move { library.media().trash(&ids).await })
+                    .await;
 
             match result {
                 Ok(()) => {
                     if let Some(client) = client_weak.upgrade() {
-                        client.emit_by_name::<()>("items-trashed", &[&(ids.len() as u32)]);
+                        client.emit_by_name::<()>("items-trashed", &[&count]);
                     }
                 }
                 Err(e) => {
@@ -381,18 +414,17 @@ impl MediaClientV2 {
     pub fn restore(&self, ids: Vec<MediaId>) {
         let (library, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+        let count = ids.len() as u32;
 
         glib::MainContext::default().spawn_local(async move {
-            let ids_for_call = ids.clone();
-            let result = crate::client::spawn_on(&tokio, async move {
-                library.media().restore(&ids_for_call).await
-            })
-            .await;
+            let result =
+                crate::client::spawn_on(&tokio, async move { library.media().restore(&ids).await })
+                    .await;
 
             match result {
                 Ok(()) => {
                     if let Some(client) = client_weak.upgrade() {
-                        client.emit_by_name::<()>("items-restored", &[&(ids.len() as u32)]);
+                        client.emit_by_name::<()>("items-restored", &[&count]);
                     }
                 }
                 Err(e) => {
@@ -404,27 +436,24 @@ impl MediaClientV2 {
     }
 
     /// Permanently delete items.
+    ///
+    /// `items-deleted` is emitted from `on_media_removed` (the
+    /// `MediaEvent::Removed` listener), not directly from this method, so
+    /// the signal also fires for the background purge task.
     pub fn delete(&self, ids: Vec<MediaId>) {
         let (library, tokio) = self.deps();
-        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
-            let ids_for_call = ids.clone();
-            let result = crate::client::spawn_on(&tokio, async move {
-                library.delete_permanently(&ids_for_call).await
-            })
-            .await;
+            let result =
+                crate::client::spawn_on(
+                    &tokio,
+                    async move { library.delete_permanently(&ids).await },
+                )
+                .await;
 
-            match result {
-                Ok(()) => {
-                    if let Some(client) = client_weak.upgrade() {
-                        client.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
-                    }
-                }
-                Err(e) => {
-                    error!("delete permanently failed: {e}");
-                    crate::client::show_error_toast(&e);
-                }
+            if let Err(e) = result {
+                error!("delete permanently failed: {e}");
+                crate::client::show_error_toast(&e);
             }
         });
     }
@@ -433,19 +462,18 @@ impl MediaClientV2 {
     pub fn set_favorite(&self, ids: Vec<MediaId>, state: bool) {
         let (library, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+        let count = ids.len() as u32;
 
         glib::MainContext::default().spawn_local(async move {
-            let ids_for_call = ids.clone();
             let result = crate::client::spawn_on(&tokio, async move {
-                library.media().set_favorite(&ids_for_call, state).await
+                library.media().set_favorite(&ids, state).await
             })
             .await;
 
             match result {
                 Ok(()) => {
                     if let Some(client) = client_weak.upgrade() {
-                        client
-                            .emit_by_name::<()>("favorite-changed", &[&(ids.len() as u32), &state]);
+                        client.emit_by_name::<()>("favorite-changed", &[&count, &state]);
                     }
                 }
                 Err(e) => {
@@ -457,9 +485,11 @@ impl MediaClientV2 {
     }
 
     /// Permanently delete every trashed item.
+    ///
+    /// `items-deleted` is emitted from `on_media_removed`, not from this
+    /// method.
     pub fn empty_trash(&self) {
         let (library, tokio) = self.deps();
-        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let result = crate::client::spawn_on(&tokio, async move {
@@ -469,21 +499,17 @@ impl MediaClientV2 {
                     .await?;
                 let ids: Vec<_> = items.into_iter().map(|i| i.id).collect();
                 if ids.is_empty() {
-                    return Ok(Vec::new());
+                    return Ok(0);
                 }
+                let count = ids.len();
                 library.delete_permanently(&ids).await?;
-                Ok(ids)
+                Ok(count)
             })
             .await;
 
             match result {
-                Ok(ids) if ids.is_empty() => {}
-                Ok(ids) => {
-                    tracing::info!(count = ids.len(), "trash emptied");
-                    if let Some(client) = client_weak.upgrade() {
-                        client.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
-                    }
-                }
+                Ok(0) => {}
+                Ok(count) => info!(count, "trash emptied"),
                 Err(e) => {
                     error!("empty trash failed: {e}");
                     crate::client::show_error_toast(&e);
@@ -515,7 +541,7 @@ impl MediaClientV2 {
             match result {
                 Ok(ids) if ids.is_empty() => {}
                 Ok(ids) => {
-                    tracing::info!(count = ids.len(), "all trash restored");
+                    info!(count = ids.len(), "all trash restored");
                     if let Some(client) = client_weak.upgrade() {
                         client.emit_by_name::<()>("items-restored", &[&(ids.len() as u32)]);
                     }
@@ -759,6 +785,10 @@ impl MediaClientV2 {
                 self.remove_item(&store, id);
             }
         }
+        // Single source of truth for `items-deleted` — fires for user
+        // deletes, `empty_trash`, AND the background purge task. Listeners
+        // (e.g. the sidebar trash badge) react to all deletion paths.
+        self.emit_by_name::<()>("items-deleted", &[&(ids.len() as u32)]);
     }
 
     fn on_thumbnail_ready(&self, id: &MediaId) {

--- a/src/ui/album_grid/mod.rs
+++ b/src/ui/album_grid/mod.rs
@@ -162,7 +162,7 @@ impl AlbumGridView {
         );
         self.wire_empty_toggle(&store);
         self.wire_create_buttons(&album_client);
-        self.wire_activation(&settings, &texture_cache, &bus_sender, &store);
+        self.wire_activation(&settings, &texture_cache, &bus_sender);
 
         imp.toolbar_view
             .insert_action_group("album", Some(&action_group));
@@ -288,7 +288,6 @@ impl AlbumGridView {
         settings: &gio::Settings,
         texture_cache: &Rc<TextureCache>,
         bus_sender: &crate::event_bus::EventSender,
-        _store: &gio::ListStore,
     ) {
         let s = settings.clone();
         let tc = Rc::clone(texture_cache);

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -189,7 +189,7 @@ impl VideoViewer {
         imp.spinner.set_visible(true);
 
         let mc = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let weak = self.downgrade();
@@ -226,7 +226,7 @@ impl VideoViewer {
 
     fn load_metadata_async(&self, gen: u64, id: MediaId) {
         let mc = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let weak = self.downgrade();

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -248,7 +248,7 @@ impl EditPanel {
             if session.state.is_identity() {
                 let id_log = id.clone();
                 let mc = crate::application::MomentsApplication::default()
-                    .media_client()
+                    .media_client_v2()
                     .expect("media client available");
                 mc.revert_edits(&id, move |result| match result {
                     Ok(()) => debug!(media_id = %id_log, reason, "delete identity edit state"),
@@ -271,7 +271,7 @@ impl EditPanel {
         imp.save_in_flight.set(true);
         let id_log = id.clone();
         let mc = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let weak = self.downgrade();
@@ -422,7 +422,7 @@ impl EditPanel {
             if let Some(id) = id {
                 let id_log = id.clone();
                 let mc = crate::application::MomentsApplication::default()
-                    .media_client()
+                    .media_client_v2()
                     .expect("media client available");
                 mc.revert_edits(&id, move |result| match result {
                     Ok(()) => debug!(media_id = %id_log, "revert edits"),

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -18,7 +18,7 @@ impl PhotoViewer {
         imp.spinner.set_visible(true);
 
         let media_client = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let pipeline = match crate::application::MomentsApplication::default().render_pipeline() {
@@ -139,7 +139,7 @@ impl PhotoViewer {
         let tokio = crate::application::MomentsApplication::default().tokio_handle();
 
         let media_client = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let pipeline = match crate::application::MomentsApplication::default().render_pipeline() {
@@ -248,7 +248,7 @@ impl PhotoViewer {
 
     pub(super) fn load_metadata_async(&self, gen: u64, id: crate::library::media::MediaId) {
         let media_client = crate::application::MomentsApplication::default()
-            .media_client()
+            .media_client_v2()
             .expect("media client available");
 
         let weak = self.downgrade();


### PR DESCRIPTION
## Summary
First half of step 4 of the EventBus-removal epic (#587). Wraps up the read-path migration so that nothing references \`MediaClient\` v1 outside of \`MomentsApplication\`'s singleton storage. Step 4b will delete v1, the EventBus, AppEvent, and \`library/commands\`, and strip \`EventSender\` from the sync handlers, purge task, and viewer widgets — closes #580.

### V2 additions
- \`save_edit_state\` / \`revert_edits\` mirroring v1's callback signatures.

### V2 internal cleanup (#596 review carry-over)
- 4 command methods (\`trash\`, \`restore\`, \`delete\`, \`set_favorite\`) now capture \`count\` before the spawn rather than cloning the \`ids\` vec.
- \`info\` added to the \`use tracing\` import; drop qualified \`tracing::info!\`.

### UI flips (8 call sites)
- \`ui/viewer/loading.rs\` — \`original_path\`, \`get_edit_state\`, \`media_metadata\`
- \`ui/viewer/edit_panel/mod.rs\` — \`save_edit_state\`, \`revert_edits\`, etc.
- \`ui/video_viewer/mod.rs\` — \`original_path\`, \`media_metadata\`

### Sidebar trash badge fix
\`items-deleted\` is now emitted from \`on_media_removed\` (the \`MediaEvent::Removed\` listener) rather than directly from V2's \`delete\`/\`empty_trash\`. Single source of truth — fires for user deletes, \`empty_trash\`, **and** the background purge task. Closes the staleness gap flagged in #596 review.

### Misc
- Drop dead \`_store\` parameter from \`album_grid::wire_activation\` (unused after the sort-coordinate fix in #596).

## Test plan
- [x] \`make lint\` passes
- [x] \`make test\` — 445 unit tests pass
- [ ] Smoke test: open photo viewer (load original + edit panel), open video viewer; toggle favourite, trash, delete, empty trash; observe sidebar trash badge updates correctly