### PR TITLE
fix(renderer): RAW thumbnails skip full demosaic via DecodeHint

### DIFF
--- a/src/renderer/decode.rs
+++ b/src/renderer/decode.rs
@@ -11,12 +11,16 @@ use image::DynamicImage;
 use tracing::instrument;
 
 use crate::renderer::error::RenderError;
-use crate::renderer::format::FormatRegistry;
+use crate::renderer::format::{DecodeHint, FormatRegistry};
 
 /// Decode an image from a file path using magic-byte detection.
 #[instrument(skip(formats))]
-pub fn decode(path: &Path, formats: &Arc<FormatRegistry>) -> Result<DynamicImage, RenderError> {
-    formats.decode(path)
+pub fn decode(
+    path: &Path,
+    formats: &Arc<FormatRegistry>,
+    hint: DecodeHint,
+) -> Result<DynamicImage, RenderError> {
+    formats.decode(path, hint)
 }
 
 #[cfg(test)]
@@ -48,14 +52,14 @@ mod tests {
         let path = write_test_jpeg(dir.path(), "no_extension");
         let formats = test_formats();
 
-        let img = decode(&path, &formats).unwrap();
+        let img = decode(&path, &formats, DecodeHint::Full).unwrap();
         assert_eq!((img.width(), img.height()), (100, 50));
     }
 
     #[test]
     fn decode_missing_file_returns_error() {
         let formats = test_formats();
-        let result = decode(Path::new("/nonexistent/photo"), &formats);
+        let result = decode(Path::new("/nonexistent/photo"), &formats, DecodeHint::Full);
         assert!(result.is_err());
     }
 }

--- a/src/renderer/format/mod.rs
+++ b/src/renderer/format/mod.rs
@@ -4,5 +4,5 @@ pub(crate) mod registry;
 pub(crate) mod standard;
 pub(crate) mod video;
 
-pub(crate) use registry::FormatRegistry;
 pub use registry::VIDEO_EXTENSIONS;
+pub(crate) use registry::{DecodeHint, FormatRegistry};

--- a/src/renderer/format/raw.rs
+++ b/src/renderer/format/raw.rs
@@ -4,16 +4,20 @@ use rawler::decoders::RawDecodeParams;
 use rawler::rawsource::RawSource;
 
 use crate::renderer::error::RenderError;
-use crate::renderer::format::registry::FormatHandler;
+use crate::renderer::format::registry::{DecodeHint, FormatHandler};
 
 /// Decodes RAW camera files via the `rawler` crate.
 ///
-/// Attempts to extract an embedded JPEG preview in this order:
-///   1. `thumbnail_image` — smallest embedded preview
-///   2. `preview_image`   — larger embedded preview
+/// The decode chain order depends on [`DecodeHint`]:
 ///
-/// Thumbnails are cached on disk after import, so the decode cost is
-/// paid only once per asset.
+/// * [`DecodeHint::Full`] — `full_image` (full demosaic) → `preview_image`
+///   → `thumbnail_image`. Used by the viewer's full-resolution path so
+///   editing operations work on real sensor data when available.
+/// * [`DecodeHint::Thumbnail`] — `thumbnail_image` → `preview_image` →
+///   `full_image`. Used by the import thumbnail pipeline. The embedded
+///   JPEGs are typically 160-2048 px and decode in milliseconds with a
+///   ~5 MB transient allocation, vs ~150 MB+ for a 50 MP demosaic. See
+///   issue #617.
 pub struct RawHandler;
 
 impl FormatHandler for RawHandler {
@@ -27,7 +31,7 @@ impl FormatHandler for RawHandler {
         ]
     }
 
