### PR TITLE
fix: wire person thumbnails directory into FacesService

### DIFF
--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -23,7 +23,7 @@ use crate::library::recorder::MutationRecorder;
 #[derive(Clone)]
 pub struct FacesService {
     repo: FacesRepository,
-    thumbnails_dir: Option<std::path::PathBuf>,
+    thumbnails_dir: std::path::PathBuf,
     recorder: Arc<dyn MutationRecorder>,
     events: EventEmitter<FacesEvent>,
 }
@@ -31,11 +31,14 @@ pub struct FacesService {
 impl FacesService {
     /// Create a faces service backed by a database.
     ///
-    /// Pass `thumbnails_dir` for backends that store person thumbnails
-    /// (Immich). Pass `None` for backends without face detection (local).
+    /// `thumbnails_dir` is the bundle's thumbnails root — person face
+    /// thumbnails are stored under `{thumbnails_dir}/people/{id}.jpg`
+    /// by the sync handler and read back by [`Self::person_thumbnail_path`].
+    /// Local backends pass the same dir even though they never write into
+    /// it; that keeps the contract uniform across backends.
     pub fn new(
         db: Database,
-        thumbnails_dir: Option<std::path::PathBuf>,
+        thumbnails_dir: std::path::PathBuf,
         recorder: Arc<dyn MutationRecorder>,
     ) -> Self {
         Self {
@@ -236,9 +239,12 @@ impl FacesService {
         Ok(())
     }
 
+    /// Return the on-disk path of a person's face thumbnail, if it has
+    /// been downloaded. Returns `None` when the file is missing — UI
+    /// callers fall back to rendering the person's initials.
     pub fn person_thumbnail_path(&self, person_id: &PersonId) -> Option<std::path::PathBuf> {
-        let dir = self.thumbnails_dir.as_ref()?;
-        let path = dir
+        let path = self
+            .thumbnails_dir
             .join("people")
             .join(format!("{}.jpg", person_id.as_str()));
         if path.exists() {
@@ -246,5 +252,45 @@ impl FacesService {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::library::db::test_helpers::open_test_db;
+    use crate::sync::outbox::NoOpRecorder;
+
+    async fn make_service(thumbnails_dir: std::path::PathBuf) -> (tempfile::TempDir, FacesService) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let svc = FacesService::new(db, thumbnails_dir, Arc::new(NoOpRecorder));
+        (dir, svc)
+    }
+
+    /// Sync handler writes to `{thumbnails_dir}/people/{id}.jpg`; the
+    /// service must read from the same location (#611).
+    #[tokio::test]
+    async fn person_thumbnail_path_returns_file_when_present() {
+        let thumb_root = tempfile::tempdir().unwrap();
+        let people_dir = thumb_root.path().join("people");
+        std::fs::create_dir_all(&people_dir).unwrap();
+        let person_id = PersonId::from_raw("person-uuid".to_string());
+        let thumb_file = people_dir.join("person-uuid.jpg");
+        std::fs::write(&thumb_file, b"jpeg bytes").unwrap();
+
+        let (_dir, svc) = make_service(thumb_root.path().to_path_buf()).await;
+        let result = svc.person_thumbnail_path(&person_id);
+        assert_eq!(result, Some(thumb_file));
+    }
+
+    /// No file on disk → None, so the UI falls back to initials.
+    #[tokio::test]
+    async fn person_thumbnail_path_returns_none_when_absent() {
+        let thumb_root = tempfile::tempdir().unwrap();
+        let person_id = PersonId::from_raw("never-downloaded".to_string());
+
+        let (_dir, svc) = make_service(thumb_root.path().to_path_buf()).await;
+        assert!(svc.person_thumbnail_path(&person_id).is_none());
     }
 }

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -63,7 +63,7 @@ impl Library {
         db.open(&db_path).await?;
 
         let albums = AlbumService::new(db.clone(), Arc::clone(&recorder));
-        let faces = FacesService::new(db.clone(), None, Arc::clone(&recorder));
+        let faces = FacesService::new(db.clone(), bundle.thumbnails.clone(), Arc::clone(&recorder));
         let editing = EditingService::new(db.clone());
         let media = MediaService::new(
             db.clone(),


### PR DESCRIPTION
## Summary
- People view shows initials only on the Immich backend (#611)
- The Immich pull handler downloads each person's face thumbnail to \`{thumbnails_dir}/people/{id}.jpg\`, but \`FacesService\` was constructed with \`thumbnails_dir: None\` in \`Library::open\`
- \`person_thumbnail_path()\` therefore returned \`None\` for every person, regardless of whether the file existed on disk

## Fix
- Pass \`bundle.thumbnails.clone()\` into \`FacesService::new\`
- Simplify the parameter from \`Option<PathBuf>\` to \`PathBuf\` — the optional shape was the footgun that hid this. Local backends pass the same dir even though they never write into it; that keeps the contract uniform.

## Test plan
- [ ] On Immich backend with detected faces: open People view → tiles render face thumbnails (no initials)
- [ ] Existing previously-synced libraries also render thumbnails on next launch (the on-disk files were already there; only the lookup was broken)
- [ ] Local backend: no regression — face detection is disabled, so no person rows exist to look up

🤖 Generated with [Claude Code](https://claude.com/claude-code)