### PR TITLE
fix(ui): silence GtkStack 'hidden' warning in activity indicator

### DIFF
--- a/src/ui/widgets/activity_indicator/activity_indicator.blp
+++ b/src/ui/widgets/activity_indicator/activity_indicator.blp
@@ -9,7 +9,14 @@ template $MomentsActivityIndicator : Gtk.Widget {
     child: Gtk.Stack stack {
       transition-type: crossfade;
       transition-duration: 200;
-      visible-child-name: "hidden";
+
+      // First page is the default visible child. Keep "hidden" first so
+      // GTK doesn't warn about visible-child-name resolving before pages
+      // are added — Blueprint applies stack properties before children.
+      Gtk.StackPage {
+        name: "hidden";
+        child: Gtk.Box {};
+      }
 
       Gtk.StackPage {
         name: "active";
@@ -23,11 +30,6 @@ template $MomentsActivityIndicator : Gtk.Widget {
         child: Gtk.Image status_icon {
           icon-name: "object-select-symbolic";
         };
-      }
-
-      Gtk.StackPage {
-        name: "hidden";
-        child: Gtk.Box {};
       }
     };
 


### PR DESCRIPTION
## Summary
- Blueprint applies parent stack properties before its `StackPage` children are constructed, so `visible-child-name: \"hidden\"` resolved against an empty stack and GTK printed `Child name 'hidden' not found in GtkStack` on every launch.
- Reordered the pages so the empty \"hidden\" page is first (and therefore the default visible child) and dropped the explicit `visible-child-name` property.
- No behavioural change: the parent `menu_button` starts with `visible: false`, so the briefly-wrong initial page was never visible — only the warning is gone.

## Test plan
- [ ] `make run-dev` and confirm `Gtk-WARNING **: Child name 'hidden' not found in GtkStack` no longer appears in stderr.
- [ ] Trigger import/sync activity and confirm the indicator still cycles through hidden → active (spinner) → status (checkmark) correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)