-    fn decode(&self, path: &Path) -> Result<image::DynamicImage, RenderError> {
+    fn decode(&self, path: &Path, hint: DecodeHint) -> Result<image::DynamicImage, RenderError> {
         let source = RawSource::new(path)
             .map_err(|e| RenderError::DecodeFailed(format!("failed to open RAW file: {e}")))?;
 
@@ -36,28 +40,45 @@ impl FormatHandler for RawHandler {
 
         let params = RawDecodeParams::default();
 
-        // Full demosaicing — highest quality. Thumbnails are cached on disk
-        // so this cost is paid only once per import.
-        if let Some(img) = decoder
-            .full_image(&source, &params)
-            .map_err(|e| RenderError::DecodeFailed(format!("RAW full decode failed: {e}")))?
-        {
-            return Ok(img);
-        }
+        let thumb = || {
+            decoder.thumbnail_image(&source, &params).map_err(|e| {
+                RenderError::DecodeFailed(format!("RAW thumbnail extraction failed: {e}"))
+            })
+        };
+        let preview = || {
+            decoder.preview_image(&source, &params).map_err(|e| {
+                RenderError::DecodeFailed(format!("RAW preview extraction failed: {e}"))
+            })
+        };
+        let full = || {
+            decoder
+                .full_image(&source, &params)
+                .map_err(|e| RenderError::DecodeFailed(format!("RAW full decode failed: {e}")))
+        };
 
-        // Embedded full-size preview — fast fallback if demosaic unavailable.
-        if let Some(img) = decoder
-            .preview_image(&source, &params)
-            .map_err(|e| RenderError::DecodeFailed(format!("RAW preview extraction failed: {e}")))?
-        {
-            return Ok(img);
-        }
-
-        // Last resort: smallest embedded thumbnail.
-        if let Some(img) = decoder.thumbnail_image(&source, &params).map_err(|e| {
-            RenderError::DecodeFailed(format!("RAW thumbnail extraction failed: {e}"))
-        })? {
-            return Ok(img);
+        match hint {
+            DecodeHint::Thumbnail => {
+                if let Some(img) = thumb()? {
+                    return Ok(img);
+                }
+                if let Some(img) = preview()? {
+                    return Ok(img);
+                }
+                if let Some(img) = full()? {
+                    return Ok(img);
+                }
+            }
+            DecodeHint::Full => {
+                if let Some(img) = full()? {
+                    return Ok(img);
+                }
+                if let Some(img) = preview()? {
+                    return Ok(img);
+                }
+                if let Some(img) = thumb()? {
+                    return Ok(img);
+                }
+            }
         }
 
         Err(RenderError::DecodeFailed(

--- a/src/renderer/format/raw.rs
+++ b/src/renderer/format/raw.rs
@@ -56,34 +56,32 @@ impl FormatHandler for RawHandler {
                 .map_err(|e| RenderError::DecodeFailed(format!("RAW full decode failed: {e}")))
         };
 
+        // Fall through past `Err(...)` from earlier options too — rawler
+        // can fail on a particular embedded JPEG or demosaic variant while
+        // a different path on the same file still works. Only the last
+        // option in each chain propagates its error, so a useful message
+        // surfaces when nothing succeeded.
         match hint {
             DecodeHint::Thumbnail => {
-                if let Some(img) = thumb()? {
+                if let Ok(Some(img)) = thumb() {
                     return Ok(img);
                 }
-                if let Some(img) = preview()? {
+                if let Ok(Some(img)) = preview() {
                     return Ok(img);
                 }
-                if let Some(img) = full()? {
-                    return Ok(img);
-                }
+                full()?
             }
             DecodeHint::Full => {
-                if let Some(img) = full()? {
+                if let Ok(Some(img)) = full() {
                     return Ok(img);
                 }
-                if let Some(img) = preview()? {
+                if let Ok(Some(img)) = preview() {
                     return Ok(img);
                 }
-                if let Some(img) = thumb()? {
-                    return Ok(img);
-                }
+                thumb()?
             }
         }
-
-        Err(RenderError::DecodeFailed(
-            "RAW decoder returned no image".to_string(),
-        ))
+        .ok_or_else(|| RenderError::DecodeFailed("RAW decoder returned no image".to_string()))
     }
 }
 

--- a/src/renderer/format/registry.rs
+++ b/src/renderer/format/registry.rs
@@ -14,6 +14,22 @@ pub const VIDEO_EXTENSIONS: &[&str] = &[
     "mp4", "mov", "m4v", "mkv", "webm", "avi", "mts", "m2ts", "3gp",
 ];
 
+/// Hint to decoders about the size the caller actually needs.
+///
+/// Some formats (notably RAW) have multiple decode paths with very different
+/// cost: a full sensor demosaic produces a sensor-resolution image and a
+/// large transient allocation, while an embedded JPEG preview is small and
+/// almost free. When the caller only wants a thumbnail, decoders should
+/// prefer the cheap path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecodeHint {
+    /// Best quality available (e.g. full demosaic for RAW). Used by the
+    /// viewer's full-resolution path.
+    Full,
+    /// Smallest acceptable result. Used by the thumbnail pipeline.
+    Thumbnail,
+}
+
 /// Decodes image files of a specific set of formats into a [`image::DynamicImage`].
 ///
 /// Implement this trait for each format family (standard, RAW, etc.) and
@@ -24,7 +40,11 @@ pub trait FormatHandler: Send + Sync {
     fn extensions(&self) -> &[&str];
 
     /// Decode the file at `path` to a [`image::DynamicImage`].
-    fn decode(&self, path: &Path) -> Result<image::DynamicImage, RenderError>;
+    ///
+    /// `hint` lets the handler pick a cheaper decode path when only a
+    /// thumbnail is needed; handlers may ignore it if they have only one
+    /// decode path.
+    fn decode(&self, path: &Path, hint: DecodeHint) -> Result<image::DynamicImage, RenderError>;
 }
 
 /// Single source of truth for all supported image formats.
@@ -64,16 +84,20 @@ impl FormatRegistry {
     ///
     /// Returns [`RenderError::DecodeFailed`] if no handler is registered or
     /// decoding fails.
-    pub fn decode(&self, path: &Path) -> Result<image::DynamicImage, RenderError> {
+    pub fn decode(
+        &self,
+        path: &Path,
+        hint: DecodeHint,
+    ) -> Result<image::DynamicImage, RenderError> {
         // Try magic-byte detection first (works for extensionless files).
         if let Some(handler) = self.handler_by_magic(path) {
-            match handler.decode(path) {
+            match handler.decode(path, hint) {
                 Ok(img) => return Ok(img),
                 Err(_) => {
                     // Magic-byte match failed (e.g. TIFF header but actually
                     // a RAW format). Try all other handlers.
                     for other in self.handlers.values() {
-                        if let Ok(img) = other.decode(path) {
+                        if let Ok(img) = other.decode(path, hint) {
                             return Ok(img);
                         }
                     }
@@ -93,7 +117,7 @@ impl FormatRegistry {
             .get(&ext)
             .ok_or_else(|| RenderError::FormatNotRecognised(path.to_path_buf()))?;
 
-        handler.decode(path)
+        handler.decode(path, hint)
     }
 
     /// Try to find a handler by reading magic bytes from the file.
@@ -183,14 +207,37 @@ impl FormatRegistry {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::Mutex;
 
     struct FakeHandler;
     impl FormatHandler for FakeHandler {
         fn extensions(&self) -> &[&str] {
             &["fake"]
         }
-        fn decode(&self, _path: &Path) -> Result<image::DynamicImage, RenderError> {
+        fn decode(
+            &self,
+            _path: &Path,
+            _hint: DecodeHint,
+        ) -> Result<image::DynamicImage, RenderError> {
             Err(RenderError::DecodeFailed("fake handler".into()))
+        }
+    }
+
+    /// Records the hint passed to `decode` so tests can assert it.
+    struct RecordingHandler {
+        last_hint: Arc<Mutex<Option<DecodeHint>>>,
+    }
+    impl FormatHandler for RecordingHandler {
+        fn extensions(&self) -> &[&str] {
+            &["rec"]
+        }
+        fn decode(
+            &self,
+            _path: &Path,
+            hint: DecodeHint,
+        ) -> Result<image::DynamicImage, RenderError> {
+            *self.last_hint.lock().unwrap() = Some(hint);
+            Err(RenderError::DecodeFailed("recording handler".into()))
         }
     }
 
@@ -213,7 +260,9 @@ mod tests {
     #[test]
     fn decode_returns_error_for_unknown_extension() {
         let reg = FormatRegistry::new();
-        let err = reg.decode(&PathBuf::from("photo.jpg")).unwrap_err();
+        let err = reg
+            .decode(&PathBuf::from("photo.jpg"), DecodeHint::Full)
+            .unwrap_err();
         assert!(matches!(err, RenderError::FormatNotRecognised(_)));
     }
 
@@ -265,6 +314,22 @@ mod tests {
             reg.media_type_with_sniff(f.path(), "fake"),
             Some(MediaType::Video),
         );
+    }
+
+    #[test]
+    fn decode_forwards_hint_to_handler() {
+        let last_hint = Arc::new(Mutex::new(None));
+        let handler = Arc::new(RecordingHandler {
+            last_hint: Arc::clone(&last_hint),
+        });
+        let mut reg = FormatRegistry::new();
+        reg.register(handler);
+
+        let _ = reg.decode(&PathBuf::from("photo.rec"), DecodeHint::Thumbnail);
+        assert_eq!(*last_hint.lock().unwrap(), Some(DecodeHint::Thumbnail));
+
+        let _ = reg.decode(&PathBuf::from("photo.rec"), DecodeHint::Full);
+        assert_eq!(*last_hint.lock().unwrap(), Some(DecodeHint::Full));
     }
 
     #[test]

--- a/src/renderer/format/standard.rs
+++ b/src/renderer/format/standard.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::renderer::error::RenderError;
-use crate::renderer::format::registry::FormatHandler;
+use crate::renderer::format::registry::{DecodeHint, FormatHandler};
 
 /// Decodes all formats supported by the [`image`] crate via `image::open`.
 ///
@@ -15,7 +15,11 @@ impl FormatHandler for StandardHandler {
         &["jpg", "jpeg", "png", "webp", "tiff", "tif", "heic", "heif"]
     }
 
-    fn decode(&self, path: &Path) -> Result<image::DynamicImage, RenderError> {
+    fn decode(&self, path: &Path, _hint: DecodeHint) -> Result<image::DynamicImage, RenderError> {
+        // The hint is ignored for now. JPEG DCT-scale decoding (1/2, 1/4, 1/8)
+        // would let us honour DecodeHint::Thumbnail at near-zero cost — see
+        // issue #617 follow-up.
+        //
         // Use Reader with format guessing instead of image::open() so that
         // extensionless files (UUID-sharded originals) are decoded via magic
         // bytes rather than relying on the file extension.

--- a/src/renderer/format/video.rs
+++ b/src/renderer/format/video.rs
@@ -8,7 +8,7 @@ use tracing::{debug, instrument, warn};
 use crate::renderer::error::RenderError;
 use crate::renderer::orientation::apply_orientation;
 
-use super::registry::{FormatHandler, VIDEO_EXTENSIONS};
+use super::registry::{DecodeHint, FormatHandler, VIDEO_EXTENSIONS};
 
 /// Extracts a poster frame from video files via GStreamer.
 ///
@@ -24,7 +24,7 @@ impl FormatHandler for VideoHandler {
     }
 
     #[instrument(skip(self), fields(path = %path.display()))]
-    fn decode(&self, path: &Path) -> Result<image::DynamicImage, RenderError> {
+    fn decode(&self, path: &Path, _hint: DecodeHint) -> Result<image::DynamicImage, RenderError> {
         extract_poster_frame(path)
     }
 }

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -18,7 +18,7 @@ use tracing::instrument;
 use crate::library::editing::EditState;
 use crate::library::media::MediaType;
 use crate::renderer::error::RenderError;
-use crate::renderer::format::FormatRegistry;
+use crate::renderer::format::{DecodeHint, FormatRegistry};
 
 /// What size to render.
 #[derive(Debug, Clone)]
@@ -81,7 +81,13 @@ impl RenderPipeline {
         options: &RenderOptions<'_>,
     ) -> Result<DynamicImage, RenderError> {
         // Step 1: Decode — detect format from magic bytes, dispatch to handler.
-        let img = super::decode::decode(path, &self.formats)?;
+        // Map RenderSize → DecodeHint so RAW (and future format-specific
+        // optimisations) can pick a cheaper decode path for thumbnails.
+        let hint = match options.size {
+            RenderSize::FullRes => DecodeHint::Full,
+            RenderSize::Thumbnail(_) => DecodeHint::Thumbnail,
+        };
+        let img = super::decode::decode(path, &self.formats, hint)?;
 
         // Step 2: Orient — apply EXIF rotation/flip (skips video and HEIF).
         let img = super::orientation::orient(path, img, &self.formats);


### PR DESCRIPTION
## Summary

- Adds `DecodeHint::{Full, Thumbnail}` to `FormatHandler::decode` and threads it through the render pipeline.
- `RawHandler` inverts its fallback chain on `Thumbnail` (`thumbnail_image → preview_image → full_image`), so import-time thumbnails use the embedded JPEG preview (a few MB) instead of demosaicing the full sensor (~150 MB for 50 MP).
- Full-resolution viewer path is unchanged — `RenderSize::FullRes` maps to `DecodeHint::Full`, keeping the demosaic-first chain so editing still gets real sensor data when available.
- `StandardHandler` and `VideoHandler` accept and ignore the hint. JPEG DCT-scale decoding is noted as a follow-up.
- New registry test verifies the hint propagates to handlers.

Closes #617. Likely mitigates #594 (initial-import OOM/RSS climb).

## Test plan

- [x] `make lint` clean
- [x] `make test` — 461 passed
- [ ] Manual: `make run-dev`, import a folder of RAW files, observe `VmHWM` for the running process. Pre-fix it climbed to ≈ sensor-resolution × 3 bytes per file; post-fix it should stay near the embedded-preview size.
- [ ] Manual: open a RAW file in the full-resolution viewer to confirm the demosaic path still runs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)