### PR TITLE
fix(sync): keep MediaId stable across upload→pull round-trip (#626)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,18 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,20 +149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
-]
-
-[[package]]
-name = "blake3"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures",
 ]
 
 [[package]]
@@ -314,12 +288,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -2120,7 +2088,7 @@ name = "moments"
 version = "0.3.0"
 dependencies = [
  "async-trait",
- "blake3",
+ "base64",
  "chrono",
  "futures-util",
  "gettext-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ futures-util = "0.3"
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "macros", "migrate"] }
-blake3 = "1"
 
 # Observability
 tracing = "0.1"
@@ -57,9 +56,14 @@ serde_json = "1"
 libsecret = "0.9"
 
 # Utilities
-# Used for Immich protocol compatibility (asset deduplication checksums).
-# Not used for any security function.
+# Content hashing for dedup. SHA-1 + base64 matches Immich's `checksum`
+# wire format, so locally-imported and server-pulled rows share the
+# same `media.content_hash` column and dedup symmetrically (#626 fix).
+# SHA-1 is sufficient for accidental-collision detection in a personal
+# photo library — `content_hash` is never the asset's identity (that's
+# a UUID), so this is not a security-sensitive use of the algorithm.
 sha1 = "0.10"
+base64 = "0.22"
 thiserror = "2"
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,48 @@ metrics:
 	@rust-code-analysis-cli --metrics -O json -p src/ 2>/dev/null | \
 	python3 scripts/complexity-report.py
 
+# ── Debug a hung process ────────────────────────────────────────────────────
+#
+# Usage: make stack [PID=<pid>]
+#
+# When the dev app hangs (no CPU activity, no log progress), this target
+# attaches gdb from the GNOME SDK runtime and dumps a 30-frame backtrace
+# for every thread. Auto-detects the PID by matching the dev app id; pass
+# PID=… explicitly if more than one moments process is running.
+#
+# Example: a CR2 import sat forever on `typefind:sink`; `make stack` over
+# the same process showed `gst::Pipeline::set_state` / `pull_sample` in
+# seconds and named the deadlock unambiguously.
+
+stack:
+	@PID="$${PID:-$$(pgrep -f io.github.justinf555.Moments.Devel | tail -1)}"; \
+	if [ -z "$$PID" ]; then \
+		echo "no PID given and no Moments.Devel process found" >&2; exit 1; \
+	fi; \
+	echo "===== thread backtraces for PID $$PID ====="; \
+	flatpak run --command=gdb org.gnome.Sdk//50 -p "$$PID" \
+		-ex 'set pagination off' \
+		-ex 'thread apply all bt 30' \
+		-ex quit 2>&1 | grep -v '^\[New '
+
+# Attach an interactive gdb session to a running dev app. The dev binary
+# is built with debug symbols, so Rust function names tab-complete:
+#
+#   (gdb) break moments::importer::pipeline::ImportPipeline::import_one
+#   (gdb) break src/renderer/format/registry.rs:99
+#   (gdb) continue
+#   (gdb) bt        # when it stops
+#   (gdb) detach    # let the app run free again
+#
+# Auto-detects the dev app's PID; pass PID=… to override.
+attach:
+	@PID="$${PID:-$$(pgrep -f io.github.justinf555.Moments.Devel | tail -1)}"; \
+	if [ -z "$$PID" ]; then \
+		echo "no PID given and no Moments.Devel process found" >&2; exit 1; \
+	fi; \
+	echo "attaching gdb to PID $$PID — type 'continue' to resume, 'detach' to release"; \
+	flatpak run --command=gdb org.gnome.Sdk//50 -p "$$PID"
+
 # ── Full CI locally ─────────────────────────────────────────────────────────
 
 ci-all: lint test test-integration audit

--- a/src/importer/hasher.rs
+++ b/src/importer/hasher.rs
@@ -1,13 +1,21 @@
 use std::path::Path;
 
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use sha1::{Digest, Sha1};
 use tracing::instrument;
 
 use super::error::ImportError;
 
-/// Compute the BLAKE3 content hash of a file.
+/// Compute the SHA-1 content hash of a file, base64-encoded.
 ///
-/// Returns a 64-char lowercase hex string. Used for deduplication —
-/// not as the asset's identity (which is a UUID).
+/// Matches Immich's `checksum` wire format byte-for-byte so that
+/// locally-imported and server-pulled rows share a single `content_hash`
+/// column and can dedup symmetrically (issue #626 follow-up).
+///
+/// Used for deduplication only — never as the asset's identity (which is
+/// a UUID). SHA-1 is sufficient for accidental-collision detection in a
+/// personal photo library; we are not in an adversarial threat model.
 ///
 /// Runs on a blocking thread via [`tokio::task::spawn_blocking`] so the
 /// async executor stays free during the streaming hash. Large video files
