### PR TITLE
fix(sync): preserve local imported_at across pull-sync upserts

### DIFF
--- a/src/library/db/migrations/020_add_media_external_id_index.sql
+++ b/src/library/db/migrations/020_add_media_external_id_index.sql
@@ -1,0 +1,7 @@
+-- Index media.external_id so the sync upsert path doesn't full-scan
+-- the table on every asset. Two queries hit external_id per upsert:
+--   - SELECT imported_at WHERE id = ? OR external_id = ? (added in #614)
+--   - DELETE FROM media WHERE external_id = ? AND id != ? (#610)
+-- Both are run once per asset during pull-sync, so a 10k-photo library
+-- doing a full sync was previously paying 20k full table scans.
+CREATE INDEX IF NOT EXISTS idx_media_external_id ON media(external_id);

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -340,7 +340,29 @@ impl MediaRepository {
     /// Without this, the UI would still hold a model item keyed on the
     /// local id even though the row has been replaced server-side
     /// (issue #610).
+    ///
+    /// `imported_at` is treated as a **local-only** field: when an existing
+    /// row is being replaced (matched by id, or by external_id during the
+    /// local→server UUID swap), its `imported_at` is preserved instead of
+    /// being overwritten by the incoming value. This stops sync from
+    /// retroactively rewriting "when this asset entered my library" to
+    /// the server's `file_created_at` (the photo's capture time), which
+    /// would silently move assets out of the Recent Imports view (issue #614).
     pub async fn upsert(&self, record: &MediaRecord) -> Result<Option<MediaId>, LibraryError> {
+        // Capture the existing local row's imported_at — by id (plain
+        // update) or by external_id (local→server UUID swap). At most one
+        // row matches in practice; if both somehow do, take the id match.
+        let existing_imported_at: Option<i64> = sqlx::query_scalar(
+            "SELECT imported_at FROM media
+             WHERE id = ?1 OR external_id = ?1
+             ORDER BY (id = ?1) DESC LIMIT 1",
+        )
+        .bind(record.id.as_str())
+        .fetch_optional(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        let imported_at = existing_imported_at.unwrap_or(record.imported_at);
+
         // Atomic delete-and-return so the replaced-id observation can
         // never disagree with the row that was actually removed. SQLite
         // 3.35+ supports RETURNING; sqlx surfaces it via fetch_optional.
@@ -366,7 +388,7 @@ impl MediaRepository {
         .bind(&record.relative_path)
         .bind(&record.original_filename)
         .bind(record.file_size)
-        .bind(record.imported_at)
+        .bind(imported_at)
         .bind(record.media_type as i64)
         .bind(record.taken_at)
         .bind(record.width)
@@ -668,6 +690,53 @@ mod tests {
 
         let replaced = repo.upsert(&record).await.unwrap();
         assert!(replaced.is_none());
+    }
+
+    /// Re-syncing an existing asset must not overwrite its `imported_at` —
+    /// that field belongs to the local library's view of "when did this
+    /// arrive", not the server's view of "when was it captured". See #614.
+    #[tokio::test]
+    async fn upsert_preserves_imported_at_for_existing_id() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+        let id = MediaId::new("e".repeat(64));
+
+        let mut record = test_record(id.clone());
+        record.imported_at = 1_700_000_000; // original local import
+        repo.insert(&record).await.unwrap();
+
+        // Pull-sync upserts with a much older capture-time-derived value
+        // (what the asset handler used to do).
+        record.imported_at = 1_400_000_000;
+        repo.upsert(&record).await.unwrap();
+
+        let item = repo.get(&id).await.unwrap().unwrap();
+        assert_eq!(item.imported_at, 1_700_000_000);
+    }
+
+    /// Local→server UUID swap: the new server-keyed row inherits the local
+    /// row's `imported_at` rather than starting fresh, so the freshly
+    /// round-tripped asset stays in the Recent Imports view (#614).
+    #[tokio::test]
+    async fn upsert_preserves_imported_at_across_external_id_swap() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let local_id = MediaId::new("local-uuid-eeeeeeeeeeeeeeeeeeee".to_string());
+        let server_id = MediaId::new("server-uuid-ffffffffffffffffffff".to_string());
+
+        let mut local = test_record(local_id.clone());
+        local.external_id = Some(server_id.as_str().to_string());
+        local.imported_at = 1_700_000_000;
+        repo.insert(&local).await.unwrap();
+
+        let mut from_server = test_record(server_id.clone());
+        from_server.external_id = Some(server_id.as_str().to_string());
+        from_server.imported_at = 1_400_000_000;
+        repo.upsert(&from_server).await.unwrap();
+
+        let item = repo.get(&server_id).await.unwrap().unwrap();
+        assert_eq!(item.imported_at, 1_700_000_000);
     }
 
     #[tokio::test]

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -43,8 +43,14 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
     let taken_at =
         parse_datetime(&asset.local_date_time).or_else(|| parse_datetime(&asset.file_created_at));
 
-    let imported_at =
-        parse_datetime(&asset.file_created_at).unwrap_or_else(|| chrono::Utc::now().timestamp());
+    // `imported_at` means "when did this asset enter the local library", not
+    // "when was the photo taken". For a row we've never seen, that's now;
+    // for a row that already exists, the repository preserves the prior
+    // value during upsert. See issue #614 — previously this was set to the
+    // server's `file_created_at`, which Immich's own EXIF-extraction job
+    // overwrites with the photo's capture date, silently moving assets
+    // out of the Recent Imports view as soon as they round-tripped.
+    let imported_at = chrono::Utc::now().timestamp();
 
     let is_trashed = asset.deleted_at.is_some();
     let trashed_at = parse_datetime(&asset.deleted_at);


### PR DESCRIPTION
## Summary

Photo grid stops at a fraction of the imported count after import + sync round-trips (~34 of 326). Root cause: sync conflates two concepts.

The pull-side asset handler was setting the local row's \`imported_at\` to the asset's \`file_created_at\` from the server. Immich's metadata-extraction job overwrites \`file_created_at\` with the photo's actual EXIF capture date, so on first round-trip every asset's \`imported_at\` silently became the time the photo was **taken**, not the time it entered the library. The Recent Imports view filters on \`imported_at > now - N days\` and quietly dropped everything older than that.

\`imported_at\` is a local-only field. Two changes enforce that invariant:

- **\`repository::upsert\`** preserves \`imported_at\` from any existing row (matched by \`id\`, or by \`external_id\` during the local→server UUID swap), falling back to the incoming value only for genuinely-new rows.
- **\`handlers::asset\`** sets incoming \`imported_at\` to \`Utc::now()\`; the upsert preserves the prior value on update, so the field correctly captures *"when did this asset enter my local library"* in both the first-time-from-server and round-trip cases.

Closes #614.

## Test plan

- [x] \`make lint\` clean
- [x] \`make test\` — 462 passed
- [x] New tests:
  - \`upsert_preserves_imported_at_for_existing_id\` — re-syncing doesn't rewrite \`imported_at\`
  - \`upsert_preserves_imported_at_across_external_id_swap\` — local→server UUID swap carries the original \`imported_at\` forward
- [ ] Manual: import N photos against the Immich backend, wait for round-trip, verify the grid converges to N items in Recent Imports.

## Note on existing data

Pre-existing rows that already have wrong \`imported_at\` values (set to capture time by the buggy handler) will **stay wrong** under the new logic — the upsert preserves whatever's there. Per project convention there's no data-fix migration in this PR. To recover, wipe the local library and re-sync, or run a one-off SQL update. Worth revisiting if we want to ship with a data-fix migration once the app is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)