### PR TITLE
fix(immich): use EXIF capture time + file mtime on upload, not Utc::now()

### DIFF
--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -359,10 +359,19 @@ impl PushManager {
         // `original_filename` (e.g. `IMG_1234.jpg`) instead.
         let filename = self.lookup_original_filename(&entry.entity_id).await?;
 
-        let now = chrono::Utc::now().to_rfc3339();
+        let (file_created_at, file_modified_at) = self
+            .lookup_upload_timestamps(&entry.entity_id, path)
+            .await?;
         let resp = self
             .client
-            .upload_asset(path, &filename, &entry.entity_id, &now, &now, None)
+            .upload_asset(
+                path,
+                &filename,
+                &entry.entity_id,
+                &file_created_at,
+                &file_modified_at,
+                None,
+            )
             .await?;
 
         // Store the server-assigned ID as external_id.
@@ -505,6 +514,43 @@ impl PushManager {
             ))),
             None => Err(LibraryError::Immich(format!("media not found: {local_id}"))),
         }
+    }
+
+    /// Resolve the timestamps Immich expects on upload.
+    ///
+    /// Returns `(file_created_at, file_modified_at)` as RFC 3339 strings:
+    /// - `file_created_at` — capture time, sourced from `media.taken_at`
+    ///   (set by the importer from EXIF DateTimeOriginal). Falls back to the
+    ///   file's on-disk mtime when EXIF is missing — matches what Immich
+    ///   would derive for itself, and avoids `Utc::now()` collapsing the
+    ///   whole library onto today's timeline. See issue #616.
+    /// - `file_modified_at` — the on-disk file's mtime.
+    async fn lookup_upload_timestamps(
+        &self,
+        local_id: &str,
+        path: &std::path::Path,
+    ) -> Result<(String, String), LibraryError> {
+        let row: Option<(Option<i64>,)> = sqlx::query_as("SELECT taken_at FROM media WHERE id = ?")
+            .bind(local_id)
+            .fetch_optional(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+
+        let taken_at = row
+            .ok_or_else(|| LibraryError::Immich(format!("media not found: {local_id}")))?
+            .0;
+
+        let mtime = tokio::fs::metadata(path)
+            .await
+            .and_then(|m| m.modified())
+            .map_err(LibraryError::Io)?;
+        let modified_at: chrono::DateTime<chrono::Utc> = mtime.into();
+
+        let created_at = taken_at
+            .and_then(|secs| chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0))
+            .unwrap_or(modified_at);
+
+        Ok((created_at.to_rfc3339(), modified_at.to_rfc3339()))
     }
 
     async fn lookup_media_external_id(&self, local_id: &str) -> Result<String, LibraryError> {
@@ -995,6 +1041,84 @@ mod tests {
         let result = push.lookup_original_filename("nope").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("media not found"));
+    }
+
+    #[tokio::test]
+    async fn lookup_upload_timestamps_uses_taken_at_when_set() {
+        let (_dir, db) = setup_push_db().await;
+
+        // 2023-06-15T12:34:56Z
+        let taken_at_secs: i64 = 1_686_832_496;
+        let mut record = test_record(MediaId::new("local-1".to_string()));
+        record.taken_at = Some(taken_at_secs);
+        db.upsert_media(&record).await.unwrap();
+
+        // Real on-disk file so the metadata() call succeeds.
+        let file = tempfile::NamedTempFile::new().unwrap();
+
+        let push = make_push_manager(db).await;
+        let (created, modified) = push
+            .lookup_upload_timestamps("local-1", file.path())
+            .await
+            .unwrap();
+
+        // file_created_at must reflect the EXIF capture time, not Utc::now().
+        let parsed = chrono::DateTime::parse_from_rfc3339(&created).unwrap();
+        assert_eq!(parsed.timestamp(), taken_at_secs);
+
+        // file_modified_at must parse and be close to the file's actual mtime.
+        let parsed_mod = chrono::DateTime::parse_from_rfc3339(&modified).unwrap();
+        let now = chrono::Utc::now().timestamp();
+        assert!((now - parsed_mod.timestamp()).abs() < 60);
+    }
+
+    #[tokio::test]
+    async fn lookup_upload_timestamps_falls_back_to_mtime_when_taken_at_null() {
+        let (_dir, db) = setup_push_db().await;
+
+        // taken_at is None by default in test_record.
+        let record = test_record(MediaId::new("local-2".to_string()));
+        assert!(record.taken_at.is_none());
+        db.upsert_media(&record).await.unwrap();
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+
+        let push = make_push_manager(db).await;
+        let (created, modified) = push
+            .lookup_upload_timestamps("local-2", file.path())
+            .await
+            .unwrap();
+
+        // Without EXIF, both timestamps should equal the file mtime — matches
+        // what Immich would derive on its own.
+        assert_eq!(created, modified);
+    }
+
+    #[tokio::test]
+    async fn lookup_upload_timestamps_missing_media_returns_error() {
+        let (_dir, db) = setup_push_db().await;
+        let file = tempfile::NamedTempFile::new().unwrap();
+
+        let push = make_push_manager(db).await;
+        let result = push
+            .lookup_upload_timestamps("nonexistent", file.path())
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("media not found"));
+    }
+
+    #[tokio::test]
+    async fn lookup_upload_timestamps_missing_file_returns_error() {
+        let (_dir, db) = setup_push_db().await;
+
+        let record = test_record(MediaId::new("local-3".to_string()));
+        db.upsert_media(&record).await.unwrap();
+
+        let push = make_push_manager(db).await;
+        let result = push
+            .lookup_upload_timestamps("local-3", std::path::Path::new("/nonexistent/file"))
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -357,11 +357,8 @@ impl PushManager {
         // file type. Immich infers media type from the multipart
         // filename's extension, so we must send the user-facing
         // `original_filename` (e.g. `IMG_1234.jpg`) instead.
-        let filename = self.lookup_original_filename(&entry.entity_id).await?;
-
-        let (file_created_at, file_modified_at) = self
-            .lookup_upload_timestamps(&entry.entity_id, path)
-            .await?;
+        let (filename, file_created_at, file_modified_at) =
+            self.lookup_upload_metadata(&entry.entity_id, path).await?;
         let resp = self
             .client
             .upload_asset(
@@ -494,51 +491,42 @@ impl PushManager {
 
     // ── Media row lookups ───────────────────────────────────────────
 
-    /// Fetch the user-facing original filename for an asset.
+    /// Fetch everything Immich needs to upload an asset.
     ///
-    /// Required for upload — Immich keys media-type detection off the
-    /// multipart filename's extension, and the extensionless UUID-sharded
-    /// path on disk doesn't carry one.
-    async fn lookup_original_filename(&self, local_id: &str) -> Result<String, LibraryError> {
-        let row: Option<(String,)> =
-            sqlx::query_as("SELECT original_filename FROM media WHERE id = ?")
+    /// Returns `(original_filename, file_created_at, file_modified_at)`:
+    /// - `original_filename` — the user-facing filename (e.g.
+    ///   `IMG_1234.jpg`). Immich keys media-type detection off the
+    ///   multipart filename's extension, and the extensionless
+    ///   UUID-sharded path on disk doesn't carry one.
+    /// - `file_created_at` (RFC 3339) — capture time, sourced from
+    ///   `media.taken_at` (set by the importer from EXIF
+    ///   DateTimeOriginal). Falls back to the file's on-disk mtime when
+    ///   EXIF is missing — matches what Immich would derive for itself,
+    ///   and avoids `Utc::now()` collapsing the whole library onto
+    ///   today's timeline. See issue #616.
+    /// - `file_modified_at` (RFC 3339) — the on-disk file's mtime.
+    ///
+    /// One DB roundtrip per asset; the outbox push path was previously
+    /// running two `WHERE id = ?` selects against the same row.
+    async fn lookup_upload_metadata(
+        &self,
+        local_id: &str,
+        path: &std::path::Path,
+    ) -> Result<(String, String, String), LibraryError> {
+        let row: Option<(String, Option<i64>)> =
+            sqlx::query_as("SELECT original_filename, taken_at FROM media WHERE id = ?")
                 .bind(local_id)
                 .fetch_optional(self.db.pool())
                 .await
                 .map_err(LibraryError::Db)?;
 
-        match row {
-            Some((name,)) if !name.is_empty() => Ok(name),
-            Some(_) => Err(LibraryError::Immich(format!(
+        let (filename, taken_at) =
+            row.ok_or_else(|| LibraryError::Immich(format!("media not found: {local_id}")))?;
+        if filename.is_empty() {
+            return Err(LibraryError::Immich(format!(
                 "media has empty original_filename: {local_id}"
-            ))),
-            None => Err(LibraryError::Immich(format!("media not found: {local_id}"))),
+            )));
         }
-    }
-
-    /// Resolve the timestamps Immich expects on upload.
-    ///
-    /// Returns `(file_created_at, file_modified_at)` as RFC 3339 strings:
-    /// - `file_created_at` — capture time, sourced from `media.taken_at`
-    ///   (set by the importer from EXIF DateTimeOriginal). Falls back to the
-    ///   file's on-disk mtime when EXIF is missing — matches what Immich
-    ///   would derive for itself, and avoids `Utc::now()` collapsing the
-    ///   whole library onto today's timeline. See issue #616.
-    /// - `file_modified_at` — the on-disk file's mtime.
-    async fn lookup_upload_timestamps(
-        &self,
-        local_id: &str,
-        path: &std::path::Path,
-    ) -> Result<(String, String), LibraryError> {
-        let row: Option<(Option<i64>,)> = sqlx::query_as("SELECT taken_at FROM media WHERE id = ?")
-            .bind(local_id)
-            .fetch_optional(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-
-        let taken_at = row
-            .ok_or_else(|| LibraryError::Immich(format!("media not found: {local_id}")))?
-            .0;
 
         let mtime = tokio::fs::metadata(path)
             .await
@@ -546,11 +534,26 @@ impl PushManager {
             .map_err(LibraryError::Io)?;
         let modified_at: chrono::DateTime<chrono::Utc> = mtime.into();
 
-        let created_at = taken_at
-            .and_then(|secs| chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0))
-            .unwrap_or(modified_at);
+        let created_at = match taken_at {
+            Some(secs) => match chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0) {
+                Some(dt) => dt,
+                None => {
+                    // Out-of-range epoch — DB row is corrupted somehow.
+                    // Fall back to mtime so the upload still succeeds, but
+                    // surface a warning so a future "wrong date" report
+                    // has a breadcrumb.
+                    warn!(
+                        media_id = %local_id,
+                        taken_at = secs,
+                        "taken_at is out of range for chrono::DateTime; falling back to file mtime"
+                    );
+                    modified_at
+                }
+            },
+            None => modified_at,
+        };
 
-        Ok((created_at.to_rfc3339(), modified_at.to_rfc3339()))
+        Ok((filename, created_at.to_rfc3339(), modified_at.to_rfc3339()))
     }
 
     async fn lookup_media_external_id(&self, local_id: &str) -> Result<String, LibraryError> {
@@ -1021,35 +1024,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_original_filename_returns_stored_name() {
-        let (_dir, db) = setup_push_db().await;
-
-        let mut record = test_record(MediaId::new("local-1".to_string()));
-        record.original_filename = "IMG_1234.jpg".to_string();
-        db.upsert_media(&record).await.unwrap();
-
-        let push = make_push_manager(db).await;
-        let name = push.lookup_original_filename("local-1").await.unwrap();
-        assert_eq!(name, "IMG_1234.jpg");
-    }
-
-    #[tokio::test]
-    async fn lookup_original_filename_missing_returns_error() {
-        let (_dir, db) = setup_push_db().await;
-        let push = make_push_manager(db).await;
-
-        let result = push.lookup_original_filename("nope").await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("media not found"));
-    }
-
-    #[tokio::test]
-    async fn lookup_upload_timestamps_uses_taken_at_when_set() {
+    async fn lookup_upload_metadata_uses_taken_at_when_set() {
         let (_dir, db) = setup_push_db().await;
 
         // 2023-06-15T12:34:56Z
         let taken_at_secs: i64 = 1_686_832_496;
         let mut record = test_record(MediaId::new("local-1".to_string()));
+        record.original_filename = "IMG_1234.jpg".to_string();
         record.taken_at = Some(taken_at_secs);
         db.upsert_media(&record).await.unwrap();
 
@@ -1057,10 +1038,12 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
 
         let push = make_push_manager(db).await;
-        let (created, modified) = push
-            .lookup_upload_timestamps("local-1", file.path())
+        let (filename, created, modified) = push
+            .lookup_upload_metadata("local-1", file.path())
             .await
             .unwrap();
+
+        assert_eq!(filename, "IMG_1234.jpg");
 
         // file_created_at must reflect the EXIF capture time, not Utc::now().
         let parsed = chrono::DateTime::parse_from_rfc3339(&created).unwrap();
@@ -1073,7 +1056,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_upload_timestamps_falls_back_to_mtime_when_taken_at_null() {
+    async fn lookup_upload_metadata_falls_back_to_mtime_when_taken_at_null() {
         let (_dir, db) = setup_push_db().await;
 
         // taken_at is None by default in test_record.
@@ -1084,8 +1067,8 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
 
         let push = make_push_manager(db).await;
-        let (created, modified) = push
-            .lookup_upload_timestamps("local-2", file.path())
+        let (_filename, created, modified) = push
+            .lookup_upload_metadata("local-2", file.path())
             .await
             .unwrap();
 
@@ -1095,20 +1078,42 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_upload_timestamps_missing_media_returns_error() {
+    async fn lookup_upload_metadata_falls_back_to_mtime_when_taken_at_out_of_range() {
+        let (_dir, db) = setup_push_db().await;
+
+        // Way out of chrono's representable range. from_timestamp returns None.
+        let mut record = test_record(MediaId::new("local-bogus".to_string()));
+        record.taken_at = Some(i64::MAX);
+        db.upsert_media(&record).await.unwrap();
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+
+        let push = make_push_manager(db).await;
+        let (_filename, created, modified) = push
+            .lookup_upload_metadata("local-bogus", file.path())
+            .await
+            .unwrap();
+
+        // Corrupt taken_at must not propagate as the upload timestamp;
+        // fall back to mtime so the upload still succeeds.
+        assert_eq!(created, modified);
+    }
+
+    #[tokio::test]
+    async fn lookup_upload_metadata_missing_media_returns_error() {
         let (_dir, db) = setup_push_db().await;
         let file = tempfile::NamedTempFile::new().unwrap();
 
         let push = make_push_manager(db).await;
         let result = push
-            .lookup_upload_timestamps("nonexistent", file.path())
+            .lookup_upload_metadata("nonexistent", file.path())
             .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("media not found"));
     }
 
     #[tokio::test]
-    async fn lookup_upload_timestamps_missing_file_returns_error() {
+    async fn lookup_upload_metadata_missing_file_returns_error() {
         let (_dir, db) = setup_push_db().await;
 
         let record = test_record(MediaId::new("local-3".to_string()));
@@ -1116,21 +1121,24 @@ mod tests {
 
         let push = make_push_manager(db).await;
         let result = push
-            .lookup_upload_timestamps("local-3", std::path::Path::new("/nonexistent/file"))
+            .lookup_upload_metadata("local-3", std::path::Path::new("/nonexistent/file"))
             .await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn lookup_original_filename_empty_returns_error() {
+    async fn lookup_upload_metadata_empty_filename_returns_error() {
         let (_dir, db) = setup_push_db().await;
 
         let mut record = test_record(MediaId::new("local-empty".to_string()));
         record.original_filename = String::new();
         db.upsert_media(&record).await.unwrap();
 
+        let file = tempfile::NamedTempFile::new().unwrap();
         let push = make_push_manager(db).await;
-        let result = push.lookup_original_filename("local-empty").await;
+        let result = push
+            .lookup_upload_metadata("local-empty", file.path())
+            .await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()


### PR DESCRIPTION
## Summary

- `push_asset_import` was sending `chrono::Utc::now()` for both `fileCreatedAt` and `fileModifiedAt`, so every uploaded asset landed on today's date in the Immich timeline regardless of when it was actually taken. Backfilling an older library collapsed it onto a single day.
- New `lookup_upload_timestamps(local_id, path)` helper returns RFC 3339 strings from the right sources:
  - `file_created_at` ← `media.taken_at` (set by the importer from EXIF DateTimeOriginal). Falls back to file mtime when EXIF is missing — matches what Immich would derive itself.
  - `file_modified_at` ← file mtime via `tokio::fs::metadata`.
- Four new unit tests cover the EXIF-set path, the mtime-fallback path, missing media row, and missing file.

Closes #616.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 464 passed (4 new tests for `lookup_upload_timestamps`)
- [ ] Manual: upload an asset with a known `taken_at` to a fresh Immich instance, confirm it appears on the correct day in the Immich timeline.
- [ ] Manual: upload an asset with no EXIF and confirm it lands on the file's mtime, not today.

## Notes

Existing assets uploaded with the wrong timestamps can be corrected via Immich's own bulk-edit — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)