### PR TITLE
fix(photo-grid): app-owned selection state (#547)

### DIFF
--- a/io.github.justinf555.Moments.dev.json
+++ b/io.github.justinf555.Moments.dev.json
@@ -13,7 +13,8 @@
         "--socket=fallback-x11",
         "--device=dri",
         "--socket=wayland",
-        "--socket=pulseaudio"
+        "--socket=pulseaudio",
+        "--env=RUST_LOG=moments=debug"
     ],
     "build-options" : {
         "append-path" : "/usr/lib/sdk/rust-stable/bin",

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -15,6 +15,8 @@ src/ui/import_dialog/import_dialog.blp
 src/ui/people_grid/actions.rs
 src/ui/people_grid/cell.rs
 src/ui/people_grid/people_grid.blp
+src/ui/photo_grid/action_bar.rs
+src/ui/photo_grid/actions.rs
 src/ui/photo_grid/cell.rs
 src/ui/photo_grid/factory.rs
 src/ui/photo_grid/mod.rs

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,18 @@ fn main() -> glib::ExitCode {
     // Initialise GStreamer for video poster-frame extraction.
     gstreamer::init().expect("failed to initialise GStreamer");
 
-    // Initialise tracing — RUST_LOG controls verbosity (e.g. RUST_LOG=moments=debug)
+    // Initialise tracing — RUST_LOG controls verbosity (e.g. RUST_LOG=moments=debug).
+    // Debug builds default to `moments=debug` so dev runs (make run-dev,
+    // GNOME Builder) get verbose output without needing the env var
+    // wired through the Flatpak sandbox; release defaults to `info`.
+    let default_filter = if cfg!(debug_assertions) {
+        "moments=debug"
+    } else {
+        "moments=info"
+    };
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("moments=info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_filter)),
         )
         .init();
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,20 +1,20 @@
 /* ── Selection highlighting for the photo grid ────────────────────────────
  *
- * Custom rule because GtkGridView's default :selected styling is a full
- * background fill — we need a tight accent-coloured border around each
- * cell instead.  Only shown when the grid has the .selection-active class
- * (set by enter/exit selection mode).  Without the class, clicking cells
- * does not show a selection border — selection is driven by checkboxes.
+ * Selection is driven by checkboxes via the app-owned SelectionState
+ * (#547).  PhotoGridCell::set_checked toggles a `.selected` CSS class
+ * on the cell whenever its id is in the set.  These rules only paint
+ * during selection mode (the GridView gets `.selection-active` from
+ * enter/exit-selection) — outside selection mode the class is never
+ * applied because cells are never checked.
  */
-gridview.selection-active > child:selected photo-grid-cell {
+gridview.selection-active photo-grid-cell.selected {
     border: 3px solid @accent_bg_color;
     border-radius: 6px;
 }
 
-/* Custom rule: GTK's default :selected state does not dim the picture.
- * A subtle opacity reduction gives visual feedback that the cell is
- * selected without obscuring the image content. */
-gridview.selection-active > child:selected photo-grid-cell picture {
+/* Subtle opacity reduction on the picture itself reinforces the border
+ * without obscuring the image content. */
+gridview.selection-active photo-grid-cell.selected picture {
     opacity: 0.85;
 }
 

--- a/src/ui/photo_grid/action_bar.rs
+++ b/src/ui/photo_grid/action_bar.rs
@@ -6,6 +6,7 @@
 //! - **Album**: Favourite, Remove from album, Delete
 
 use adw::prelude::*;
+use gettextrs::{gettext, ngettext};
 use gtk::gio;
 
 use crate::library::album::AlbumId;
@@ -43,10 +44,10 @@ pub fn build_for_filter(
 // ── Standard: Favourite, Add to album, Delete ────────────────────────────────
 
 fn build_standard_bar(state: &SelectionState, store: &gio::ListStore) -> ActionBarButtons {
-    let fav_btn = make_button("starred-symbolic", "Favourite");
+    let fav_btn = make_button("starred-symbolic", &gettext("Favourite"));
     fav_btn.set_width_request(150);
-    let album_btn = make_button("folder-new-symbolic", "Add to album");
-    let trash_btn = make_button("user-trash-symbolic", "Delete");
+    let album_btn = make_button("folder-new-symbolic", &gettext("Add to album"));
+    let trash_btn = make_button("user-trash-symbolic", &gettext("Delete"));
 
     wire_favourite(&fav_btn, state, store);
     wire_trash(&trash_btn, state);
@@ -66,8 +67,8 @@ fn build_standard_bar(state: &SelectionState, store: &gio::ListStore) -> ActionB
 // ── Trash: Restore, Delete permanently ───────────────────────────────────────
 
 fn build_trash_bar(state: &SelectionState) -> ActionBarButtons {
-    let restore_btn = make_button("edit-undo-symbolic", "Restore");
-    let delete_btn = make_button("edit-delete-symbolic", "Delete permanently");
+    let restore_btn = make_button("edit-undo-symbolic", &gettext("Restore"));
+    let delete_btn = make_button("edit-delete-symbolic", &gettext("Delete permanently"));
 
     wire_restore(&restore_btn, state);
     wire_delete_permanently(&delete_btn, state);
@@ -90,10 +91,10 @@ fn build_album_bar(
     store: &gio::ListStore,
     album_id: &AlbumId,
 ) -> ActionBarButtons {
-    let fav_btn = make_button("starred-symbolic", "Favourite");
+    let fav_btn = make_button("starred-symbolic", &gettext("Favourite"));
     fav_btn.set_width_request(150);
-    let remove_btn = make_button("list-remove-symbolic", "Remove from album");
-    let trash_btn = make_button("user-trash-symbolic", "Delete");
+    let remove_btn = make_button("list-remove-symbolic", &gettext("Remove from album"));
+    let trash_btn = make_button("user-trash-symbolic", &gettext("Delete"));
 
     wire_favourite(&fav_btn, state, store);
     wire_remove_from_album(&remove_btn, state, album_id);
@@ -143,20 +144,22 @@ fn wire_favourite(btn: &gtk::Button, state: &SelectionState, store: &gio::ListSt
     let btn_ref = btn.clone();
     btn.connect_clicked(move |_| {
         let ids = s.ids();
-        let Some(first_id) = ids.first() else {
+        if ids.is_empty() {
             return;
-        };
+        }
 
-        // Toggle direction is decided by the first selected item's
-        // current favourite state — same as the legacy MultiSelection
-        // path. With NoSelection there's no order from GTK, so "first"
-        // here is HashSet iteration order; for the toggle direction
-        // this matches the legacy semantics of "do the opposite of
-        // whatever the lead item shows".
-        let first_fav = super::find_item_in_store(&st, first_id)
-            .map(|o| o.is_favorite())
-            .unwrap_or(false);
-        let new_state = !first_fav;
+        // Toggle direction matches the visible button label, which is
+        // derived from `all_fav` in the selection-changed handler:
+        //   all favourited → label "Unfavourite" → click unfavourites all
+        //   any unfavourited → label "Favourite"  → click favourites all
+        // This is order-independent, unlike `s.ids().first()` which
+        // would depend on HashSet iteration order.
+        let all_fav = ids.iter().all(|id| {
+            super::find_item_in_store(&st, id)
+                .map(|o| o.is_favorite())
+                .unwrap_or(false)
+        });
+        let new_state = !all_fav;
 
         if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
             mc.set_favorite(ids, new_state);
@@ -200,18 +203,19 @@ fn wire_delete_permanently(btn: &gtk::Button, state: &SelectionState) {
         }
 
         let count = ids.len();
-        let message = if count == 1 {
-            "Permanently delete this photo? This cannot be undone.".to_string()
-        } else {
-            format!("Permanently delete {count} photos? This cannot be undone.")
-        };
+        let message = ngettext(
+            "Permanently delete this photo? This cannot be undone.",
+            "Permanently delete {} photos? This cannot be undone.",
+            count as u32,
+        )
+        .replace("{}", &count.to_string());
 
         let dialog = adw::AlertDialog::builder()
-            .heading("Delete permanently?")
+            .heading(gettext("Delete permanently?"))
             .body(&message)
             .build();
-        dialog.add_response("cancel", "Cancel");
-        dialog.add_response("delete", "Delete");
+        dialog.add_response("cancel", &gettext("Cancel"));
+        dialog.add_response("delete", &gettext("Delete"));
         dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
         dialog.set_default_response(Some("cancel"));
 

--- a/src/ui/photo_grid/action_bar.rs
+++ b/src/ui/photo_grid/action_bar.rs
@@ -6,12 +6,13 @@
 //! - **Album**: Favourite, Remove from album, Delete
 
 use adw::prelude::*;
+use gtk::gio;
 
 use crate::library::album::AlbumId;
 use crate::library::media::MediaFilter;
 
 use super::actions;
-use crate::client::MediaItemObject;
+use super::selection::SelectionState;
 
 /// The built action bar buttons and the container box.
 pub struct ActionBarButtons {
@@ -27,24 +28,28 @@ pub struct ActionBarButtons {
 /// Build action bar buttons appropriate for the given filter.
 ///
 /// Returns wired buttons ready to be placed in a `gtk::ActionBar`.
-pub fn build_for_filter(filter: &MediaFilter, selection: &gtk::MultiSelection) -> ActionBarButtons {
+pub fn build_for_filter(
+    filter: &MediaFilter,
+    state: &SelectionState,
+    store: &gio::ListStore,
+) -> ActionBarButtons {
     match filter {
-        MediaFilter::Trashed => build_trash_bar(selection),
-        MediaFilter::Album { album_id } => build_album_bar(selection, album_id),
-        _ => build_standard_bar(selection),
+        MediaFilter::Trashed => build_trash_bar(state),
+        MediaFilter::Album { album_id } => build_album_bar(state, store, album_id),
+        _ => build_standard_bar(state, store),
     }
 }
 
 // ── Standard: Favourite, Add to album, Delete ────────────────────────────────
 
-fn build_standard_bar(selection: &gtk::MultiSelection) -> ActionBarButtons {
+fn build_standard_bar(state: &SelectionState, store: &gio::ListStore) -> ActionBarButtons {
     let fav_btn = make_button("starred-symbolic", "Favourite");
     fav_btn.set_width_request(150);
     let album_btn = make_button("folder-new-symbolic", "Add to album");
     let trash_btn = make_button("user-trash-symbolic", "Delete");
 
-    wire_favourite(&fav_btn, selection);
-    wire_trash(&trash_btn, selection);
+    wire_favourite(&fav_btn, state, store);
+    wire_trash(&trash_btn, state);
 
     let container = bar_container();
     container.append(&fav_btn);
@@ -60,12 +65,12 @@ fn build_standard_bar(selection: &gtk::MultiSelection) -> ActionBarButtons {
 
 // ── Trash: Restore, Delete permanently ───────────────────────────────────────
 
-fn build_trash_bar(selection: &gtk::MultiSelection) -> ActionBarButtons {
+fn build_trash_bar(state: &SelectionState) -> ActionBarButtons {
     let restore_btn = make_button("edit-undo-symbolic", "Restore");
     let delete_btn = make_button("edit-delete-symbolic", "Delete permanently");
 
-    wire_restore(&restore_btn, selection);
-    wire_delete_permanently(&delete_btn, selection);
+    wire_restore(&restore_btn, state);
+    wire_delete_permanently(&delete_btn, state);
 
     let container = bar_container();
     container.append(&restore_btn);
@@ -80,15 +85,19 @@ fn build_trash_bar(selection: &gtk::MultiSelection) -> ActionBarButtons {
 
 // ── Album: Favourite, Remove from album, Delete ──────────────────────────────
 
-fn build_album_bar(selection: &gtk::MultiSelection, album_id: &AlbumId) -> ActionBarButtons {
+fn build_album_bar(
+    state: &SelectionState,
+    store: &gio::ListStore,
+    album_id: &AlbumId,
+) -> ActionBarButtons {
     let fav_btn = make_button("starred-symbolic", "Favourite");
     fav_btn.set_width_request(150);
     let remove_btn = make_button("list-remove-symbolic", "Remove from album");
     let trash_btn = make_button("user-trash-symbolic", "Delete");
 
-    wire_favourite(&fav_btn, selection);
-    wire_remove_from_album(&remove_btn, selection, album_id);
-    wire_trash(&trash_btn, selection);
+    wire_favourite(&fav_btn, state, store);
+    wire_remove_from_album(&remove_btn, state, album_id);
+    wire_trash(&trash_btn, state);
 
     let container = bar_container();
     container.append(&fav_btn);
@@ -128,18 +137,23 @@ fn bar_container() -> gtk::Box {
 
 // ── Wiring ───────────────────────────────────────────────────────────────────
 
-fn wire_favourite(btn: &gtk::Button, selection: &gtk::MultiSelection) {
-    let sel = selection.clone();
+fn wire_favourite(btn: &gtk::Button, state: &SelectionState, store: &gio::ListStore) {
+    let s = state.clone();
+    let st = store.clone();
     let btn_ref = btn.clone();
     btn.connect_clicked(move |_| {
-        let ids = super::collect_selected_ids(&sel);
-        if ids.is_empty() {
+        let ids = s.ids();
+        let Some(first_id) = ids.first() else {
             return;
-        }
+        };
 
-        let first_fav = sel
-            .item(sel.selection().nth(0))
-            .and_then(|o| o.downcast::<MediaItemObject>().ok())
+        // Toggle direction is decided by the first selected item's
+        // current favourite state — same as the legacy MultiSelection
+        // path. With NoSelection there's no order from GTK, so "first"
+        // here is HashSet iteration order; for the toggle direction
+        // this matches the legacy semantics of "do the opposite of
+        // whatever the lead item shows".
+        let first_fav = super::find_item_in_store(&st, first_id)
             .map(|o| o.is_favorite())
             .unwrap_or(false);
         let new_state = !first_fav;
@@ -151,10 +165,10 @@ fn wire_favourite(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     });
 }
 
-fn wire_trash(btn: &gtk::Button, selection: &gtk::MultiSelection) {
-    let sel = selection.clone();
+fn wire_trash(btn: &gtk::Button, state: &SelectionState) {
+    let s = state.clone();
     btn.connect_clicked(move |_| {
-        let ids = super::collect_selected_ids(&sel);
+        let ids = s.ids();
         if ids.is_empty() {
             return;
         }
@@ -164,10 +178,10 @@ fn wire_trash(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     });
 }
 
-fn wire_restore(btn: &gtk::Button, selection: &gtk::MultiSelection) {
-    let sel = selection.clone();
+fn wire_restore(btn: &gtk::Button, state: &SelectionState) {
+    let s = state.clone();
     btn.connect_clicked(move |_| {
-        let ids = super::collect_selected_ids(&sel);
+        let ids = s.ids();
         if ids.is_empty() {
             return;
         }
@@ -177,10 +191,10 @@ fn wire_restore(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     });
 }
 
-fn wire_delete_permanently(btn: &gtk::Button, selection: &gtk::MultiSelection) {
-    let sel = selection.clone();
+fn wire_delete_permanently(btn: &gtk::Button, state: &SelectionState) {
+    let s = state.clone();
     btn.connect_clicked(move |btn| {
-        let ids = super::collect_selected_ids(&sel);
+        let ids = s.ids();
         if ids.is_empty() {
             return;
         }
@@ -218,11 +232,11 @@ fn wire_delete_permanently(btn: &gtk::Button, selection: &gtk::MultiSelection) {
     });
 }
 
-fn wire_remove_from_album(btn: &gtk::Button, selection: &gtk::MultiSelection, album_id: &AlbumId) {
-    let sel = selection.clone();
+fn wire_remove_from_album(btn: &gtk::Button, state: &SelectionState, album_id: &AlbumId) {
+    let s = state.clone();
     let aid = album_id.clone();
     btn.connect_clicked(move |_| {
-        let ids = super::collect_selected_ids(&sel);
+        let ids = s.ids();
         if ids.is_empty() {
             return;
         }

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use adw::prelude::*;
+use gettextrs::{gettext, ngettext};
 use gtk::{gio, glib};
 use tracing::debug;
 
@@ -158,11 +159,11 @@ fn find_clicked_item(grid_view: &gtk::GridView, x: f64, y: f64) -> Option<MediaI
 
 /// Build the trash-view context menu: Restore, Delete Permanently.
 fn build_trash_menu(vbox: &gtk::Box, pop_ref: &glib::WeakRef<gtk::Popover>, ids: Vec<MediaId>) {
-    let restore_btn = gtk::Button::with_label("Restore");
+    let restore_btn = gtk::Button::with_label(&gettext("Restore"));
     restore_btn.add_css_class("flat");
     vbox.append(&restore_btn);
 
-    let delete_btn = gtk::Button::with_label("Delete Permanently");
+    let delete_btn = gtk::Button::with_label(&gettext("Delete Permanently"));
     delete_btn.add_css_class("flat");
     delete_btn.add_css_class("error");
     vbox.append(&delete_btn);
@@ -181,21 +182,21 @@ fn build_standard_menu(
     is_favorite: bool,
 ) {
     let fav_label = if is_favorite {
-        "Unfavourite"
+        gettext("Unfavourite")
     } else {
-        "Favourite"
+        gettext("Favourite")
     };
-    let fav_btn = gtk::Button::with_label(fav_label);
+    let fav_btn = gtk::Button::with_label(&fav_label);
     fav_btn.add_css_class("flat");
     vbox.append(&fav_btn);
 
-    let trash_btn = gtk::Button::with_label("Move to Trash");
+    let trash_btn = gtk::Button::with_label(&gettext("Move to Trash"));
     trash_btn.add_css_class("flat");
     trash_btn.add_css_class("error");
     vbox.append(&trash_btn);
 
     if let MediaFilter::Album { ref album_id } = *filter {
-        let remove_btn = gtk::Button::with_label("Remove from Album");
+        let remove_btn = gtk::Button::with_label(&gettext("Remove from Album"));
         remove_btn.add_css_class("flat");
         vbox.append(&remove_btn);
 
@@ -255,18 +256,19 @@ fn wire_permanent_delete_button(
         }
 
         let count = ids.len();
-        let message = if count == 1 {
-            "Permanently delete this photo? This cannot be undone.".to_string()
-        } else {
-            format!("Permanently delete {count} photos? This cannot be undone.")
-        };
+        let message = ngettext(
+            "Permanently delete this photo? This cannot be undone.",
+            "Permanently delete {} photos? This cannot be undone.",
+            count as u32,
+        )
+        .replace("{}", &count.to_string());
 
         let dialog = adw::AlertDialog::builder()
-            .heading("Delete permanently?")
+            .heading(gettext("Delete permanently?"))
             .body(&message)
             .build();
-        dialog.add_response("cancel", "Cancel");
-        dialog.add_response("delete", "Delete");
+        dialog.add_response("cancel", &gettext("Cancel"));
+        dialog.add_response("delete", &gettext("Delete"));
         dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
         dialog.set_default_response(Some("cancel"));
 
@@ -340,9 +342,9 @@ pub(super) fn update_fav_button(btn: &gtk::Button, all_fav: bool) {
 
     if all_fav {
         icon.set_icon_name(Some("non-starred-symbolic"));
-        label.set_label("Unfavourite");
+        label.set_label(&gettext("Unfavourite"));
     } else {
         icon.set_icon_name(Some("starred-symbolic"));
-        label.set_label("Favourite");
+        label.set_label(&gettext("Favourite"));
     }
 }

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -1,34 +1,81 @@
 //! Context menu and album popover wiring for the photo grid.
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use adw::prelude::*;
-use gtk::glib;
+use gtk::{gio, glib};
 use tracing::debug;
 
-use crate::library::media::MediaFilter;
+use crate::library::media::{MediaFilter, MediaId};
 
 use crate::client::MediaItemObject;
+
+use super::selection::SelectionState;
 
 /// Context passed to wiring functions.
 ///
 /// Carries view references for context menus and action bar actions.
 pub(super) struct ActionContext {
-    pub selection: gtk::MultiSelection,
+    pub state: SelectionState,
+    pub store: gio::ListStore,
     pub filter: MediaFilter,
     pub grid_view: gtk::GridView,
 }
 
 /// Wire the "Add to Album" button to open the album picker dialog.
 pub(super) fn wire_album_controls(ctx: &ActionContext, album_btn: &gtk::Button) {
-    let selection = ctx.selection.clone();
+    let state = ctx.state.clone();
 
     album_btn.connect_clicked(move |btn: &gtk::Button| {
         debug!("album button clicked");
-        let ids = super::collect_selected_ids(&selection);
+        let ids = state.ids();
         if ids.is_empty() {
             return;
         }
         crate::ui::album_picker_dialog::show_album_picker_dialog(btn, ids);
     });
+}
+
+/// Wire single-click cell-body selection toggling.
+///
+/// In selection mode, clicking anywhere on a cell toggles its
+/// membership in [`SelectionState`]. The gesture is on the GridView
+/// itself (not each cell) because GridView wraps cells in
+/// `GtkListItemWidget` which intercepts clicks before any cell-level
+/// gesture fires — same reason the right-click context menu is wired
+/// here too. Outside selection mode the gesture is a no-op so the
+/// GridView's double-click activation continues to fire normally.
+pub(super) fn wire_selection_click(ctx: &ActionContext, selection_mode: Rc<Cell<bool>>) {
+    let gesture = gtk::GestureClick::new();
+    gesture.set_button(1);
+    // Capture-phase: GridView's internal `GtkListItemWidget` wrappers
+    // handle button-1 presses on the way back up the tree (focus +
+    // activation routing), so a Bubble-phase gesture never sees the
+    // event. Right-click (button 3) doesn't compete and works on
+    // Bubble; left-click needs Capture to win.
+    gesture.set_propagation_phase(gtk::PropagationPhase::Capture);
+
+    let grid_view = ctx.grid_view.clone();
+    let state = ctx.state.clone();
+
+    gesture.connect_pressed(move |gesture, _, x, y| {
+        if !selection_mode.get() {
+            return;
+        }
+        let Some(item) = find_clicked_item(&grid_view, x, y) else {
+            return;
+        };
+        let id = item.item().id.clone();
+        if state.contains(&id) {
+            state.remove(&id);
+        } else {
+            state.insert(id);
+        }
+        gesture.set_state(gtk::EventSequenceState::Claimed);
+    });
+
+    ctx.grid_view.add_controller(gesture);
 }
 
 /// Wire the right-click context menu on grid cells.
@@ -39,31 +86,29 @@ pub(super) fn wire_context_menu(ctx: &ActionContext) {
     gesture.set_button(3);
 
     let grid_view = ctx.grid_view.clone();
-    let selection = ctx.selection.clone();
+    let state = ctx.state.clone();
     let filter = ctx.filter.clone();
 
     gesture.connect_pressed(move |gesture, _, x, y| {
-        let Some(pos) = find_clicked_position(&grid_view, &selection, x, y) else {
+        let Some(item) = find_clicked_item(&grid_view, x, y) else {
             return;
         };
+        let id = item.item().id.clone();
 
-        // If the right-clicked item is not already selected, select just it
-        // (replacing any existing selection). If it's already part of a
-        // multi-selection, preserve the selection so the context menu acts
-        // on all selected items.
-        if !selection.is_selected(pos) {
-            selection.unselect_all();
-            selection.select_item(pos, true);
-        }
-
-        let Some(obj) = selection
-            .item(pos)
-            .and_then(|o| o.downcast::<MediaItemObject>().ok())
-        else {
-            return;
+        // Decide the operative ids without mutating the visible
+        // selection (#547 follow-up). If the clicked item is checked,
+        // act on the whole selection; otherwise clear stale checks and
+        // act on just this item — but don't *add* it to the selection,
+        // since visible cells repaint on `state.changed` and a
+        // surprise checkmark appears under the user's right-click.
+        let operative_ids: Vec<MediaId> = if state.contains(&id) {
+            state.ids()
+        } else {
+            state.clear();
+            vec![id]
         };
 
-        let is_favorite = obj.is_favorite();
+        let is_favorite = item.is_favorite();
         let is_trash = matches!(filter, MediaFilter::Trashed);
 
         let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
@@ -76,9 +121,9 @@ pub(super) fn wire_context_menu(ctx: &ActionContext) {
         let pop_ref: glib::WeakRef<gtk::Popover> = popover.downgrade();
 
         if is_trash {
-            build_trash_menu(&vbox, &pop_ref, &selection);
+            build_trash_menu(&vbox, &pop_ref, operative_ids);
         } else {
-            build_standard_menu(&vbox, &pop_ref, &selection, &filter, is_favorite);
+            build_standard_menu(&vbox, &pop_ref, operative_ids, &filter, is_favorite);
         }
 
         popover.set_child(Some(&vbox));
@@ -97,35 +142,14 @@ pub(super) fn wire_context_menu(ctx: &ActionContext) {
     ctx.grid_view.add_controller(gesture);
 }
 
-/// Find the store position of the item at (x, y) by resolving the cell's
-/// bound data. This is correct even when the grid is scrolled (unlike
-/// counting siblings, which only works for non-virtualized lists).
-fn find_clicked_position(
-    grid_view: &gtk::GridView,
-    selection: &gtk::MultiSelection,
-    x: f64,
-    y: f64,
-) -> Option<u32> {
-    let picked = grid_view.pick(x, y, gtk::PickFlags::DEFAULT)?;
-
-    // Walk up from the picked widget to find the PhotoGridCell.
-    let mut widget = Some(picked);
+/// Walk up from the picked widget to find the bound `MediaItemObject`.
+/// Correct under virtualization (positions are recycled), unlike the
+/// previous position-based lookup.
+fn find_clicked_item(grid_view: &gtk::GridView, x: f64, y: f64) -> Option<MediaItemObject> {
+    let mut widget = grid_view.pick(x, y, gtk::PickFlags::DEFAULT);
     while let Some(ref w) = widget {
         if let Some(cell) = w.downcast_ref::<super::cell::PhotoGridCell>() {
-            let item = cell.bound_item()?;
-            let target_id = item.item().id.clone();
-            // Search the selection model for the matching item.
-            for i in 0..selection.n_items() {
-                if let Some(obj) = selection
-                    .item(i)
-                    .and_then(|o| o.downcast::<MediaItemObject>().ok())
-                {
-                    if obj.item().id == target_id {
-                        return Some(i);
-                    }
-                }
-            }
-            return None;
+            return cell.bound_item();
         }
         widget = w.parent();
     }
@@ -133,11 +157,7 @@ fn find_clicked_position(
 }
 
 /// Build the trash-view context menu: Restore, Delete Permanently.
-fn build_trash_menu(
-    vbox: &gtk::Box,
-    pop_ref: &glib::WeakRef<gtk::Popover>,
-    selection: &gtk::MultiSelection,
-) {
+fn build_trash_menu(vbox: &gtk::Box, pop_ref: &glib::WeakRef<gtk::Popover>, ids: Vec<MediaId>) {
     let restore_btn = gtk::Button::with_label("Restore");
     restore_btn.add_css_class("flat");
     vbox.append(&restore_btn);
@@ -147,8 +167,8 @@ fn build_trash_menu(
     delete_btn.add_css_class("error");
     vbox.append(&delete_btn);
 
-    wire_restore_button(&restore_btn, pop_ref, selection);
-    wire_permanent_delete_button(&delete_btn, pop_ref, selection);
+    wire_restore_button(&restore_btn, pop_ref, ids.clone());
+    wire_permanent_delete_button(&delete_btn, pop_ref, ids);
 }
 
 /// Build the standard/album context menu: Favourite, Move to Trash,
@@ -156,7 +176,7 @@ fn build_trash_menu(
 fn build_standard_menu(
     vbox: &gtk::Box,
     pop_ref: &glib::WeakRef<gtk::Popover>,
-    selection: &gtk::MultiSelection,
+    ids: Vec<MediaId>,
     filter: &MediaFilter,
     is_favorite: bool,
 ) {
@@ -180,44 +200,41 @@ fn build_standard_menu(
         vbox.append(&remove_btn);
 
         let pw = pop_ref.clone();
-        let sel = selection.clone();
         let aid = album_id.clone();
+        let ids_for_remove = ids.clone();
         remove_btn.connect_clicked(move |_| {
             if let Some(p) = pw.upgrade() {
                 p.popdown();
             }
-            let ids = super::collect_selected_ids(&sel);
-            if ids.is_empty() {
+            if ids_for_remove.is_empty() {
                 return;
             }
             if let Some(ac) = crate::application::MomentsApplication::default().album_client_v2() {
-                ac.remove_from_album(aid.clone(), ids);
+                ac.remove_from_album(aid.clone(), ids_for_remove.clone());
             }
         });
     }
 
-    wire_favourite_button(&fav_btn, pop_ref, selection, !is_favorite);
-    wire_trash_button(&trash_btn, pop_ref, selection);
+    wire_favourite_button(&fav_btn, pop_ref, ids.clone(), !is_favorite);
+    wire_trash_button(&trash_btn, pop_ref, ids);
 }
 
 /// Wire the Restore button to send a restore command.
 fn wire_restore_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
-    selection: &gtk::MultiSelection,
+    ids: Vec<MediaId>,
 ) {
     let pw = pop_ref.clone();
-    let sel = selection.clone();
     btn.connect_clicked(move |_| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
-        let ids = super::collect_selected_ids(&sel);
         if ids.is_empty() {
             return;
         }
         if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.restore(ids);
+            mc.restore(ids.clone());
         }
     });
 }
@@ -226,15 +243,13 @@ fn wire_restore_button(
 fn wire_permanent_delete_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
-    selection: &gtk::MultiSelection,
+    ids: Vec<MediaId>,
 ) {
     let pw = pop_ref.clone();
-    let sel = selection.clone();
     btn.connect_clicked(move |btn| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
-        let ids = super::collect_selected_ids(&sel);
         if ids.is_empty() {
             return;
         }
@@ -256,6 +271,7 @@ fn wire_permanent_delete_button(
         dialog.set_default_response(Some("cancel"));
 
         let window = btn.root().and_downcast::<gtk::Window>();
+        let ids_for_dialog = ids.clone();
         dialog.choose(
             window.as_ref(),
             gtk::gio::Cancellable::NONE,
@@ -264,7 +280,7 @@ fn wire_permanent_delete_button(
                     if let Some(mc) =
                         crate::application::MomentsApplication::default().media_client_v2()
                     {
-                        mc.delete(ids);
+                        mc.delete(ids_for_dialog);
                     }
                 }
             },
@@ -276,43 +292,35 @@ fn wire_permanent_delete_button(
 fn wire_favourite_button(
     btn: &gtk::Button,
     pop_ref: &glib::WeakRef<gtk::Popover>,
-    selection: &gtk::MultiSelection,
+    ids: Vec<MediaId>,
     new_fav: bool,
 ) {
     let pw = pop_ref.clone();
-    let sel = selection.clone();
     btn.connect_clicked(move |_| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
-        let ids = super::collect_selected_ids(&sel);
         if ids.is_empty() {
             return;
         }
         if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.set_favorite(ids, new_fav);
+            mc.set_favorite(ids.clone(), new_fav);
         }
     });
 }
 
 /// Wire the Move to Trash button.
-fn wire_trash_button(
-    btn: &gtk::Button,
-    pop_ref: &glib::WeakRef<gtk::Popover>,
-    selection: &gtk::MultiSelection,
-) {
+fn wire_trash_button(btn: &gtk::Button, pop_ref: &glib::WeakRef<gtk::Popover>, ids: Vec<MediaId>) {
     let pw = pop_ref.clone();
-    let sel = selection.clone();
     btn.connect_clicked(move |_| {
         if let Some(p) = pw.upgrade() {
             p.popdown();
         }
-        let ids = super::collect_selected_ids(&sel);
         if ids.is_empty() {
             return;
         }
         if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.trash(ids);
+            mc.trash(ids.clone());
         }
     });
 }

--- a/src/ui/photo_grid/cell.rs
+++ b/src/ui/photo_grid/cell.rs
@@ -4,6 +4,7 @@ use gettextrs::gettext;
 use gtk::{glib, prelude::*, subclass::prelude::*};
 
 use crate::client::MediaItemObject;
+use crate::ui::photo_grid::selection::SelectionState;
 
 /// Handler IDs stored between `bind` and `unbind` calls.
 ///
@@ -50,6 +51,11 @@ mod imp {
         /// Click handler for the checkbox — connected in factory `bind`,
         /// disconnected in factory `unbind`.
         pub checkbox_handler: RefCell<Option<glib::SignalHandlerId>>,
+        /// `SelectionState::changed` subscription — connected in `bind`,
+        /// disconnected in `unbind`. Disconnecting is essential: cells
+        /// are recycled by virtualization, and a stale handler would fire
+        /// against the wrong bound id (#547).
+        pub state_changed_handler: RefCell<Option<(SelectionState, glib::SignalHandlerId)>>,
     }
 
     #[glib::object_subclass]
@@ -228,8 +234,11 @@ impl PhotoGridCell {
     /// Update the checkbox without firing the `toggled` handler.
     ///
     /// Blocks the signal while setting the active state so that
-    /// programmatic updates don't trigger select/unselect on the
-    /// `MultiSelection` model with a potentially stale position.
+    /// programmatic updates (e.g. from a `SelectionState::changed`
+    /// broadcast on a sibling cell) don't re-enter the toggle handler
+    /// and double-mutate the state. Also reflects the checked state
+    /// as a `.selected` CSS class so the cell's selected styling
+    /// (#547) can target it directly.
     pub fn set_checked(&self, checked: bool) {
         let imp = self.imp();
         let handler = imp.checkbox_handler.borrow();
@@ -239,6 +248,11 @@ impl PhotoGridCell {
         imp.checkbox.set_active(checked);
         if let Some(ref id) = *handler {
             imp.checkbox.unblock_signal(id);
+        }
+        if checked {
+            self.add_css_class("selected");
+        } else {
+            self.remove_css_class("selected");
         }
     }
 

--- a/src/ui/photo_grid/factory.rs
+++ b/src/ui/photo_grid/factory.rs
@@ -11,6 +11,7 @@ use crate::client::{MediaClientV2, MediaItemObject};
 use crate::library::media::{MediaFilter, MediaItem};
 
 use super::cell::PhotoGridCell;
+use super::selection::SelectionState;
 use super::texture_cache::TextureCache;
 
 /// Concurrent thumbnail decodes: half of available cores, minimum 2.
@@ -30,7 +31,7 @@ pub fn build_factory(
     filter: MediaFilter,
     cache: Rc<TextureCache>,
     selection_mode: Rc<Cell<bool>>,
-    selection: gtk::MultiSelection,
+    state: SelectionState,
     enter_selection: gio::SimpleAction,
 ) -> gtk::SignalListItemFactory {
     let factory = gtk::SignalListItemFactory::new();
@@ -56,7 +57,7 @@ pub fn build_factory(
         #[strong]
         selection_mode,
         #[strong]
-        selection,
+        state,
         #[strong]
         enter_selection,
         move |_, obj| {
@@ -69,15 +70,17 @@ pub fn build_factory(
                 .item()
                 .and_downcast::<MediaItemObject>()
                 .expect("item is MediaItemObject");
-            let position = list_item.position();
+            let media_id = item.item().id.clone();
 
             // Configure cell for the view type before binding.
             let is_trash = filter == MediaFilter::Trashed;
             cell.imp().show_star.set(!is_trash);
 
-            // Set checkbox state based on current selection mode.
+            // Set checkbox state from the app-owned SelectionState
+            // (#547). With NoSelection on the GridView, GTK no longer
+            // tracks per-row selection — `state` is the source of truth.
             cell.set_selection_mode(selection_mode.get());
-            cell.set_checked(list_item.is_selected());
+            cell.set_checked(state.contains(&media_id));
 
             cell.bind(&item);
 
@@ -184,10 +187,11 @@ pub fn build_factory(
                     .replace(handler_id);
             }
 
-            // Wire checkbox → select/deselect item + enter selection mode.
+            // Wire checkbox → mutate SelectionState + enter selection mode.
             {
                 let checkbox = cell.imp().checkbox.clone();
-                let sel = selection.clone();
+                let s = state.clone();
+                let id_for_checkbox = media_id.clone();
                 let enter = enter_selection.clone();
                 let sm = Rc::clone(&selection_mode);
                 let handler_id = checkbox.connect_toggled(move |cb| {
@@ -195,12 +199,35 @@ pub fn build_factory(
                         if !sm.get() {
                             enter.activate(None);
                         }
-                        sel.select_item(position, false);
+                        s.insert(id_for_checkbox.clone());
                     } else {
-                        sel.unselect_item(position);
+                        s.remove(&id_for_checkbox);
                     }
                 });
                 cell.imp().checkbox_handler.borrow_mut().replace(handler_id);
+            }
+
+            // Subscribe this cell to SelectionState changes so its
+            // checkbox reflects mutations from any source (other cells,
+            // exit-selection clearing, future select-all). Disconnect in
+            // unbind — the cell is recycled and a stale handler would
+            // fire against the wrong id.
+            {
+                let cell_weak = cell.downgrade();
+                let id_for_signal = media_id.clone();
+                let handler_id = state.connect_closure(
+                    "changed",
+                    false,
+                    glib::closure_local!(move |s: SelectionState| {
+                        if let Some(cell) = cell_weak.upgrade() {
+                            cell.set_checked(s.contains(&id_for_signal));
+                        }
+                    }),
+                );
+                cell.imp()
+                    .state_changed_handler
+                    .borrow_mut()
+                    .replace((state.clone(), handler_id));
             }
         }
     ));
@@ -216,6 +243,9 @@ pub fn build_factory(
         }
         if let Some(handler) = cell.imp().checkbox_handler.borrow_mut().take() {
             cell.imp().checkbox.disconnect(handler);
+        }
+        if let Some((state, handler)) = cell.imp().state_changed_handler.borrow_mut().take() {
+            state.disconnect(handler);
         }
         cell.unbind();
 

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -16,6 +16,7 @@ pub mod action_bar;
 pub mod actions;
 pub mod cell;
 pub mod factory;
+pub mod selection;
 pub mod texture_cache;
 
 /// Available cell sizes (px), smallest to largest.
@@ -34,7 +35,10 @@ mod photo_grid_imp {
         pub scrolled: OnceCell<gtk::ScrolledWindow>,
         pub grid_view: OnceCell<gtk::GridView>,
         pub empty_page: OnceCell<adw::StatusPage>,
-        pub selection: RefCell<Option<gtk::MultiSelection>>,
+        /// App-owned selection set (#547). Mutated by checkbox toggle and
+        /// cell-body clicks while in selection mode; consumed by action
+        /// bar / context menu wiring; observed via the `changed` signal.
+        pub selection_state: super::selection::SelectionState,
         pub store: RefCell<Option<gio::ListStore>>,
         pub zoom_level: Cell<usize>,
         pub media_client: OnceCell<crate::client::MediaClientV2>,
@@ -53,7 +57,7 @@ mod photo_grid_imp {
                 scrolled: OnceCell::default(),
                 grid_view: OnceCell::default(),
                 empty_page: OnceCell::default(),
-                selection: RefCell::default(),
+                selection_state: super::selection::SelectionState::new(),
                 store: RefCell::default(),
                 zoom_level: Cell::new(DEFAULT_ZOOM_INDEX),
                 media_client: OnceCell::default(),
@@ -206,7 +210,7 @@ impl PhotoGrid {
         let filter = imp.filter.borrow().clone();
         let cache = imp.texture_cache().clone();
         let sm = Rc::clone(&imp.selection_mode);
-        let selection = imp.selection.borrow().clone().unwrap();
+        let state = imp.selection_state.clone();
         let enter = imp.enter_selection.borrow().clone().unwrap();
         grid_view.set_factory(Some(&factory::build_factory(
             self.current_cell_size(),
@@ -214,7 +218,7 @@ impl PhotoGrid {
             filter,
             cache,
             sm,
-            selection,
+            state,
             enter,
         )));
     }
@@ -238,11 +242,14 @@ impl PhotoGrid {
         let grid_view = imp.grid_view();
         let scrolled = imp.scrolled();
 
-        let selection = gtk::MultiSelection::new(Some(store.clone()));
-        grid_view.set_model(Some(&selection));
-        *imp.selection.borrow_mut() = Some(selection.clone());
+        // Issue #547: NoSelection disables GTK's native click-to-select
+        // so checkbox state is the single source of truth. Selection
+        // lives in `imp.selection_state`, keyed on `MediaId`.
+        let no_selection = gtk::NoSelection::new(Some(store.clone()));
+        grid_view.set_model(Some(&no_selection));
 
         let sm = Rc::clone(&imp.selection_mode);
+        let state = imp.selection_state.clone();
         let enter = imp.enter_selection.borrow().clone().unwrap();
         grid_view.set_factory(Some(&factory::build_factory(
             self.current_cell_size(),
@@ -250,7 +257,7 @@ impl PhotoGrid {
             filter.clone(),
             cache,
             sm,
-            selection.clone(),
+            state,
             enter,
         )));
 
@@ -287,12 +294,12 @@ impl PhotoGrid {
             });
         }
 
-        let selection_ref = selection.clone();
+        let store_ref = store.clone();
         grid_view.connect_activate(move |_, position| {
-            let n = selection_ref.n_items();
+            let n = store_ref.n_items();
             let items: Vec<MediaItemObject> = (0..n)
                 .filter_map(|i| {
-                    selection_ref
+                    store_ref
                         .item(i)
                         .and_then(|obj| obj.downcast::<MediaItemObject>().ok())
                 })
@@ -347,8 +354,9 @@ mod view_imp {
         pub photo_viewer: OnceCell<PhotoViewer>,
         pub video_viewer: OnceCell<VideoViewer>,
 
-        // Selection mode state
-        pub selection_mode: Rc<Cell<bool>>,
+        // Selection mode state — `selection_mode` itself lives on the
+        // inner PhotoGrid widget so the factory bind path and the
+        // outer enter/exit handlers share one Rc<Cell<bool>>. (#547)
         pub exit_selection: OnceCell<gio::SimpleAction>,
         pub selection_title: OnceCell<gtk::Label>,
         pub bar_box: OnceCell<gtk::Box>,
@@ -584,7 +592,11 @@ impl PhotoGridView {
         action_group.add_action(&zoom_out_action);
 
         // ── Selection mode actions ───────────────────────────────────────
-        let selection_mode = Rc::clone(&imp.selection_mode);
+        // The Rc<Cell<bool>> lives on the inner PhotoGrid widget so the
+        // factory bind path (which decides cell checkbox visibility)
+        // and the cell-body click gesture (which toggles selection
+        // ids) read the same flag we set here.
+        let selection_mode = Rc::clone(&imp.photo_grid.imp().selection_mode);
 
         let enter_selection = gio::SimpleAction::new("enter-selection", None);
         {
@@ -632,9 +644,10 @@ impl PhotoGridView {
                 imp.header.set_title_widget(None::<&gtk::Widget>);
                 imp.action_bar.set_revealed(false);
 
-                if let Some(ref sel) = *imp.photo_grid.imp().selection.borrow() {
-                    sel.unselect_all();
-                }
+                // Drop the app-owned selection set; visible cells re-paint
+                // via the SelectionState `changed` signal subscribed in
+                // factory::build_factory.
+                imp.photo_grid.imp().selection_state.clear();
 
                 let grid_view = imp.photo_grid.imp().grid_view();
                 grid_view.remove_css_class("selection-active");
@@ -737,16 +750,18 @@ impl PhotoGridView {
             },
         );
 
-        let selection = imp.photo_grid.imp().selection.borrow().clone().unwrap();
+        let state = imp.photo_grid.imp().selection_state.clone();
         let grid_view = imp.photo_grid.imp().grid_view().clone();
 
         let ctx = actions::ActionContext {
-            selection: selection.clone(),
+            state: state.clone(),
+            store: store.clone(),
             filter: filter.clone(),
             grid_view,
         };
 
         actions::wire_context_menu(&ctx);
+        actions::wire_selection_click(&ctx, Rc::clone(&imp.photo_grid.imp().selection_mode));
 
         // ── Build action bar buttons for this filter ────────────────────
         let bar_box = imp.bar_box();
@@ -754,7 +769,7 @@ impl PhotoGridView {
             bar_box.remove(&child);
         }
 
-        let bar_buttons = action_bar::build_for_filter(&filter, &ctx.selection);
+        let bar_buttons = action_bar::build_for_filter(&filter, &ctx.state, &ctx.store);
         bar_box.append(&bar_buttons.container);
         *imp.fav_btn.borrow_mut() = bar_buttons.fav_btn;
 
@@ -833,52 +848,53 @@ impl PhotoGridView {
 
         // ── Selection changed → update count, auto-exit ─────────────────
         {
-            let sm = Rc::clone(&imp.selection_mode);
+            let sm = Rc::clone(&imp.photo_grid.imp().selection_mode);
             let exit = imp.exit_selection().clone();
             let title = imp.selection_title().clone();
             let fav_btn = imp.fav_btn.borrow().clone();
-            selection.connect_selection_changed(move |sel, _, _| {
-                let count = sel.selection().size();
-                title.set_label(&selection_count_label(count));
+            let store_ref = store.clone();
+            state.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(move |s: selection::SelectionState| {
+                    let count = s.len() as u64;
+                    title.set_label(&selection_count_label(count));
 
-                if let Some(ref fav) = fav_btn {
-                    if count > 0 {
-                        let bitset = sel.selection();
-                        let all_fav = (0..bitset.size() as u32).all(|i| {
-                            sel.item(bitset.nth(i))
-                                .and_then(|o| o.downcast::<MediaItemObject>().ok())
-                                .map(|o| o.is_favorite())
-                                .unwrap_or(false)
-                        });
-                        actions::update_fav_button(fav, all_fav);
+                    if let Some(ref fav) = fav_btn {
+                        if count > 0 {
+                            let ids = s.ids();
+                            let all_fav = ids.iter().all(|id| {
+                                find_item_in_store(&store_ref, id)
+                                    .map(|o| o.is_favorite())
+                                    .unwrap_or(false)
+                            });
+                            actions::update_fav_button(fav, all_fav);
+                        }
                     }
-                }
 
-                if count == 0 && sm.get() {
-                    exit.activate(None);
-                }
-            });
+                    if count == 0 && sm.get() {
+                        exit.activate(None);
+                    }
+                }),
+            );
         }
     }
 }
 
-/// Collect media IDs from the current selection.
-pub(super) fn collect_selected_ids(
-    selection: &gtk::MultiSelection,
-) -> Vec<crate::library::media::MediaId> {
-    let bitset = selection.selection();
-    let n = bitset.size();
-    let mut ids = Vec::with_capacity(n as usize);
+/// Find a `MediaItemObject` in the store by id. Walks the store linearly.
+pub(super) fn find_item_in_store(
+    store: &gio::ListStore,
+    id: &crate::library::media::MediaId,
+) -> Option<MediaItemObject> {
+    let n = store.n_items();
     for i in 0..n {
-        let pos = bitset.nth(i as u32);
-        if let Some(obj) = selection
-            .item(pos)
-            .and_then(|o| o.downcast::<MediaItemObject>().ok())
-        {
-            ids.push(obj.item().id.clone());
+        if let Some(obj) = store.item(i).and_downcast::<MediaItemObject>() {
+            if &obj.item().id == id {
+                return Some(obj);
+            }
         }
     }
-    ids
+    None
 }
 
 /// Configure the empty state status page for the given filter.

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -211,7 +211,11 @@ impl PhotoGrid {
         let cache = imp.texture_cache().clone();
         let sm = Rc::clone(&imp.selection_mode);
         let state = imp.selection_state.clone();
-        let enter = imp.enter_selection.borrow().clone().unwrap();
+        let enter = imp
+            .enter_selection
+            .borrow()
+            .clone()
+            .expect("PhotoGridView::setup() must be called before set_store()/apply_zoom()");
         grid_view.set_factory(Some(&factory::build_factory(
             self.current_cell_size(),
             media_client,
@@ -250,7 +254,11 @@ impl PhotoGrid {
 
         let sm = Rc::clone(&imp.selection_mode);
         let state = imp.selection_state.clone();
-        let enter = imp.enter_selection.borrow().clone().unwrap();
+        let enter = imp
+            .enter_selection
+            .borrow()
+            .clone()
+            .expect("PhotoGridView::setup() must be called before set_store()/apply_zoom()");
         grid_view.set_factory(Some(&factory::build_factory(
             self.current_cell_size(),
             media_client.clone(),
@@ -364,6 +372,11 @@ mod view_imp {
         /// Signal handler IDs — disconnected on unrealize.
         /// Stores (client_object, handler_id) pairs for later disconnect.
         pub _signal_handlers: RefCell<Vec<(glib::Object, glib::SignalHandlerId)>>,
+        /// Handler id for the `SelectionState::changed` closure installed
+        /// by `set_store`. Disconnected on re-entry so a second
+        /// `set_store` doesn't leave a stale closure capturing the
+        /// previous store.
+        pub selection_changed_handler: RefCell<Option<glib::SignalHandlerId>>,
     }
 
     impl PhotoGridView {
@@ -702,6 +715,14 @@ impl PhotoGridView {
 
     pub fn set_store(&self, store: gio::ListStore, filter: MediaFilter) {
         let imp = self.imp();
+
+        // Disconnect any previous `SelectionState::changed` closure so a
+        // second `set_store` call doesn't leave a stale handler bound to
+        // the previous store.
+        if let Some(handler) = imp.selection_changed_handler.borrow_mut().take() {
+            imp.photo_grid.imp().selection_state.disconnect(handler);
+        }
+
         let media_client = crate::application::MomentsApplication::default()
             .media_client_v2()
             .expect("media client available");
@@ -853,7 +874,7 @@ impl PhotoGridView {
             let title = imp.selection_title().clone();
             let fav_btn = imp.fav_btn.borrow().clone();
             let store_ref = store.clone();
-            state.connect_closure(
+            let handler = state.connect_closure(
                 "changed",
                 false,
                 glib::closure_local!(move |s: selection::SelectionState| {
@@ -877,6 +898,7 @@ impl PhotoGridView {
                     }
                 }),
             );
+            *imp.selection_changed_handler.borrow_mut() = Some(handler);
         }
     }
 }

--- a/src/ui/photo_grid/selection.rs
+++ b/src/ui/photo_grid/selection.rs
@@ -1,0 +1,209 @@
+//! App-owned selection state for the photo grid.
+//!
+//! The grid uses [`gtk::NoSelection`] as its `GridView` selection model
+//! (#547). Selection is tracked here, keyed on [`MediaId`] rather than
+//! position, so virtualization-driven recycling does not corrupt the
+//! state. Cells subscribe to the `changed` signal during bind to keep
+//! their checkbox in sync.
+
+use std::cell::RefCell;
+use std::collections::HashSet;
+
+use gtk::glib;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+use crate::library::media::MediaId;
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct SelectionState {
+        pub set: RefCell<HashSet<MediaId>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for SelectionState {
+        const NAME: &'static str = "MomentsPhotoGridSelectionState";
+        type Type = super::SelectionState;
+        type ParentType = glib::Object;
+    }
+
+    impl ObjectImpl for SelectionState {
+        fn signals() -> &'static [glib::subclass::Signal] {
+            static SIGNALS: std::sync::OnceLock<Vec<glib::subclass::Signal>> =
+                std::sync::OnceLock::new();
+            SIGNALS.get_or_init(|| vec![glib::subclass::Signal::builder("changed").build()])
+        }
+    }
+}
+
+glib::wrapper! {
+    /// Selection set for one photo grid view.
+    ///
+    /// Each [`PhotoGridView`] owns a single instance. Mutations emit a
+    /// `changed` signal so visible cells can update their checkbox
+    /// state without polling.
+    ///
+    /// [`PhotoGridView`]: super::PhotoGridView
+    pub struct SelectionState(ObjectSubclass<imp::SelectionState>);
+}
+
+impl Default for SelectionState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SelectionState {
+    pub fn new() -> Self {
+        glib::Object::builder().build()
+    }
+
+    /// Insert `id`. Returns `true` if it was newly added; emits `changed`
+    /// only when the state actually moved.
+    pub fn insert(&self, id: MediaId) -> bool {
+        let inserted = self.imp().set.borrow_mut().insert(id);
+        if inserted {
+            self.emit_by_name::<()>("changed", &[]);
+        }
+        inserted
+    }
+
+    /// Remove `id`. Returns `true` if it was present; emits `changed`
+    /// only when the state actually moved.
+    pub fn remove(&self, id: &MediaId) -> bool {
+        let removed = self.imp().set.borrow_mut().remove(id);
+        if removed {
+            self.emit_by_name::<()>("changed", &[]);
+        }
+        removed
+    }
+
+    /// Drop every selected id. Emits `changed` only if the set was
+    /// non-empty.
+    pub fn clear(&self) {
+        let was_nonempty = !self.imp().set.borrow().is_empty();
+        if was_nonempty {
+            self.imp().set.borrow_mut().clear();
+            self.emit_by_name::<()>("changed", &[]);
+        }
+    }
+
+    pub fn contains(&self, id: &MediaId) -> bool {
+        self.imp().set.borrow().contains(id)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.imp().set.borrow().is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.imp().set.borrow().len()
+    }
+
+    /// Snapshot of the selected ids. Allocates; cheap for selection-mode
+    /// workloads (tens to hundreds of items).
+    pub fn ids(&self) -> Vec<MediaId> {
+        self.imp().set.borrow().iter().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    fn id(s: &str) -> MediaId {
+        MediaId::new(format!("{s:0<32}"))
+    }
+
+    fn count_changes(state: &SelectionState) -> Rc<Cell<u32>> {
+        let counter = Rc::new(Cell::new(0u32));
+        let c = Rc::clone(&counter);
+        state.connect_closure(
+            "changed",
+            false,
+            glib::closure_local!(move |_: SelectionState| {
+                c.set(c.get() + 1);
+            }),
+        );
+        counter
+    }
+
+    #[test]
+    fn new_is_empty() {
+        let s = SelectionState::new();
+        assert!(s.is_empty());
+        assert_eq!(s.len(), 0);
+        assert!(s.ids().is_empty());
+    }
+
+    #[test]
+    fn insert_returns_true_then_false() {
+        let s = SelectionState::new();
+        let a = id("a");
+        assert!(s.insert(a.clone()));
+        assert!(!s.insert(a));
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn remove_returns_true_on_hit_false_on_miss() {
+        let s = SelectionState::new();
+        let a = id("a");
+        s.insert(a.clone());
+        assert!(s.remove(&a));
+        assert!(!s.remove(&a));
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn clear_empties() {
+        let s = SelectionState::new();
+        s.insert(id("a"));
+        s.insert(id("b"));
+        s.clear();
+        assert!(s.is_empty());
+    }
+
+    #[test]
+    fn contains_reflects_membership() {
+        let s = SelectionState::new();
+        let a = id("a");
+        let b = id("b");
+        s.insert(a.clone());
+        assert!(s.contains(&a));
+        assert!(!s.contains(&b));
+    }
+
+    #[test]
+    fn ids_returns_all() {
+        let s = SelectionState::new();
+        s.insert(id("a"));
+        s.insert(id("b"));
+        s.insert(id("c"));
+        let mut ids = s.ids();
+        ids.sort_by(|x, y| x.as_str().cmp(y.as_str()));
+        assert_eq!(ids.len(), 3);
+    }
+
+    #[test]
+    fn changed_fires_only_on_real_mutations() {
+        let s = SelectionState::new();
+        let counter = count_changes(&s);
+        let a = id("a");
+
+        s.insert(a.clone()); // 1
+        s.insert(a.clone()); // no-op
+        s.remove(&a); // 2
+        s.remove(&a); // no-op
+        s.clear(); // already empty: no-op
+        s.insert(id("b")); // 3
+        s.clear(); // 4
+
+        assert_eq!(counter.get(), 4);
+    }
+}


### PR DESCRIPTION
## Summary
- `gtk::MultiSelection` → `gtk::NoSelection` on the photo GridView; selection now lives in a new `SelectionState` GObject keyed on `MediaId` with a `changed` signal.
- Cells subscribe on bind / disconnect on unbind, so checkbox state always tracks the set even under virtualisation. A capture-phase body-click gesture on the GridView toggles membership while in selection mode (same pattern the right-click context menu uses).
- CSS retargeted from `gridview > child:selected photo-grid-cell` (dead under `NoSelection`) to `photo-grid-cell.selected`, applied by `cell.set_checked`.

Fixes #547.

## Side fixes
- **Right-click no longer mutates the visible selection.** Operative ids are computed at click time; the right-clicked cell isn't surprise-checked.
- **Latent dual `selection_mode` flags collapsed.** PhotoGrid and PhotoGridView each owned their own `Rc<Cell<bool>>`. Now there's one on PhotoGrid, observed by the factory, the body-click gesture, and the enter/exit handlers.
- **Debug builds default `RUST_LOG=moments=debug`.** Lets dev runs (make run-dev, GNOME Builder) pick up traces without threading the env var through the Flatpak sandbox; release behaviour unchanged.

## Album grid
The album grid uses the same vulnerable `MultiSelection` pattern. Folded into #632 (vBacklog) to be tackled alongside the widget-hierarchy work (#559–#565), so the SelectionState primitive can be lifted into `src/ui/widgets/` and shared by both grids.

## Test plan
- [x] `make lint`, `make test` (482 pass, includes 7 new SelectionState tests)
- [x] Manual verification of the original repro: clicking around in selection mode never causes visible checkboxes to drift from operative selection
- [x] Body click in selection mode toggles the cell
- [x] Cell click outside selection mode is a no-op (dormant gesture); double-click still opens the viewer
- [x] Right-click on unchecked item clears the selection but does not visibly check the right-clicked cell; menu acts on just that item
- [x] Right-click on a checked item leaves the selection alone; menu acts on the whole selection
- [x] Cancel button + Escape both exit selection mode
- [x] Auto-exit when last item is deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)