### PR TITLE
chore: add shared VS Code workspace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,11 @@ flatpak-build-dev/
 *.db-shm
 
 # Editor files
-.vscode/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/tasks.json
+!.vscode/settings.json
+!.vscode/launch.json
 .idea/
 *.swp
 *.swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer",
+    "bodil.blueprint-gtk",
+    "vadimcn.vscode-lldb",
+    "mesonbuild.mesonbuild",
+    "tamasfe.even-better-toml",
+    "fill-labs.dependi"
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,68 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "run-dev",
+      "type": "shell",
+      "command": "make run-dev",
+      "group": { "kind": "build", "isDefault": true },
+      "problemMatcher": ["$rustc"],
+      "presentation": { "reveal": "always", "panel": "dedicated" }
+    },
+    {
+      "label": "run",
+      "type": "shell",
+      "command": "make run",
+      "group": "build",
+      "problemMatcher": ["$rustc"],
+      "presentation": { "reveal": "always", "panel": "dedicated" }
+    },
+    {
+      "label": "check",
+      "type": "shell",
+      "command": "make check",
+      "group": "build",
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "make lint",
+      "group": "test",
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "test",
+      "type": "shell",
+      "command": "make test",
+      "group": { "kind": "test", "isDefault": true },
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "test-integration",
+      "type": "shell",
+      "command": "make test-integration",
+      "group": "test",
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "ci-all",
+      "type": "shell",
+      "command": "make ci-all",
+      "group": "test",
+      "problemMatcher": ["$rustc"]
+    },
+    {
+      "label": "fmt",
+      "type": "shell",
+      "command": "make fmt",
+      "problemMatcher": []
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "make clean",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Recommend the six VS Code extensions used for this project (`rust-analyzer`, `bodil.blueprint-gtk`, `vadimcn.vscode-lldb`, `mesonbuild.mesonbuild`, `tamasfe.even-better-toml`, `fill-labs.dependi`) — contributors get prompted on first open.
- Wire `make` targets as VS Code tasks: `run-dev` (default build, `Ctrl+Shift+B`), `test` (default test), plus `run`, `check`, `lint`, `test-integration`, `ci-all`, `fmt`, `clean`. All use the `$rustc` problem matcher so cargo/clippy errors are clickable.
- Adjust `.gitignore` to share `extensions.json` / `tasks.json` / `settings.json` / `launch.json` while keeping per-user `.vscode` files local.

## Test plan

- [ ] Open the repo in VS Code; verify the "Recommended extensions" prompt appears
- [ ] `Ctrl+Shift+B` runs `make run-dev`
- [ ] `Ctrl+Shift+P` → "Tasks: Run Test Task" runs `make test`
- [ ] Trigger a clippy warning; confirm it's clickable from the Problems panel