### PR TITLE
fix(immich): send original_filename when uploading assets

### DIFF
--- a/src/sync/providers/immich/client.rs
+++ b/src/sync/providers/immich/client.rs
@@ -304,9 +304,16 @@ impl ImmichClient {
     }
 
     /// Upload an asset via multipart form-data.
+    ///
+    /// `filename` must be the original user-facing filename (e.g.
+    /// `IMG_1234.jpg`). It is sent in the multipart `Content-Disposition`
+    /// header so Immich can infer the asset's media type from the
+    /// extension. The on-disk path may be extensionless (UUID-sharded
+    /// originals layout) so we cannot derive it from `file_path`.
     pub(crate) async fn upload_asset(
         &self,
         file_path: &std::path::Path,
+        filename: &str,
         device_asset_id: &str,
         file_created_at: &str,
         file_modified_at: &str,
@@ -314,16 +321,10 @@ impl ImmichClient {
     ) -> Result<UploadResponse, LibraryError> {
         let url = self.url("/assets");
 
-        let file_name = file_path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("upload")
-            .to_owned();
-
         let file_bytes = tokio::fs::read(file_path).await.map_err(LibraryError::Io)?;
 
         let file_part = reqwest::multipart::Part::bytes(file_bytes)
-            .file_name(file_name)
+            .file_name(filename.to_owned())
             .mime_str("application/octet-stream")
             .map_err(|e| LibraryError::Immich(format!("invalid mime type: {e}")))?;
 

--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -309,10 +309,17 @@ impl PushManager {
             )));
         }
 
+        // Originals are stored at extensionless UUID-sharded paths, so
+        // `path.file_name()` yields a bare UUID with no clue to the
+        // file type. Immich infers media type from the multipart
+        // filename's extension, so we must send the user-facing
+        // `original_filename` (e.g. `IMG_1234.jpg`) instead.
+        let filename = self.lookup_original_filename(&entry.entity_id).await?;
+
         let now = chrono::Utc::now().to_rfc3339();
         let resp = self
             .client
-            .upload_asset(path, &entry.entity_id, &now, &now, None)
+            .upload_asset(path, &filename, &entry.entity_id, &now, &now, None)
             .await?;
 
         // Store the server-assigned ID as external_id.
@@ -392,7 +399,29 @@ impl PushManager {
         Ok(())
     }
 
-    // ── External ID lookups ─────────────────────────────────────────
+    // ── Media row lookups ───────────────────────────────────────────
+
+    /// Fetch the user-facing original filename for an asset.
+    ///
+    /// Required for upload — Immich keys media-type detection off the
+    /// multipart filename's extension, and the extensionless UUID-sharded
+    /// path on disk doesn't carry one.
+    async fn lookup_original_filename(&self, local_id: &str) -> Result<String, LibraryError> {
+        let row: Option<(String,)> =
+            sqlx::query_as("SELECT original_filename FROM media WHERE id = ?")
+                .bind(local_id)
+                .fetch_optional(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
+
+        match row {
+            Some((name,)) if !name.is_empty() => Ok(name),
+            Some(_) => Err(LibraryError::Immich(format!(
+                "media has empty original_filename: {local_id}"
+            ))),
+            None => Err(LibraryError::Immich(format!("media not found: {local_id}"))),
+        }
+    }
 
     async fn lookup_media_external_id(&self, local_id: &str) -> Result<String, LibraryError> {
         let row: Option<(String,)> =
@@ -747,6 +776,46 @@ mod tests {
         let result = push.lookup_media_external_id("nonexistent").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("media not found"));
+    }
+
+    #[tokio::test]
+    async fn lookup_original_filename_returns_stored_name() {
+        let (_dir, db) = setup_push_db().await;
+
+        let mut record = test_record(MediaId::new("local-1".to_string()));
+        record.original_filename = "IMG_1234.jpg".to_string();
+        db.upsert_media(&record).await.unwrap();
+
+        let push = make_push_manager(db).await;
+        let name = push.lookup_original_filename("local-1").await.unwrap();
+        assert_eq!(name, "IMG_1234.jpg");
+    }
+
+    #[tokio::test]
+    async fn lookup_original_filename_missing_returns_error() {
+        let (_dir, db) = setup_push_db().await;
+        let push = make_push_manager(db).await;
+
+        let result = push.lookup_original_filename("nope").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("media not found"));
+    }
+
+    #[tokio::test]
+    async fn lookup_original_filename_empty_returns_error() {
+        let (_dir, db) = setup_push_db().await;
+
+        let mut record = test_record(MediaId::new("local-empty".to_string()));
+        record.original_filename = String::new();
+        db.upsert_media(&record).await.unwrap();
+
+        let push = make_push_manager(db).await;
+        let result = push.lookup_original_filename("local-empty").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("empty original_filename"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Originals are stored at extensionless UUID-sharded paths, so `path.file_name()` returns a bare hex UUID
- Multipart uploads sent that as the filename with mime `application/octet-stream`, leaving Immich no signal to infer media type
- Every upload was rejected with `400 Bad Request: Unsupported file type <uuid>`

`upload_asset` now takes an explicit `filename` parameter; `push_asset_import` looks up `original_filename` from the media table (e.g. `IMG_1234.jpg`) before calling it. Immich infers the type from the extension and uploads succeed.

This was discovered while testing #602's retry/backoff work — the new outbox machinery surfaced a permanent error that was previously silently re-attempted forever.

## Test plan
- [ ] On Immich backend, import a new file from the local filesystem
- [ ] Watch sync log: \`asset uploaded\` debug line at info/debug level (was previously \`push failed ... 400 Bad Request\`)
- [ ] Confirm the asset appears on the Immich web UI with the correct preview
- [ ] Run a previously-failing import (with the file still on disk) and confirm it succeeds on next push cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)