### PR TITLE
fix(immich): surface keyring failures instead of empty token

### DIFF
--- a/src/application/keyring.rs
+++ b/src/application/keyring.rs
@@ -51,6 +51,38 @@ pub fn lookup_access_token(server_url: &str) -> Result<Option<String>, String> {
     Ok(secret.map(|s| s.to_string()))
 }
 
+/// Why an Immich session token could not be resolved at startup.
+///
+/// Distinguishes the three states callers need to surface differently:
+/// a legitimately missing entry (user must sign in again), an empty
+/// stored value (treated as missing), and a keyring/D-Bus failure
+/// (system-level problem the user should see).
+#[derive(Debug)]
+pub enum TokenError {
+    /// No keyring entry exists for this server, or the stored value
+    /// was empty.
+    Missing,
+    /// libsecret returned an error (e.g. D-Bus unavailable, locked
+    /// collection, schema mismatch). The string is the underlying error.
+    KeyringFailed(String),
+}
+
+/// Resolve an Immich session token from the keyring, collapsing the
+/// three keyring outcomes into a strict `Ok(non-empty token)` /
+/// `Err(reason)` shape so call sites cannot accidentally pass an
+/// empty string downstream.
+pub fn resolve_immich_token(server_url: &str) -> Result<String, TokenError> {
+    map_lookup_result(lookup_access_token(server_url))
+}
+
+fn map_lookup_result(result: Result<Option<String>, String>) -> Result<String, TokenError> {
+    match result {
+        Ok(Some(token)) if !token.is_empty() => Ok(token),
+        Ok(_) => Err(TokenError::Missing),
+        Err(e) => Err(TokenError::KeyringFailed(e)),
+    }
+}
+
 /// Delete a stored Immich session token from the GNOME Keyring.
 #[allow(dead_code)] // Will be called by logout flow (not yet implemented)
 #[instrument(fields(server_url = %server_url))]
@@ -82,5 +114,29 @@ mod tests {
     fn schema_has_correct_name() {
         let s = schema();
         let _ = format!("{s:?}");
+    }
+
+    #[test]
+    fn map_lookup_present_returns_ok() {
+        let r = map_lookup_result(Ok(Some("abc".into())));
+        assert!(matches!(r, Ok(t) if t == "abc"));
+    }
+
+    #[test]
+    fn map_lookup_empty_string_treated_as_missing() {
+        let r = map_lookup_result(Ok(Some(String::new())));
+        assert!(matches!(r, Err(TokenError::Missing)));
+    }
+
+    #[test]
+    fn map_lookup_none_is_missing() {
+        let r = map_lookup_result(Ok(None));
+        assert!(matches!(r, Err(TokenError::Missing)));
+    }
+
+    #[test]
+    fn map_lookup_error_is_keyring_failed() {
+        let r = map_lookup_result(Err("dbus down".into()));
+        assert!(matches!(r, Err(TokenError::KeyringFailed(e)) if e == "dbus down"));
     }
 }