@@ -18,9 +26,10 @@ pub async fn hash_file(path: &Path) -> Result<String, ImportError> {
     tokio::task::spawn_blocking(move || -> Result<String, ImportError> {
         let file = std::fs::File::open(&path).map_err(ImportError::Io)?;
         let mut reader = std::io::BufReader::new(file);
-        let mut hasher = blake3::Hasher::new();
+        let mut hasher = Sha1::new();
         std::io::copy(&mut reader, &mut hasher).map_err(ImportError::Io)?;
-        Ok(hasher.finalize().to_hex().to_string())
+        let digest = hasher.finalize();
+        Ok(B64.encode(digest))
     })
     .await
     .map_err(|e| ImportError::Runtime(e.to_string()))?
@@ -56,13 +65,17 @@ mod tests {
         assert_ne!(h1, h2);
     }
 
+    /// SHA-1 base64 of "abc" is `qZk+NkcGgWq6PiVxeFDCbJzQ2J0=` — a fixed
+    /// vector from the SHA-1 spec, encoded the way Immich emits it. Using
+    /// a known-answer test pins both the algorithm and the encoding so
+    /// that a future swap can't silently desync our local hashes from
+    /// what we receive over the sync stream.
     #[tokio::test]
-    async fn hash_is_64_char_hex() {
+    async fn matches_immich_sha1_base64_for_known_input() {
         let mut f = NamedTempFile::new().unwrap();
-        f.write_all(b"test").unwrap();
+        f.write_all(b"abc").unwrap();
         let hash = hash_file(f.path()).await.unwrap();
-        assert_eq!(hash.len(), 64);
-        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(hash, "qZk+NkcGgWq6PiVxeFDCbJzQ2J0=");
     }
 
     #[tokio::test]

--- a/src/library/db/migrations/001_create_media.sql
+++ b/src/library/db/migrations/001_create_media.sql
@@ -1,5 +1,5 @@
 CREATE TABLE media (
-    id                TEXT    PRIMARY KEY NOT NULL,  -- BLAKE3 hex (64 chars)
+    id                TEXT    PRIMARY KEY NOT NULL,  -- UUID v4 (32-char hex, no dashes)
     relative_path     TEXT    NOT NULL UNIQUE,       -- e.g. "2025/01/15/photo.jpg"
     original_filename TEXT    NOT NULL,
     file_size         INTEGER NOT NULL,

--- a/src/library/db/migrations/016_add_content_hash_and_external_id.sql
+++ b/src/library/db/migrations/016_add_content_hash_and_external_id.sql
@@ -1,4 +1,7 @@
--- Content hash for dedup (BLAKE3 hex, 64 chars). MediaId is now UUID.
+-- Content hash for dedup, base64-encoded SHA-1 (28 chars including
+-- padding) — same wire format Immich emits on its sync stream so that
+-- locally-imported and server-pulled rows can dedup symmetrically.
+-- MediaId is now UUID.
 ALTER TABLE media ADD COLUMN content_hash TEXT;
 
 -- External ID for Immich server mapping.

--- a/src/library/db/migrations/020_add_media_external_id_index.sql
+++ b/src/library/db/migrations/020_add_media_external_id_index.sql
@@ -1,7 +1,20 @@
 -- Index media.external_id so the sync upsert path doesn't full-scan
--- the table on every asset. Two queries hit external_id per upsert:
+-- the table on every asset. Several queries hit external_id per upsert:
 --   - SELECT imported_at WHERE id = ? OR external_id = ? (added in #614)
 --   - DELETE FROM media WHERE external_id = ? AND id != ? (#610)
--- Both are run once per asset during pull-sync, so a 10k-photo library
--- doing a full sync was previously paying 20k full table scans.
-CREATE INDEX IF NOT EXISTS idx_media_external_id ON media(external_id);
+--   - SELECT id WHERE external_id = ?                     (#626)
+-- Each runs once per asset during pull-sync, so a 10k-photo library
+-- doing a full sync was previously paying tens of thousands of full
+-- table scans.
+--
+-- The index is UNIQUE over non-NULL values: an Immich UUID identifies
+-- one server-side asset, so it must map to at most one local row.
+-- Locally-imported assets that haven't been pushed yet have NULL
+-- external_id and are unaffected (SQLite treats NULLs as distinct in
+-- unique indexes, so any number of NULL rows are allowed). Issue #626
+-- needed this guarantee: the new "look up local MediaId by external_id,
+-- else generate fresh" handler logic is a check, not a constraint, so
+-- without DB-level uniqueness any concurrent or out-of-order path
+-- could silently produce two rows sharing one Immich UUID.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_media_external_id
+    ON media(external_id) WHERE external_id IS NOT NULL;

--- a/src/library/media/model.rs
+++ b/src/library/media/model.rs
@@ -135,7 +135,12 @@ pub struct MediaCursor {
 #[derive(Debug, Clone)]
 pub struct MediaRecord {
     pub id: MediaId,
-    /// BLAKE3 content hash (64-char hex). Used for dedup, not identity.
+    /// SHA-1 content hash, base64-encoded — matches Immich's wire format.
+    /// Used for dedup, not identity. Local imports compute this from the
+    /// file bytes; sync-origin rows take it from the Immich `AssetV1`
+    /// stream's `checksum` field. Symmetric format means a file pulled
+    /// from Immich and then re-imported locally is rejected as a dup
+    /// without needing to download the original.
     pub content_hash: Option<String>,
     /// Immich server UUID. Set when synced with an Immich server.
     pub external_id: Option<String>,

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -425,6 +425,50 @@ impl MediaRepository {
         Ok(())
     }
 
+    /// Look up a locally-imported row by `content_hash` that has not yet
+    /// been pushed to a server (i.e. `external_id IS NULL`).
+    ///
+    /// Used by the sync handler to *adopt* a local row when the same
+    /// asset arrives over the pull stream before push has finished
+    /// stamping the server id. Without this step the AssetHandler would
+    /// generate a fresh `MediaId` and `INSERT` a parallel stub row,
+    /// then push's eventual `UPDATE … SET external_id = ?` would hit
+    /// the unique partial index on `external_id` and fail.
+    ///
+    /// Restricting the match to `external_id IS NULL` is deliberate:
+    /// rows already mapped to a *different* Immich asset must never be
+    /// silently re-pointed by a hash collision.
+    pub async fn id_by_content_hash_pending_push(
+        &self,
+        content_hash: &str,
+    ) -> Result<Option<MediaId>, LibraryError> {
+        let row: Option<String> = sqlx::query_scalar(
+            "SELECT id FROM media WHERE content_hash = ? AND external_id IS NULL",
+        )
+        .bind(content_hash)
+        .fetch_optional(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(row.map(MediaId::new))
+    }
+
+    /// Look up the local [`MediaId`] for a given `external_id`.
+    ///
+    /// Used by sync handlers to translate Immich-side asset UUIDs into the
+    /// stable, locally-owned id under which we actually store the row.
+    /// Returns `None` if no row carries that `external_id`.
+    pub async fn id_by_external_id(
+        &self,
+        external_id: &str,
+    ) -> Result<Option<MediaId>, LibraryError> {
+        let row: Option<String> = sqlx::query_scalar("SELECT id FROM media WHERE external_id = ?")
+            .bind(external_id)
+            .fetch_optional(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(row.map(MediaId::new))
+    }
+
     /// Look up external_ids for a batch of media IDs.
     ///
     /// Returns `(local_id, external_id)` pairs. IDs without an external_id
@@ -675,6 +719,71 @@ mod tests {
             repo.exists(&server_id).await.unwrap(),
             "new server row inserted"
         );
+    }
+
+    /// Adopt-by-content_hash: pull's `AssetHandler` looks up a local
+    /// row that has the same hash but no `external_id`, so the same
+    /// asset arriving from sync before push has stamped the server id
+    /// is merged in place. A row that *already* has an `external_id`
+    /// — i.e. is mapped to a different (or even the same) Immich
+    /// asset — must never be returned, since silently re-pointing it
+    /// would corrupt the mapping.
+    #[tokio::test]
+    async fn id_by_content_hash_pending_push_only_matches_unstamped_rows() {
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+
+        let hash = "qZk+NkcGgWq6PiVxeFDCbJzQ2J0=".to_string();
+
+        // Locally-imported, push hasn't run yet → eligible for adoption.
+        let pending = MediaId::new("local-pending-aaaaaaaaaaaaaaaaaaa".to_string());
+        let mut pending_rec = test_record(pending.clone());
+        pending_rec.content_hash = Some(hash.clone());
+        pending_rec.external_id = None;
+        repo.insert(&pending_rec).await.unwrap();
+
+        let found = repo.id_by_content_hash_pending_push(&hash).await.unwrap();
+        assert_eq!(found.as_ref().map(|m| m.as_str()), Some(pending.as_str()));
+
+        // Now stamp external_id — the row must no longer be eligible.
+        sqlx::query("UPDATE media SET external_id = ? WHERE id = ?")
+            .bind("immich-uuid")
+            .bind(pending.as_str())
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let after_stamp = repo.id_by_content_hash_pending_push(&hash).await.unwrap();
+        assert!(
+            after_stamp.is_none(),
+            "stamped rows must never be adopted by content_hash"
+        );
+
+        // A different hash never matches.
+        let miss = repo.id_by_content_hash_pending_push("other").await.unwrap();
+        assert!(miss.is_none());
+    }
+
+    /// Issue #626: sync handlers translate Immich UUIDs to local
+    /// `MediaId`s via `id_by_external_id`. The lookup must return the
+    /// row's primary key when `external_id` matches, and `None`
+    /// otherwise.
+    #[tokio::test]
+    async fn id_by_external_id_finds_row_or_returns_none() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let local_id = MediaId::new("local-uuid-eeeeeeeeeeeeeeeeeeeeeee".to_string());
+        let server_id = "server-uuid-ffffffffffffffffffffff".to_string();
+        let mut rec = test_record(local_id.clone());
+        rec.external_id = Some(server_id.clone());
+        repo.insert(&rec).await.unwrap();
+
+        let found = repo.id_by_external_id(&server_id).await.unwrap();
+        assert_eq!(found.as_ref().map(|m| m.as_str()), Some(local_id.as_str()));
+
+        let missing = repo.id_by_external_id("nope").await.unwrap();
+        assert!(missing.is_none());
     }
 
     /// Upsert with an external_id that doesn't match any existing row

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -349,18 +349,18 @@ impl MediaRepository {
     /// the server's `file_created_at` (the photo's capture time), which
     /// would silently move assets out of the Recent Imports view (issue #614).
     pub async fn upsert(&self, record: &MediaRecord) -> Result<Option<MediaId>, LibraryError> {
-        // Capture the existing local row's imported_at — by id (plain
-        // update) or by external_id (local→server UUID swap). At most one
-        // row matches in practice; if both somehow do, take the id match.
-        let existing_imported_at: Option<i64> = sqlx::query_scalar(
-            "SELECT imported_at FROM media
-             WHERE id = ?1 OR external_id = ?1
-             ORDER BY (id = ?1) DESC LIMIT 1",
-        )
-        .bind(record.id.as_str())
-        .fetch_optional(self.db.pool())
-        .await
-        .map_err(LibraryError::Db)?;
+        // Capture the existing row's imported_at so we can preserve it —
+        // see #614. Post-#626 the upserting handler always passes the
+        // locally-owned `MediaId` (resolved via `id_by_external_id` /
+        // `id_by_content_hash_pending_push`), so a plain `id = ?` lookup
+        // is sufficient; the older `OR external_id = ?` arm was for the
+        // local→server UUID swap that no longer happens.
+        let existing_imported_at: Option<i64> =
+            sqlx::query_scalar("SELECT imported_at FROM media WHERE id = ?")
+                .bind(record.id.as_str())
+                .fetch_optional(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
         let imported_at = existing_imported_at.unwrap_or(record.imported_at);
 
         // Atomic delete-and-return so the replaced-id observation can
@@ -820,31 +820,6 @@ mod tests {
         repo.upsert(&record).await.unwrap();
 
         let item = repo.get(&id).await.unwrap().unwrap();
-        assert_eq!(item.imported_at, 1_700_000_000);
-    }
-
-    /// Local→server UUID swap: the new server-keyed row inherits the local
-    /// row's `imported_at` rather than starting fresh, so the freshly
-    /// round-tripped asset stays in the Recent Imports view (#614).
-    #[tokio::test]
-    async fn upsert_preserves_imported_at_across_external_id_swap() {
-        let dir = tempdir().unwrap();
-        let (repo, _db) = test_repo(dir.path()).await;
-
-        let local_id = MediaId::new("local-uuid-eeeeeeeeeeeeeeeeeeee".to_string());
-        let server_id = MediaId::new("server-uuid-ffffffffffffffffffff".to_string());
-
-        let mut local = test_record(local_id.clone());
-        local.external_id = Some(server_id.as_str().to_string());
-        local.imported_at = 1_700_000_000;
-        repo.insert(&local).await.unwrap();
-
-        let mut from_server = test_record(server_id.clone());
-        from_server.external_id = Some(server_id.as_str().to_string());
-        from_server.imported_at = 1_400_000_000;
-        repo.upsert(&from_server).await.unwrap();
-
-        let item = repo.get(&server_id).await.unwrap().unwrap();
         assert_eq!(item.imported_at, 1_700_000_000);
     }
 

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{instrument, warn};
 
 use super::event::MediaEvent;
 use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord};
@@ -137,6 +137,7 @@ impl MediaService {
 
     /// Translate an `external_id` (e.g. an Immich asset UUID) to the local
     /// [`MediaId`] under which the row is stored, if any.
+    #[instrument(skip(self))]
     pub async fn id_by_external_id(
         &self,
         external_id: &str,
@@ -149,6 +150,7 @@ impl MediaService {
     /// to adopt a local row when push hasn't finished stamping the
     /// server id by the time the same asset arrives over the pull
     /// stream — see [`MediaRepository::id_by_content_hash_pending_push`].
+    #[instrument(skip(self))]
     pub async fn id_by_content_hash_pending_push(
         &self,
         content_hash: &str,

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -135,6 +135,29 @@ impl MediaService {
         self.repo.exists(id).await
     }
 
+    /// Translate an `external_id` (e.g. an Immich asset UUID) to the local
+    /// [`MediaId`] under which the row is stored, if any.
+    pub async fn id_by_external_id(
+        &self,
+        external_id: &str,
+    ) -> Result<Option<MediaId>, LibraryError> {
+        self.repo.id_by_external_id(external_id).await
+    }
+
+    /// Find a locally-imported row by `content_hash` that has not yet
+    /// been pushed (i.e. has no `external_id`). Used by the sync handler
+    /// to adopt a local row when push hasn't finished stamping the
+    /// server id by the time the same asset arrives over the pull
+    /// stream — see [`MediaRepository::id_by_content_hash_pending_push`].
+    pub async fn id_by_content_hash_pending_push(
+        &self,
+        content_hash: &str,
+    ) -> Result<Option<MediaId>, LibraryError> {
+        self.repo
+            .id_by_content_hash_pending_push(content_hash)
+            .await
+    }
+
     /// Check if an asset with this content hash already exists (dedup).
     pub async fn exists_by_content_hash(&self, hash: &str) -> Result<bool, LibraryError> {
         self.repo.exists_by_content_hash(hash).await
@@ -361,6 +384,75 @@ mod tests {
         let events = drain(&mut rx).await;
         assert_eq!(events.len(), 1);
         assert!(matches!(&events[0], MediaEvent::Added(ids) if ids.len() == 1));
+    }
+
+    /// Sync-then-import dedup: when Immich pulls down an asset with a
+    /// `checksum` (SHA-1 base64), it lands in `content_hash`. A local
+    /// import of the same bytes hashes to the same value, so the
+    /// importer's `exists_by_content_hash` check rejects it as a
+    /// duplicate — no second row, no parallel upload, no UNIQUE-index
+    /// collision when push later tries to stamp `external_id`.
+    #[tokio::test]
+    async fn exists_by_content_hash_matches_immich_pulled_row() {
+        let (_dir, svc) = make_service().await;
+
+        let server_id = MediaId::new("server-uuid-aaaaaaaaaaaaaaaaaaaaaa".to_string());
+        let mut server_row =
+            record_with_taken_at(server_id.clone(), "server/photo.jpg", Some(1_000));
+        server_row.external_id = Some("immich-uuid".to_string());
+        // SHA-1 base64 of "abc" — same value the importer would compute
+        // for an identical file.
+        server_row.content_hash = Some("qZk+NkcGgWq6PiVxeFDCbJzQ2J0=".to_string());
+        svc.upsert_media(&server_row).await.unwrap();
+
+        let dup = svc
+            .exists_by_content_hash("qZk+NkcGgWq6PiVxeFDCbJzQ2J0=")
+            .await
+            .unwrap();
+        assert!(dup, "importer must see the pulled row as a duplicate");
+
+        let miss = svc
+            .exists_by_content_hash("aGVsbG8gd29ybGQ=")
+            .await
+            .unwrap();
+        assert!(!miss, "an unrelated hash must not match");
+    }
+
+    /// Issue #626: with the stable-MediaId sync handler, an upload→pull
+    /// round-trip no longer swaps the row's primary key. The handler
+    /// looks up by `external_id`, finds the existing local row, and
+    /// upserts using its locally-owned id. The service must emit a
+    /// single `Updated` — no `Replaced`, no `Removed`+`Added` churn.
+    #[tokio::test]
+    async fn upsert_media_emits_updated_when_round_tripped_via_external_id() {
+        let (_dir, svc) = make_service().await;
+        let mut rx = svc.subscribe();
+
+        let local_id = MediaId::new("local-uuid-aaaaaaaaaaaaaaaaaaaaaaaa".to_string());
+        let server_id = "server-uuid-bbbbbbbbbbbbbbbbbbbbb".to_string();
+
+        // Local import; push has stamped the server UUID as external_id.
+        let mut local = record_with_taken_at(local_id.clone(), "local/photo.jpg", Some(1_000));
+        local.external_id = Some(server_id.clone());
+        svc.insert_media(&local).await.unwrap();
+        let _ = drain(&mut rx).await; // drop the Added event from import
+
+        // Pull-sync now arrives. The new handler resolves external_id →
+        // local_id and reuses it as the record's primary key.
+        let resolved = svc.id_by_external_id(&server_id).await.unwrap();
+        assert_eq!(resolved.as_ref(), Some(&local_id));
+
+        let mut from_server =
+            record_with_taken_at(local_id.clone(), "local/photo.jpg", Some(1_000));
+        from_server.external_id = Some(server_id.clone());
+        svc.upsert_media(&from_server).await.unwrap();
+
+        let events = drain(&mut rx).await;
+        assert_eq!(events.len(), 1, "expected single Updated; got {events:?}");
+        match &events[0] {
+            MediaEvent::Updated(ids) => assert_eq!(ids, &[local_id]),
+            other => panic!("expected Updated; got {other:?}"),
+        }
     }
 
     /// Re-syncing an asset that already exists by id emits a single

--- a/src/renderer/format/registry.rs
+++ b/src/renderer/format/registry.rs
@@ -45,6 +45,24 @@ pub trait FormatHandler: Send + Sync {
     /// thumbnail is needed; handlers may ignore it if they have only one
     /// decode path.
     fn decode(&self, path: &Path, hint: DecodeHint) -> Result<image::DynamicImage, RenderError>;
+
+    /// Whether this handler is safe to invoke *speculatively* — i.e.
+    /// when the registry has fallen back to "try every handler" because
+    /// the magic-byte handler errored out (e.g. a TIFF-headered CR2
+    /// file).
+    ///
+    /// Defaults to `true`. Handlers that wrap external pipelines whose
+    /// failure modes can hang the calling thread (rather than returning
+    /// a quick `Err`) must override this to `false`. Such handlers are
+    /// still reachable through extension and magic-byte matches; they
+    /// just won't be tried blindly on unidentified data.
+    ///
+    /// See `VideoHandler` — GStreamer's `uridecodebin`/`typefind`
+    /// probe can sit forever waiting for buffers when handed input it
+    /// doesn't recognise.
+    fn fallback_safe(&self) -> bool {
+        true
+    }
 }
 
 /// Single source of truth for all supported image formats.
@@ -94,9 +112,17 @@ impl FormatRegistry {
             match handler.decode(path, hint) {
                 Ok(img) => return Ok(img),
                 Err(_) => {
-                    // Magic-byte match failed (e.g. TIFF header but actually
-                    // a RAW format). Try all other handlers.
+                    // Magic-byte match failed (e.g. TIFF header but the
+                    // file is actually a CR2 — Canon's TIFF-derived RAW
+                    // format). Try every other *fallback-safe* handler
+                    // until one succeeds. We deliberately exclude
+                    // handlers whose decode path can hang on
+                    // unidentified input — see `fallback_safe` and
+                    // `VideoHandler` for context.
                     for other in self.handlers.values() {
+                        if !other.fallback_safe() {
+                            continue;
+                        }
                         if let Ok(img) = other.decode(path, hint) {
                             return Ok(img);
                         }
@@ -223,6 +249,30 @@ mod tests {
         }
     }
 
+    /// Stand-in for a hang-prone handler (e.g. `VideoHandler` wrapping
+    /// GStreamer). The test asserts that the registry's blind
+    /// fallback iteration *never* invokes its `decode` — the symptom
+    /// would be a hung importer thread parked inside `typefind:sink`.
+    struct UnsafeFallbackHandler {
+        invoked: Arc<Mutex<bool>>,
+    }
+    impl FormatHandler for UnsafeFallbackHandler {
+        fn extensions(&self) -> &[&str] {
+            &["unsafe"]
+        }
+        fn decode(
+            &self,
+            _path: &Path,
+            _hint: DecodeHint,
+        ) -> Result<image::DynamicImage, RenderError> {
+            *self.invoked.lock().unwrap() = true;
+            Err(RenderError::DecodeFailed("unsafe-fallback".into()))
+        }
+        fn fallback_safe(&self) -> bool {
+            false
+        }
+    }
+
     /// Records the hint passed to `decode` so tests can assert it.
     struct RecordingHandler {
         last_hint: Arc<Mutex<Option<DecodeHint>>>,
@@ -330,6 +380,57 @@ mod tests {
 
         let _ = reg.decode(&PathBuf::from("photo.rec"), DecodeHint::Full);
         assert_eq!(*last_hint.lock().unwrap(), Some(DecodeHint::Full));
+    }
+
+    /// Regression for the CR2 import hang: when the magic-byte handler
+    /// errors out, the registry's blind retry loop must not invoke a
+    /// handler that has opted out of speculative dispatch. Otherwise
+    /// `VideoHandler` (wrapping GStreamer's `typefind`) would sit
+    /// forever on a TIFF-headered CR2 file.
+    /// Always-erroring stand-in for `StandardHandler` so we can drive
+    /// the registry into its "magic match → decode failed → blind
+    /// retry" path with a controlled handler set.
+    struct ErroringJpegHandler;
+    impl FormatHandler for ErroringJpegHandler {
+        fn extensions(&self) -> &[&str] {
+            &["jpg"]
+        }
+        fn decode(
+            &self,
+            _path: &Path,
+            _hint: DecodeHint,
+        ) -> Result<image::DynamicImage, RenderError> {
+            Err(RenderError::DecodeFailed("forced fail".into()))
+        }
+    }
+
+    #[test]
+    fn fallback_iteration_skips_handlers_that_opt_out() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let invoked = Arc::new(Mutex::new(false));
+        let mut reg = FormatRegistry::new();
+        // ErroringJpegHandler claims "jpg" so JPEG magic-byte matching
+        // picks it; its decode errors out, triggering the blind
+        // fallback iteration.
+        reg.register(Arc::new(ErroringJpegHandler));
+        reg.register(Arc::new(UnsafeFallbackHandler {
+            invoked: Arc::clone(&invoked),
+        }));
+
+        let mut f = NamedTempFile::with_suffix(".jpg").unwrap();
+        f.write_all(&[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]).unwrap();
+        f.flush().unwrap();
+
+        // We don't care about the eventual error — only that
+        // `UnsafeFallbackHandler::decode` is never reached.
+        let _ = reg.decode(f.path(), DecodeHint::Thumbnail);
+
+        assert!(
+            !*invoked.lock().unwrap(),
+            "fallback-unsafe handler must not be invoked during blind retry"
+        );
     }
 
     #[test]

--- a/src/renderer/format/video.rs
+++ b/src/renderer/format/video.rs
@@ -27,6 +27,18 @@ impl FormatHandler for VideoHandler {
     fn decode(&self, path: &Path, _hint: DecodeHint) -> Result<image::DynamicImage, RenderError> {
         extract_poster_frame(path)
     }
+
+    /// GStreamer's `uridecodebin` runs `typefind` to identify the
+    /// container format. Given input it can't classify (e.g. a CR2
+    /// file with TIFF magic bytes that the registry's magic-byte
+    /// fallback hands us), `typefind` parks waiting for buffers it
+    /// will never receive — the whole importer thread hangs with no
+    /// CPU activity. So this handler is reachable only through
+    /// positive identification (extension or magic match), never
+    /// through the registry's "try every handler" fallback path.
+    fn fallback_safe(&self) -> bool {
+        false
+    }
 }
 
 /// Extract the first video frame as an `image::DynamicImage`.

--- a/src/sync/providers/immich/handlers/album_asset.rs
+++ b/src/sync/providers/immich/handlers/album_asset.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tracing::warn;
 
 use crate::library::album::AlbumId;
 use crate::library::error::LibraryError;
@@ -23,9 +24,35 @@ impl SyncEntityHandler for AlbumAssetHandler {
         let assoc: SyncAlbumToAssetV1 = deserialize_entity(data, "AlbumToAssetV1", line_number)?;
         let id = format!("{}:{}", assoc.album_id, assoc.asset_id);
 
+        // Issue #626: `assoc.asset_id` is the Immich UUID; `album_media.media_id`
+        // references the local `MediaId`. Translate via `external_id` lookup.
+        // Assumes Immich emits the parent asset before its album-membership row
+        // — if the lookup misses, we warn and skip rather than persist a
+        // dangling FK pointing at the server-side UUID.
+        let media_id = match ctx
+            .library
+            .media()
+            .id_by_external_id(&assoc.asset_id)
+            .await?
+        {
+            Some(id) => id,
+            None => {
+                warn!(
+                    album_id = %assoc.album_id,
+                    asset_id = %assoc.asset_id,
+                    "AlbumToAssetV1: parent asset not found locally; skipping membership row"
+                );
+                return Ok(HandlerResult {
+                    entity_id: id,
+                    audit_action: "upsert",
+                    counter: CounterKind::Albums,
+                });
+            }
+        };
+
         let now = chrono::Utc::now().timestamp();
         ctx.db
-            .upsert_album_media(&assoc.album_id, &assoc.asset_id, now)
+            .upsert_album_media(&assoc.album_id, media_id.as_str(), now)
             .await?;
         ctx.library
             .albums()
@@ -57,8 +84,21 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
             deserialize_entity(data, "AlbumToAssetDeleteV1", line_number)?;
         let id = format!("{}:{}", assoc.album_id, assoc.asset_id);
 
+        // Issue #626: translate Immich UUID → local MediaId before
+        // deleting. For legacy rows where `id == external_id` the
+        // translation is a no-op; for post-#626 rows it's required to
+        // match the locally-keyed album_media row. Falls back to the
+        // raw UUID if the parent media has already been deleted.
+        let media_key = ctx
+            .library
+            .media()
+            .id_by_external_id(&assoc.asset_id)
+            .await?
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_else(|| assoc.asset_id.clone());
+
         ctx.db
-            .delete_album_media_entry(&assoc.album_id, &assoc.asset_id)
+            .delete_album_media_entry(&assoc.album_id, &media_key)
             .await?;
         ctx.library
             .albums()

--- a/src/sync/providers/immich/handlers/album_asset.rs
+++ b/src/sync/providers/immich/handlers/album_asset.rs
@@ -84,21 +84,37 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
             deserialize_entity(data, "AlbumToAssetDeleteV1", line_number)?;
         let id = format!("{}:{}", assoc.album_id, assoc.asset_id);
 
-        // Issue #626: translate Immich UUID → local MediaId before
-        // deleting. For legacy rows where `id == external_id` the
-        // translation is a no-op; for post-#626 rows it's required to
-        // match the locally-keyed album_media row. Falls back to the
-        // raw UUID if the parent media has already been deleted.
-        let media_key = ctx
+        // Issue #626: `assoc.asset_id` is the Immich UUID; the
+        // album_media row references the local `MediaId`. Translate
+        // before deleting. If the parent media row has already been
+        // removed locally, the album_media join row went with it via
+        // the manual cascade in `delete_permanently`, so there's
+        // nothing left to clean up — match the add-path's pattern of
+        // warn-and-skip rather than firing a delete with a key that
+        // can't possibly hit anything.
+        let media_id = match ctx
             .library
             .media()
             .id_by_external_id(&assoc.asset_id)
             .await?
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_else(|| assoc.asset_id.clone());
+        {
+            Some(id) => id,
+            None => {
+                warn!(
+                    album_id = %assoc.album_id,
+                    asset_id = %assoc.asset_id,
+                    "AlbumToAssetDeleteV1: parent asset not found locally; nothing to delete"
+                );
+                return Ok(HandlerResult {
+                    entity_id: id,
+                    audit_action: "delete",
+                    counter: CounterKind::Deletes,
+                });
+            }
+        };
 
         ctx.db
-            .delete_album_media_entry(&assoc.album_id, &media_key)
+            .delete_album_media_entry(&assoc.album_id, media_id.as_str())
             .await?;
         ctx.library
             .albums()

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -56,12 +56,49 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
     let trashed_at = parse_datetime(&asset.deleted_at);
     let duration_ms = asset.duration.as_deref().and_then(parse_duration_ms);
 
-    let id_str = asset.id.clone();
+    // Issue #626: keep the locally-owned `MediaId` stable across the
+    // upload→pull round-trip. The Immich UUID lives only in
+    // `external_id` from now on — never as the primary key.
+    //
+    // Resolution order:
+    //   1. `external_id` — already-stamped row from a previous sync
+    //      cycle or a completed push. This is the steady-state path.
+    //   2. `content_hash` (only if Immich emitted `checksum` and only
+    //      against rows with `external_id IS NULL`) — adopt a local
+    //      row whose push hasn't yet stamped the server id. This
+    //      closes the import-then-pull race that would otherwise
+    //      create a parallel stub row and wedge push's external_id
+    //      stamp behind a UNIQUE-constraint violation.
+    //   3. Generate a fresh `MediaId` — server-origin asset that has
+    //      no local twin.
+    let external_id = asset.id.clone();
+    let media_id =
+        if let Some(existing) = ctx.library.media().id_by_external_id(&external_id).await? {
+            existing
+        } else if let Some(hash) = asset.checksum.as_deref() {
+            match ctx
+                .library
+                .media()
+                .id_by_content_hash_pending_push(hash)
+                .await?
+            {
+                Some(local) => local,
+                None => MediaId::generate(),
+            }
+        } else {
+            MediaId::generate()
+        };
+
+    // Issue #626 follow-up: populate `content_hash` from Immich's own
+    // `checksum` field (SHA-1 base64). The local importer hashes the
+    // same way, so a file pulled from Immich and then re-selected in
+    // the import dialog is rejected as a duplicate without needing to
+    // download the original first.
     let record = MediaRecord {
-        id: MediaId::new(id_str.clone()),
-        content_hash: None,
-        external_id: Some(id_str.clone()),
-        relative_path: sharded_original_relative(&MediaId::new(id_str.clone())),
+        id: media_id.clone(),
+        content_hash: asset.checksum,
+        external_id: Some(external_id),
+        relative_path: sharded_original_relative(&media_id),
         original_filename: asset.original_file_name,
         file_size: 0,
         imported_at,
@@ -76,11 +113,17 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
         trashed_at,
     };
 
-    let media_id = record.id.clone();
+    let server_id = record.external_id.clone().expect("external_id set above");
     ctx.library.media().upsert_media(&record).await?;
 
-    if let Err(e) =
-        download_thumbnail(&ctx.client, &ctx.library, &ctx.thumbnails_dir, &media_id).await
+    if let Err(e) = download_thumbnail(
+        &ctx.client,
+        &ctx.library,
+        &ctx.thumbnails_dir,
+        &media_id,
+        &server_id,
+    )
+    .await
     {
         debug!(id = %media_id, "thumbnail download failed: {e}");
     }
@@ -103,13 +146,22 @@ impl SyncEntityHandler for AssetDeleteHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let delete: SyncAssetDeleteV1 = deserialize_entity(data, "AssetDeleteV1", line_number)?;
-        let id = delete.asset_id.clone();
-        let media_id = MediaId::new(id.clone());
-        ctx.library
-            .delete_permanently_from_sync(std::slice::from_ref(&media_id))
-            .await?;
+        let external_id = delete.asset_id.clone();
+        // Issue #626: the stream carries the Immich UUID; translate to
+        // the local `MediaId` before deleting. Missing row is a no-op —
+        // the asset was already gone or never reached us.
+        match ctx.library.media().id_by_external_id(&external_id).await? {
+            Some(media_id) => {
+                ctx.library
+                    .delete_permanently_from_sync(std::slice::from_ref(&media_id))
+                    .await?;
+            }
+            None => {
+                debug!(external_id = %external_id, "asset delete: no local row, skipping");
+            }
+        }
         Ok(HandlerResult {
-            entity_id: id,
+            entity_id: external_id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })
@@ -127,6 +179,7 @@ async fn download_thumbnail(
     library: &crate::library::Library,
     thumbnails_dir: &std::path::Path,
     media_id: &MediaId,
+    server_id: &str,
 ) -> Result<(), LibraryError> {
     let path = sharded_thumbnail_path(thumbnails_dir, media_id);
 
@@ -140,7 +193,7 @@ async fn download_thumbnail(
         return Ok(());
     }
 
-    let api_path = format!("/assets/{}/thumbnail?size=thumbnail", media_id.as_str());
+    let api_path = format!("/assets/{server_id}/thumbnail?size=thumbnail");
     let bytes = client.get_bytes(&api_path).await?;
 
     if let Some(parent) = path.parent() {

--- a/src/sync/providers/immich/handlers/asset_exif.rs
+++ b/src/sync/providers/immich/handlers/asset_exif.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
+use tracing::warn;
 
 use crate::library::error::LibraryError;
-use crate::library::media::MediaId;
 use crate::library::metadata::MediaMetadataRecord;
 
 use super::{CounterKind, HandlerResult, SyncContext, SyncEntityHandler};
@@ -24,8 +24,31 @@ impl SyncEntityHandler for AssetExifHandler {
         let exif: SyncAssetExifV1 = deserialize_entity(data, "AssetExifV1", line_number)?;
         let id = exif.asset_id.clone();
 
+        // Issue #626: `exif.asset_id` is the Immich UUID; `media_metadata.media_id`
+        // references the local `MediaId`. Translate via `external_id` lookup;
+        // skip with a warning if the parent asset hasn't been processed yet.
+        let media_id = match ctx
+            .library
+            .media()
+            .id_by_external_id(&exif.asset_id)
+            .await?
+        {
+            Some(local) => local,
+            None => {
+                warn!(
+                    asset_id = %exif.asset_id,
+                    "AssetExifV1: parent asset not found locally; skipping metadata row"
+                );
+                return Ok(HandlerResult {
+                    entity_id: id,
+                    audit_action: "upsert",
+                    counter: CounterKind::Exifs,
+                });
+            }
+        };
+
         let record = MediaMetadataRecord {
-            media_id: MediaId::new(exif.asset_id),
+            media_id,
             camera_make: exif.make,
             camera_model: exif.model,
             lens_model: exif.lens_model,

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use crate::library::error::LibraryError;
 use crate::library::faces::repository::AssetFaceRow;
@@ -25,9 +25,33 @@ impl SyncEntityHandler for AssetFaceHandler {
         let face: SyncAssetFaceV1 = deserialize_entity(data, "AssetFaceV1", line_number)?;
         let id = face.id.clone();
 
+        // Issue #626: `face.asset_id` is the Immich UUID; `asset_faces.asset_id`
+        // references the local `MediaId`. Translate via `external_id` lookup;
+        // skip with a warning if the parent asset hasn't been processed yet.
+        let local_asset_id = match ctx
+            .library
+            .media()
+            .id_by_external_id(&face.asset_id)
+            .await?
+        {
+            Some(local) => local.as_str().to_string(),
+            None => {
+                warn!(
+                    face_id = %face.id,
+                    asset_id = %face.asset_id,
+                    "AssetFaceV1: parent asset not found locally; skipping face row"
+                );
+                return Ok(HandlerResult {
+                    entity_id: id,
+                    audit_action: "upsert",
+                    counter: CounterKind::Faces,
+                });
+            }
+        };
+
         let row = AssetFaceRow {
             id: face.id,
-            asset_id: face.asset_id,
+            asset_id: local_asset_id,
             person_id: face.person_id.clone(),
             image_width: face.image_width,
             image_height: face.image_height,

--- a/src/sync/providers/immich/types.rs
+++ b/src/sync/providers/immich/types.rs
@@ -47,6 +47,13 @@ pub(crate) struct SyncAssetV1 {
     pub width: Option<i64>,
     pub height: Option<i64>,
     pub duration: Option<String>,
+    /// SHA-1 of the file's bytes, base64-encoded. Stored verbatim into
+    /// `media.content_hash` so locally-imported and server-pulled rows
+    /// share a comparable dedup key. Optional in the serde shape so
+    /// older Immich versions (pre-checksum-on-stream) don't break
+    /// deserialisation; when absent, sync rows still work but won't
+    /// participate in cross-origin dedup.
+    pub checksum: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -284,7 +291,8 @@ mod tests {
             "isFavorite": true,
             "width": 4032,
             "height": 3024,
-            "duration": null
+            "duration": null,
+            "checksum": "qZk+NkcGgWq6PiVxeFDCbJzQ2J0="
         });
 
         let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
@@ -296,6 +304,31 @@ mod tests {
         assert_eq!(asset.width, Some(4032));
         assert_eq!(asset.height, Some(3024));
         assert!(asset.duration.is_none());
+        assert_eq!(
+            asset.checksum.as_deref(),
+            Some("qZk+NkcGgWq6PiVxeFDCbJzQ2J0=")
+        );
+    }
+
+    /// Older Immich versions (pre-checksum-on-stream) don't emit the
+    /// `checksum` field — deserialisation must still succeed and leave
+    /// the field as `None` rather than failing the whole sync line.
+    #[test]
+    fn deserialize_sync_asset_v1_without_checksum_is_optional() {
+        let json = serde_json::json!({
+            "id": "uuid-noosum",
+            "originalFileName": "old.jpg",
+            "fileCreatedAt": "2024-01-01T00:00:00.000Z",
+            "localDateTime": null,
+            "type": "IMAGE",
+            "deletedAt": null,
+            "isFavorite": false,
+            "width": null,
+            "height": null,
+            "duration": null
+        });
+        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        assert!(asset.checksum.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Closes #626. Locally-owned `MediaId` now stays put for an asset's whole lifetime; Immich's UUID lives only in `external_id`. Sync handlers translate Immich UUID → local `MediaId` before writing any FK (album_media, asset_faces, media_metadata).
- Cross-origin dedup: `content_hash` switches from BLAKE3 to SHA-1 base64 — the same wire format Immich emits as `checksum` on its sync stream — so locally-imported and server-pulled rows share a single dedup key with no extra I/O.
- Schema-level guard: unique partial index on `media.external_id` makes one-row-per-server-asset a hard constraint, not a best-effort check. Pull side adopts a pending-push local row by `content_hash` to close the import-then-pull race that would otherwise wedge push behind a UNIQUE violation.
- Bonus fix found while testing: the renderer's "magic-byte match failed → try every handler" fallback could route a TIFF-headered CR2 to `VideoHandler`, whose GStreamer `typefind` probe parks indefinitely on unrecognised input. `FormatHandler::fallback_safe()` now opts `VideoHandler` out of speculative dispatch.
- Tooling: `make stack` (one-shot all-thread backtrace) and `make attach` (interactive gdb on the dev app) — both used to pin the typefind hang.

## Notable changes

- `library/media/repository.rs` — `id_by_external_id` and `id_by_content_hash_pending_push` lookups + tests.
- `library/db/migrations/020_add_media_external_id_index.sql` — non-unique → unique partial index. Includes WHERE clause so multiple NULLs (local-only assets pre-push) are still allowed.
- `sync/providers/immich/handlers/asset.rs` — three-level resolution: external_id → content_hash (pending-push only) → generate. Populates content_hash from `asset.checksum`. Thumbnail download URL uses the server id explicitly.
- `sync/providers/immich/handlers/{album_asset,asset_face,asset_exif}.rs` — translate Immich UUID → local MediaId before writing FKs; warn-and-skip if parent asset isn't yet local.
- `sync/providers/immich/types.rs` — `SyncAssetV1.checksum: Option<String>` (optional so older Immich servers still deserialize).
- `importer/hasher.rs` — SHA-1 base64. Known-answer test pins the algorithm/encoding.
- `renderer/format/registry.rs` + `format/video.rs` — `FormatHandler::fallback_safe()` + regression test.

## Out of scope (filed-or-flagged for follow-up)

- `pull.rs:250` reset orphan-cleanup uses `result.entity_id` (Immich UUID) to remove from `existing_ids` (local `MediaId`s). Latent data-loss path on sync resets that #626 surfaces — needs a separate fix.
- The repository's `DELETE FROM media WHERE external_id = ? AND id != ?` defensive path in `upsert` is now dead by construction. Left as a safety net for one release; can be removed in a follow-up.

## Test plan

- [x] `make lint` — clippy + fmt clean.
- [x] `make test` — 476 unit tests pass (was 472; +4 new tests covering the new lookups, dedup symmetry, and fallback_safe).
- [x] `make run-dev` — verified import + push + pull round-trip with the CR2 sample data set; no duplicates, no `UNIQUE` violations, RAW thumbnails render.
- [ ] One more pass over a larger sample set to confirm no regression on previously-imported libraries.
- [ ] After merge, watch for any spurious `AlbumToAssetV1: parent asset not found locally` warnings during the first big sync — would indicate Immich emits in an unexpected order and we need to reconsider buffering vs. skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)