### PR TITLE
fix(sync): keep local AlbumId stable across Immich round-trip (#585)

### DIFF
--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -35,8 +35,12 @@ impl AlbumRepository {
 
     /// Upsert an album with a known ID (used by sync and Immich write-through).
     ///
-    /// Inserts or replaces the album row. Unlike `create()`, this does not
-    /// generate a new UUID — the caller provides the ID.
+    /// Inserts a new row or updates the existing one in place. Unlike
+    /// `create()`, this does not generate a new UUID — the caller provides
+    /// the ID. Uses `ON CONFLICT(id) DO UPDATE` rather than
+    /// `INSERT OR REPLACE` so that columns not listed here (notably
+    /// `is_pinned`, which is locally-owned and never sent over sync) are
+    /// preserved across each pull cycle (#585 review).
     pub async fn upsert(
         &self,
         id: &str,
@@ -46,8 +50,13 @@ impl AlbumRepository {
         external_id: Option<&str>,
     ) -> Result<(), LibraryError> {
         sqlx::query(
-            "INSERT OR REPLACE INTO albums (id, name, created_at, updated_at, external_id)
-             VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO albums (id, name, created_at, updated_at, external_id)
+             VALUES (?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                 name = excluded.name,
+                 created_at = excluded.created_at,
+                 updated_at = excluded.updated_at,
+                 external_id = excluded.external_id",
         )
         .bind(id)
         .bind(name)
@@ -445,6 +454,22 @@ mod tests {
         let id1 = repo.create("Album 1").await.unwrap();
         let id2 = repo.create("Album 2").await.unwrap();
         assert_ne!(id1, id2);
+    }
+
+    #[tokio::test]
+    async fn upsert_preserves_is_pinned() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, _db) = test_repo(dir.path()).await;
+
+        let id = repo.create("Pinned").await.unwrap();
+        repo.set_pinned(&id, true).await.unwrap();
+        assert!(repo.get(&id).await.unwrap().unwrap().is_pinned);
+
+        // Sync pull arrives — must not clobber the locally-owned pin.
+        repo.upsert(id.as_str(), "Pinned", 0, 0, Some("server-uuid"))
+            .await
+            .unwrap();
+        assert!(repo.get(&id).await.unwrap().unwrap().is_pinned);
     }
 
     #[tokio::test]

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -162,6 +162,24 @@ impl AlbumRepository {
         Ok(row.and_then(|(eid,)| eid))
     }
 
+    /// Look up the local [`AlbumId`] for a given `external_id`.
+    ///
+    /// Used by sync handlers to translate Immich-side album UUIDs into the
+    /// stable, locally-owned id under which we actually store the row —
+    /// preventing duplicate album rows on the post-push pull round-trip
+    /// (#585). Returns `None` if no row carries that `external_id`.
+    pub async fn id_by_external_id(
+        &self,
+        external_id: &str,
+    ) -> Result<Option<AlbumId>, LibraryError> {
+        let row: Option<String> = sqlx::query_scalar("SELECT id FROM albums WHERE external_id = ?")
+            .bind(external_id)
+            .fetch_optional(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(row.map(AlbumId::from_raw))
+    }
+
     /// Delete an album and all its media associations.
     pub async fn delete(&self, id: &AlbumId) -> Result<(), LibraryError> {
         let mut tx = self.db.pool().begin().await.map_err(LibraryError::Db)?;
@@ -427,6 +445,24 @@ mod tests {
         let id1 = repo.create("Album 1").await.unwrap();
         let id2 = repo.create("Album 2").await.unwrap();
         assert_ne!(id1, id2);
+    }
+
+    #[tokio::test]
+    async fn id_by_external_id_finds_row_or_returns_none() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, _db) = test_repo(dir.path()).await;
+
+        let local_id = repo.create("Round-trip").await.unwrap();
+        let server_id = "server-album-uuid";
+        repo.upsert(local_id.as_str(), "Round-trip", 0, 0, Some(server_id))
+            .await
+            .unwrap();
+
+        let found = repo.id_by_external_id(server_id).await.unwrap();
+        assert_eq!(found, Some(local_id));
+
+        let missing = repo.id_by_external_id("nope").await.unwrap();
+        assert_eq!(missing, None);
     }
 
     #[tokio::test]

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -254,16 +254,16 @@ mod tests {
         let (_dir, svc) = make_service().await;
         let mut rx = svc.subscribe();
 
-        // Local create. Push has stamped the server UUID as external_id.
+        // Local create. `create_album` writes the row but does not emit
+        // an event. Then push stamps the server UUID as external_id —
+        // simulated here by an `upsert_album` that lands on the existing
+        // row, which emits `AlbumUpdated`. Drain it so we can isolate
+        // the second upsert below.
         let local_id = svc.create_album("Vacation").await.unwrap();
         let server_id = "server-album-uuid";
         svc.upsert_album(local_id.as_str(), "Vacation", 0, 0, Some(server_id))
             .await
             .unwrap();
-
-        // Drain events emitted so far (the upsert above will fire
-        // `AlbumAdded` on the first call because there's no prior row
-        // — `create_album` itself doesn't emit).
         while rx.try_recv().is_ok() {}
 
         // Pull-sync arrives. The new handler resolves external_id →

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -98,6 +98,17 @@ impl AlbumService {
         self.repo.get(id).await
     }
 
+    /// Translate an Immich-side album UUID to the local [`AlbumId`] under
+    /// which the row is stored. Returns `None` if no local row carries
+    /// that `external_id`. Sync handlers use this to land pulled albums on
+    /// the existing local row instead of inserting a duplicate (#585).
+    pub async fn id_by_external_id(
+        &self,
+        external_id: &str,
+    ) -> Result<Option<AlbumId>, LibraryError> {
+        self.repo.id_by_external_id(external_id).await
+    }
+
     pub async fn create_album(&self, name: &str) -> Result<AlbumId, LibraryError> {
         let id = self.repo.create(name).await?;
         if let Err(e) = self
@@ -216,5 +227,68 @@ impl AlbumService {
         limit: u32,
     ) -> Result<Vec<MediaId>, LibraryError> {
         self.repo.cover_media_ids(album_id, limit).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::library::db::test_helpers::open_test_db;
+    use crate::sync::outbox::NoOpRecorder;
+    use tempfile::tempdir;
+
+    async fn make_service() -> (tempfile::TempDir, AlbumService) {
+        let dir = tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let recorder: Arc<dyn MutationRecorder> = Arc::new(NoOpRecorder);
+        (dir, AlbumService::new(db, recorder))
+    }
+
+    /// Issue #585: a locally-created album that has been pushed (so it
+    /// carries an `external_id` for the server UUID) and then pulled
+    /// back via the sync stream must NOT produce a duplicate row. The
+    /// handler resolves `external_id` → local id and upserts in place.
+    /// The service must emit `AlbumUpdated`, not `AlbumAdded`.
+    #[tokio::test]
+    async fn upsert_album_emits_updated_when_round_tripped_via_external_id() {
+        let (_dir, svc) = make_service().await;
+        let mut rx = svc.subscribe();
+
+        // Local create. Push has stamped the server UUID as external_id.
+        let local_id = svc.create_album("Vacation").await.unwrap();
+        let server_id = "server-album-uuid";
+        svc.upsert_album(local_id.as_str(), "Vacation", 0, 0, Some(server_id))
+            .await
+            .unwrap();
+
+        // Drain events emitted so far (the upsert above will fire
+        // `AlbumAdded` on the first call because there's no prior row
+        // — `create_album` itself doesn't emit).
+        while rx.try_recv().is_ok() {}
+
+        // Pull-sync arrives. The new handler resolves external_id →
+        // local_id and upserts under it.
+        let resolved = svc.id_by_external_id(server_id).await.unwrap();
+        assert_eq!(resolved.as_ref(), Some(&local_id));
+
+        svc.upsert_album(
+            resolved.unwrap().as_str(),
+            "Vacation",
+            0,
+            0,
+            Some(server_id),
+        )
+        .await
+        .unwrap();
+
+        let albums = svc.list_albums().await.unwrap();
+        assert_eq!(albums.len(), 1, "expected single album row; got {albums:?}");
+        assert_eq!(albums[0].id, local_id);
+
+        let event = rx.try_recv().expect("expected one event");
+        match event {
+            AlbumEvent::AlbumUpdated(id) => assert_eq!(id, local_id),
+            other => panic!("expected AlbumUpdated; got {other:?}"),
+        }
     }
 }

--- a/src/library/db/migrations/021_add_album_external_id_index.sql
+++ b/src/library/db/migrations/021_add_album_external_id_index.sql
@@ -1,0 +1,17 @@
+-- Index albums.external_id so the sync upsert path doesn't full-scan
+-- the table on every album. Mirrors migration 020 for media.
+--
+-- Since #585, the AlbumV1 sync handler resolves the local AlbumId via
+-- `SELECT id FROM albums WHERE external_id = ?` once per pulled album;
+-- AlbumDeleteV1 and AlbumToAssetV1 use the same lookup. Without the
+-- index every call full-scans the albums table.
+--
+-- UNIQUE over non-NULL values: an Immich UUID identifies one
+-- server-side album, so it must map to at most one local row.
+-- Locally-created albums that haven't been pushed yet have NULL
+-- external_id and are unaffected (SQLite treats NULLs as distinct in
+-- unique indexes). The uniqueness also guarantees the new
+-- "look up local id by external_id, else mint fresh" handler logic
+-- can't silently produce two rows sharing one Immich UUID.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_albums_external_id
+    ON albums(external_id) WHERE external_id IS NOT NULL;

--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use crate::library::album::AlbumId;
 use crate::library::error::LibraryError;
@@ -73,11 +73,31 @@ impl SyncEntityHandler for AlbumDeleteHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let delete: SyncAlbumDeleteV1 = deserialize_entity(data, "AlbumDeleteV1", line_number)?;
-        let id_str = delete.album_id.clone();
-        let id = AlbumId::from_raw(id_str.clone());
-        ctx.library.albums().delete_album(&id).await?;
+        let external_id = delete.album_id.clone();
+
+        // Issue #585: `delete.album_id` is the Immich UUID; the local
+        // row is keyed by the locally-minted `AlbumId`. Translate via
+        // `external_id` lookup before deleting. Warn-and-skip on miss
+        // — the album either was never pulled locally or has already
+        // been removed.
+        let local_id = match ctx.library.albums().id_by_external_id(&external_id).await? {
+            Some(id) => id,
+            None => {
+                warn!(
+                    album_id = %external_id,
+                    "AlbumDeleteV1: no local row for this external_id; nothing to delete"
+                );
+                return Ok(HandlerResult {
+                    entity_id: external_id,
+                    audit_action: "delete",
+                    counter: CounterKind::Deletes,
+                });
+            }
+        };
+
+        ctx.library.albums().delete_album(&local_id).await?;
         Ok(HandlerResult {
-            entity_id: id_str,
+            entity_id: external_id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -23,24 +23,35 @@ impl SyncEntityHandler for AlbumHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let album: SyncAlbumV1 = deserialize_entity(data, "AlbumV1", line_number)?;
-        let id = album.id.clone();
+        let external_id = album.id.clone();
 
         let created_at = parse_datetime(&Some(album.created_at)).unwrap_or(0);
         let updated_at = parse_datetime(&Some(album.updated_at)).unwrap_or(0);
 
+        // Issue #585: keep the locally-owned `AlbumId` stable across the
+        // create→push→pull round-trip. The Immich UUID lives only in
+        // `external_id` — never as the primary key. If a local row already
+        // carries this `external_id` (i.e. push has stamped it), upsert
+        // under the existing local id; otherwise mint a fresh one for the
+        // server-origin album.
+        let local_id = match ctx.library.albums().id_by_external_id(&external_id).await? {
+            Some(existing) => existing,
+            None => AlbumId::new(),
+        };
+
         ctx.library
             .albums()
             .upsert_album(
-                &album.id,
+                local_id.as_str(),
                 &album.name,
                 created_at,
                 updated_at,
-                Some(&album.id),
+                Some(&external_id),
             )
             .await?;
 
         Ok(HandlerResult {
-            entity_id: id,
+            entity_id: external_id,
             audit_action: "upsert",
             counter: CounterKind::Albums,
         })

--- a/src/sync/providers/immich/handlers/album_asset.rs
+++ b/src/sync/providers/immich/handlers/album_asset.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use tracing::warn;
 
-use crate::library::album::AlbumId;
 use crate::library::error::LibraryError;
 
 use super::{CounterKind, HandlerResult, SyncContext, SyncEntityHandler};
@@ -50,13 +49,38 @@ impl SyncEntityHandler for AlbumAssetHandler {
             }
         };
 
+        // Issue #585: same idea for the album side. `assoc.album_id` is
+        // the Immich UUID; `album_media.album_id` references the local
+        // `AlbumId`. The parent `AlbumV1` row is emitted in the same sync
+        // batch and resolved via `external_id`, so by the time membership
+        // rows arrive we expect the local album row to exist. Warn-and-
+        // skip on miss rather than wedge a dangling FK.
+        let album_id = match ctx
+            .library
+            .albums()
+            .id_by_external_id(&assoc.album_id)
+            .await?
+        {
+            Some(id) => id,
+            None => {
+                warn!(
+                    album_id = %assoc.album_id,
+                    asset_id = %assoc.asset_id,
+                    "AlbumToAssetV1: parent album not found locally; skipping membership row"
+                );
+                return Ok(HandlerResult {
+                    entity_id: id,
+                    audit_action: "upsert",
+                    counter: CounterKind::Albums,
+                });
+            }
+        };
+
         let now = chrono::Utc::now().timestamp();
         ctx.db
-            .upsert_album_media(&assoc.album_id, media_id.as_str(), now)
+            .upsert_album_media(album_id.as_str(), media_id.as_str(), now)
             .await?;
-        ctx.library
-            .albums()
-            .emit_album_media_changed(&AlbumId::from_raw(assoc.album_id));
+        ctx.library.albums().emit_album_media_changed(&album_id);
 
         Ok(HandlerResult {
             entity_id: id,
@@ -113,12 +137,34 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
             }
         };
 
-        ctx.db
-            .delete_album_media_entry(&assoc.album_id, media_id.as_str())
-            .await?;
-        ctx.library
+        // Issue #585: translate the album side too. If the local album
+        // row has already been removed, the album_media join went with
+        // it (cascade) — nothing to delete.
+        let album_id = match ctx
+            .library
             .albums()
-            .emit_album_media_changed(&AlbumId::from_raw(assoc.album_id));
+            .id_by_external_id(&assoc.album_id)
+            .await?
+        {
+            Some(id) => id,
+            None => {
+                warn!(
+                    album_id = %assoc.album_id,
+                    asset_id = %assoc.asset_id,
+                    "AlbumToAssetDeleteV1: parent album not found locally; nothing to delete"
+                );
+                return Ok(HandlerResult {
+                    entity_id: id,
+                    audit_action: "delete",
+                    counter: CounterKind::Deletes,
+                });
+            }
+        };
+
+        ctx.db
+            .delete_album_media_entry(album_id.as_str(), media_id.as_str())
+            .await?;
+        ctx.library.albums().emit_album_media_changed(&album_id);
 
         Ok(HandlerResult {
             entity_id: id,


### PR DESCRIPTION
## Summary
- Resolve Immich-side album UUID → local `AlbumId` via `external_id` before upserting in the pull handler, so the post-push pull lands on the existing local row instead of inserting a duplicate.
- Apply the same translation in the `AlbumToAssetV1` add and delete handlers so `album_media.album_id` continues to reference the local id after round-trip.
- Mirrors the #626 stable-MediaId pattern; the Immich UUID lives in `external_id` only — never as the primary key.

Fixes #585.

## Why this happened
`AlbumHandler` previously called `upsert_album(&album.id, ..., Some(&album.id))` with the server-generated UUID as the primary key. The local row carried the locally-minted UUID, so `INSERT OR REPLACE` produced a second row, the service emitted `AlbumAdded`, and `AlbumClientV2`'s idempotency guard couldn't help because the IDs were different.

## Test plan
- [x] `make lint` clean
- [x] `make test` — 477 passed, including new `id_by_external_id_finds_row_or_returns_none` and `upsert_album_emits_updated_when_round_tripped_via_external_id`
- [x] Manual: create album with Immich backend, observe pull cycle — single album row, all `update_in_models` calls land on the local id
- [ ] Verify album-membership round-trip works (add photos via UI, pull cycle keeps association on local album_id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)