--- a/src/application/keyring.rs
+++ b/src/application/keyring.rs
@@ -57,13 +57,15 @@ pub fn lookup_access_token(server_url: &str) -> Result<Option<String>, String> {
 /// a legitimately missing entry (user must sign in again), an empty
 /// stored value (treated as missing), and a keyring/D-Bus failure
 /// (system-level problem the user should see).
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum TokenError {
     /// No keyring entry exists for this server, or the stored value
     /// was empty.
+    #[error("no keyring entry for the configured Immich server")]
     Missing,
     /// libsecret returned an error (e.g. D-Bus unavailable, locked
     /// collection, schema mismatch). The string is the underlying error.
+    #[error("keyring lookup failed: {0}")]
     KeyringFailed(String),
 }
 
@@ -111,7 +113,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn schema_has_correct_name() {
+    fn schema_constructs_without_panic() {
         let s = schema();
         let _ = format!("{s:?}");
     }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -406,15 +406,41 @@ impl MomentsApplication {
         };
 
         // For Immich configs, inject the session token from the keyring.
+        // The setup wizard stores the token before emitting setup-complete,
+        // so a failure here means the keyring became unavailable between
+        // store and lookup — surface it rather than booting the user into a
+        // library that can never authenticate.
         let config = match config {
             LibraryConfig::Immich { server_url, .. } => {
-                let access_token = keyring::lookup_access_token(&server_url)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_default();
-                LibraryConfig::Immich {
-                    server_url,
-                    access_token,
+                match keyring::resolve_immich_token(&server_url) {
+                    Ok(access_token) => LibraryConfig::Immich {
+                        server_url,
+                        access_token,
+                    },
+                    Err(err) => {
+                        let (heading, body) = match err {
+                            keyring::TokenError::Missing => (
+                                gettext("Sign in required"),
+                                gettext(
+                                    "The session token saved during setup could not be read back. Please try signing in again.",
+                                ),
+                            ),
+                            keyring::TokenError::KeyringFailed(e) => {
+                                error!(
+                                    "keyring lookup failed immediately after setup: {e}"
+                                );
+                                (
+                                    gettext("Could not access the system keyring"),
+                                    format!(
+                                        "{}\n\nDetails: {e}",
+                                        gettext("Moments stored your session in the keyring but could not read it back. Please check your keyring service and try again.")
+                                    ),
+                                )
+                            }
+                        };
+                        show_library_error_dialog(setup_win, &heading, &body);
+                        return;
+                    }
                 }
             }
             other => other,
@@ -466,15 +492,44 @@ impl MomentsApplication {
         };
 
         // For Immich configs, inject the session token from the keyring.
+        // If the token cannot be resolved, refuse to load the library — passing
+        // an empty string downstream produces opaque 401 toasts and keeps the
+        // outbox spinning. Bounce the user back to the setup window with an
+        // explanation instead.
         let config = match config {
             LibraryConfig::Immich { server_url, .. } => {
-                let access_token = keyring::lookup_access_token(&server_url)
-                    .ok()
-                    .flatten()
-                    .unwrap_or_default();
-                LibraryConfig::Immich {
-                    server_url,
-                    access_token,
+                match keyring::resolve_immich_token(&server_url) {
+                    Ok(access_token) => LibraryConfig::Immich {
+                        server_url,
+                        access_token,
+                    },
+                    Err(err) => {
+                        let settings = self.imp().settings.get().expect("settings initialised");
+                        if let Err(e) = settings.set_string("library-path", "") {
+                            error!("failed to clear stale library path: {e}");
+                        }
+                        let setup_win = self.show_setup_window();
+                        let (heading, body) = match err {
+                            keyring::TokenError::Missing => (
+                                gettext("Sign in required"),
+                                gettext(
+                                    "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
+                                ),
+                            ),
+                            keyring::TokenError::KeyringFailed(e) => {
+                                error!("keyring lookup failed during open_library: {e}");
+                                (
+                                    gettext("Could not access the system keyring"),
+                                    format!(
+                                        "{}\n\nDetails: {e}",
+                                        gettext("Moments could not read your saved Immich session. Please sign in again or check your keyring service.")
+                                    ),
+                                )
+                            }
+                        };
+                        show_library_error_dialog(&setup_win, &heading, &body);
+                        return;
+                    }
                 }
             }
             other => other,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -504,25 +504,34 @@ impl MomentsApplication {
                         access_token,
                     },
                     Err(err) => {
-                        let settings = self.imp().settings.get().expect("settings initialised");
-                        if let Err(e) = settings.set_string("library-path", "") {
-                            error!("failed to clear stale library path: {e}");
-                        }
+                        // Only `Missing` warrants clearing `library-path`: the
+                        // user has no credential for this server and must
+                        // re-run setup. `KeyringFailed` is typically transient
+                        // (D-Bus race during session start, locked collection
+                        // prompt timeout) — leave the saved path intact so a
+                        // simple relaunch recovers once the keyring is healthy.
                         let setup_win = self.show_setup_window();
                         let (heading, body) = match err {
-                            keyring::TokenError::Missing => (
-                                gettext("Sign in required"),
-                                gettext(
-                                    "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
-                                ),
-                            ),
+                            keyring::TokenError::Missing => {
+                                let settings =
+                                    self.imp().settings.get().expect("settings initialised");
+                                if let Err(e) = settings.set_string("library-path", "") {
+                                    error!("failed to clear stale library path: {e}");
+                                }
+                                (
+                                    gettext("Sign in required"),
+                                    gettext(
+                                        "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
+                                    ),
+                                )
+                            }
                             keyring::TokenError::KeyringFailed(e) => {
                                 error!("keyring lookup failed during open_library: {e}");
                                 (
                                     gettext("Could not access the system keyring"),
                                     format!(
                                         "{}\n\nDetails: {e}",
-                                        gettext("Moments could not read your saved Immich session. Please sign in again or check your keyring service.")
+                                        gettext("Moments could not read your saved Immich session. Try restarting the app once your keyring service is available, or sign in again to continue.")
                                     ),
                                 )
                             }

--- a/src/ui/setup_window/immich_setup_page.rs
+++ b/src/ui/setup_window/immich_setup_page.rs
@@ -219,12 +219,22 @@ impl MomentsImmichSetupPage {
             return;
         }
 
-        // Capture the keyring state *before* writing the new token. This lets
-        // us distinguish a fresh setup from a re-setup triggered by the
-        // "sign in required" path in `open_library` (issue #605): in that
-        // path the bundle on disk is still valid but the keyring entry is
-        // missing, so reusing the existing bundle is the correct behaviour.
+        // Decide whether this is a fresh setup, a #605 re-sign-in (keyring
+        // missing but bundle still valid), or an unwanted overwrite of a
+        // configured library — *before* mutating any persistent state, so an
+        // error path leaves the keyring untouched.
+        let bundle_path = default_immich_library_path();
         let had_existing_token = keyring::resolve_immich_token(&server_url).is_ok();
+        if bundle_path.exists() && had_existing_token {
+            // Bundle and keyring entry both already existed — refuse to
+            // silently overwrite. The user likely re-ran setup against a
+            // working library by mistake.
+            let msg = format!("Library already exists at {}", bundle_path.display());
+            error!("{msg}");
+            imp.status_label.set_text(&msg);
+            imp.status_label.add_css_class("error");
+            return;
+        }
 
         // Store session token in GNOME Keyring.
         if let Err(e) = keyring::store_access_token(&server_url, &access_token) {
@@ -236,22 +246,11 @@ impl MomentsImmichSetupPage {
         }
 
         // Create (or reuse) the Immich bundle.
-        let bundle_path = default_immich_library_path();
         let config = LibraryConfig::Immich {
             server_url,
             access_token,
         };
         if bundle_path.exists() {
-            if had_existing_token {
-                // Bundle and keyring entry both already existed — refuse to
-                // silently overwrite. The user likely re-ran setup against a
-                // working library by mistake.
-                let msg = format!("Library already exists at {}", bundle_path.display());
-                error!("{msg}");
-                imp.status_label.set_text(&msg);
-                imp.status_label.add_css_class("error");
-                return;
-            }
             info!(
                 path = %bundle_path.display(),
                 "reusing existing Immich bundle (post sign-in re-setup)",

--- a/src/ui/setup_window/immich_setup_page.rs
+++ b/src/ui/setup_window/immich_setup_page.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::glib;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, info, instrument};
 
 use crate::application::keyring;
 use crate::library::bundle::Bundle;
@@ -219,6 +219,13 @@ impl MomentsImmichSetupPage {
             return;
         }
 
+        // Capture the keyring state *before* writing the new token. This lets
+        // us distinguish a fresh setup from a re-setup triggered by the
+        // "sign in required" path in `open_library` (issue #605): in that
+        // path the bundle on disk is still valid but the keyring entry is
+        // missing, so reusing the existing bundle is the correct behaviour.
+        let had_existing_token = keyring::resolve_immich_token(&server_url).is_ok();
+
         // Store session token in GNOME Keyring.
         if let Err(e) = keyring::store_access_token(&server_url, &access_token) {
             error!("failed to store access token: {e}");
@@ -228,13 +235,28 @@ impl MomentsImmichSetupPage {
             return;
         }
 
-        // Create the Immich bundle.
+        // Create (or reuse) the Immich bundle.
         let bundle_path = default_immich_library_path();
         let config = LibraryConfig::Immich {
             server_url,
             access_token,
         };
-        if let Err(e) = Bundle::create(&bundle_path, &config) {
+        if bundle_path.exists() {
+            if had_existing_token {
+                // Bundle and keyring entry both already existed — refuse to
+                // silently overwrite. The user likely re-ran setup against a
+                // working library by mistake.
+                let msg = format!("Library already exists at {}", bundle_path.display());
+                error!("{msg}");
+                imp.status_label.set_text(&msg);
+                imp.status_label.add_css_class("error");
+                return;
+            }
+            info!(
+                path = %bundle_path.display(),
+                "reusing existing Immich bundle (post sign-in re-setup)",
+            );
+        } else if let Err(e) = Bundle::create(&bundle_path, &config) {
             error!("failed to create Immich bundle: {e}");
             imp.status_label
                 .set_text(&format!("Failed to create library: {e}"));


### PR DESCRIPTION
## Summary

Closes #605.

\`open_library\` and \`on_setup_complete\` previously collapsed all three keyring outcomes (token present, no entry, libsecret error) into an empty-string path via \`.ok().flatten().unwrap_or_default()\`. \`ImmichClient::new\` then built \`Authorization: Bearer \` and the user got opaque 401 → \"Server unreachable\" toasts forever while the outbox kept retrying.

- New \`TokenError { Missing, KeyringFailed(String) }\` + \`resolve_immich_token\` helper in \`src/application/keyring.rs\` — empty stored values are treated as \`Missing\`.
- \`open_library\` / \`on_setup_complete\` now refuse to construct \`LibraryConfig::Immich\` with an empty token. On failure they show an \`AlertDialog\` whose copy depends on which keyring outcome happened (the libsecret OS error is included for \`KeyringFailed\`).
- Setup page handles the bundle-already-exists case so the bounce-back flow actually completes: reuse the existing bundle when the keyring entry was missing on entry to the wizard; keep the current error when both bundle and keyring entry already existed (don't silently overwrite a configured library).

## Test plan
- [x] \`make lint\` / \`make test\` (4 new unit tests for the keyring mapping logic)
- [x] Manual: \`secret-tool clear server_url <immich-url>\` → restart → setup window with \"Sign in required\" dialog → re-sign-in → main window loads, no 401 spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)