### PR TITLE
chore(profiling): add opt-in dhat-rs heap profiler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ GNOME Builder can also use the dev manifest — configure it in the project buil
 
 Instruct the user to test via GNOME Builder or `make run-dev` — do not attempt to run the app binary directly.
 
+### Heap profiling (dhat-rs)
+
+`make run-dhat` rebuilds the dev Flatpak with `-Ddhat-heap=true` (Cargo `--features dhat-heap`), which swaps the global allocator for `dhat::Alloc`, runs the app, then flips the option back off. On exit dhat writes `~/.var/app/io.github.justinf555.Moments.Devel/cache/moments-dhat-heap.json`; load that into <https://nnethercote.github.io/dh_view/dh_view.html> for a flame view of allocations by Rust call path. There's measurable per-allocation overhead, so don't ship with the feature on.
+
 ## Architecture & Platform Constraints
 
 This is a Rust/GTK4 GNOME application using Flatpak. Key constraints:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -837,7 +853,7 @@ dependencies = [
  "gobject-sys 0.22.0",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2073,6 +2089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,6 +2112,7 @@ dependencies = [
  "async-trait",
  "base64",
  "chrono",
+ "dhat",
  "futures-util",
  "gettext-rs",
  "gstreamer",
@@ -2177,7 +2200,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2546,7 +2569,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror",
@@ -2566,7 +2589,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -2861,6 +2884,12 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -2884,7 +2913,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3408,7 +3437,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3430,6 +3459,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
@@ -4080,7 +4115,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ categories = ["multimedia::images"]
 
 [features]
 integration-tests = []
+# Heap profiling via dhat-rs. When enabled, replaces the global allocator
+# with `dhat::Alloc` and writes a `dhat-heap.json` capture (viewable at
+# https://nnethercote.github.io/dh_view/dh_view.html) to the cache dir
+# at exit. Off by default — there is a real per-allocation overhead.
+dhat-heap = ["dep:dhat"]
 
 [dependencies]
 
@@ -69,6 +74,10 @@ chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
 rawler = "0.7.2"
 lru = "0.18"
+
+# Heap profiling — only pulled in with `--features dhat-heap`. Adds
+# `dhat::Alloc` as the global allocator while the feature is on.
+dhat = { version = "0.3", optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run run-dev dev-bootstrap dev clean clean-dev \
+.PHONY: run run-dev run-dhat dev-bootstrap dev clean clean-dev \
         check test test-nextest test-integration test-all \
         lint fmt fmt-check typos audit coverage metrics \
         check-potfiles ci-all stack attach release
@@ -61,6 +61,8 @@ dev:
 		--socket=wayland --socket=fallback-x11 \
 		--device=dri --socket=pulseaudio \
 		--talk-name=org.freedesktop.secrets \
+		--talk-name=org.freedesktop.portal.* \
+		--bind-mount=/run/user/$(shell id -u)/doc=/run/user/$(shell id -u)/doc/by-app/io.github.justinf555.Moments.Devel \
 		--filesystem=$(HOME)/.var/app/io.github.justinf555.Moments.Devel:create \
 		--env=GTK_A11Y=none \
 		--env=RUST_LOG=moments=debug \
@@ -68,6 +70,33 @@ dev:
 		--env=XDG_CONFIG_HOME=$(HOME)/.var/app/io.github.justinf555.Moments.Devel/config \
 		--env=XDG_CACHE_HOME=$(HOME)/.var/app/io.github.justinf555.Moments.Devel/cache \
 		$(DEV_APP_DIR) moments
+
+DHAT_OUT = $(HOME)/.var/app/io.github.justinf555.Moments.Devel/cache/moments-dhat-heap.json
+
+# One-shot heap profile: rebuild with dhat-heap enabled, run, restore.
+# Requires `make dev-bootstrap` to have been done. Captures every alloc
+# during the session and writes a JSON dump on exit. View at:
+#   https://nnethercote.github.io/dh_view/dh_view.html
+run-dhat:
+	@if [ ! -f $(DEV_BUILD_DIR)/build.ninja ]; then \
+		echo "==> No build dir — running dev-bootstrap first"; \
+		$(MAKE) dev-bootstrap; \
+	fi
+	flatpak build --share=network \
+		--filesystem=$(CURDIR) \
+		--filesystem=$(CURDIR)/$(DEV_BUILD_DIR) \
+		--env=PATH=/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
+		$(DEV_APP_DIR) \
+		meson configure -Ddhat-heap=true $(CURDIR)/$(DEV_BUILD_DIR)
+	-$(MAKE) dev
+	flatpak build --share=network \
+		--filesystem=$(CURDIR) \
+		--filesystem=$(CURDIR)/$(DEV_BUILD_DIR) \
+		--env=PATH=/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
+		$(DEV_APP_DIR) \
+		meson configure -Ddhat-heap=false $(CURDIR)/$(DEV_BUILD_DIR)
+	@echo "==> dhat-heap capture written to: $(DHAT_OUT)"
+	@echo "==> View at: https://nnethercote.github.io/dh_view/dh_view.html"
 
 clean:
 	rm -rf flatpak-build-dir flatpak-build-dev

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,10 @@ test-all: test test-integration
 # ── Linting & Analysis ──────────────────────────────────────────────────────
 
 lint:
-	$(FLATPAK_RUN) -c '$(SDK_INIT) && cargo fmt -- --check && cargo clippy --all-targets -- -D warnings'
+	$(FLATPAK_RUN) -c '$(SDK_INIT) && \
+		cargo fmt -- --check && \
+		cargo clippy --all-targets -- -D warnings && \
+		cargo clippy --all-targets --features dhat-heap -- -D warnings'
 
 fmt:
 	$(FLATPAK_RUN) -c '$(SDK_INIT) && cargo fmt'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,4 @@
 option('profile', type: 'combo', choices: ['default', 'development'], value: 'default',
        description: 'Build profile: "default" for production, "development" for Devel app ID')
+option('dhat-heap', type: 'boolean', value: false,
+       description: 'Enable dhat-rs heap profiling (replaces global allocator). Off by default.')

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,23 @@ use gtk::{gio, glib};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() -> glib::ExitCode {
+    // Heap profiler. Captures every allocation/deallocation and writes a
+    // JSON dump on drop; viewer: https://nnethercote.github.io/dh_view/.
+    // Lives at the top of `main` and is moved into a binding that drops
+    // when `main` returns — the JSON is written from `Drop`.
+    #[cfg(feature = "dhat-heap")]
+    let _dhat_profiler = {
+        let path = glib::user_cache_dir().join("moments-dhat-heap.json");
+        let profiler = dhat::Profiler::builder().file_name(&path).build();
+        eprintln!("dhat-heap: writing to {}", path.display());
+        profiler
+    };
+
     // Register libheif-rs as a decoder plugin for the `image` crate so that
     // image::open() transparently handles HEIC and HEIF files throughout the app.
     libheif_rs::integration::image::register_all_decoding_hooks();

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,15 +33,25 @@ use tracing_subscriber::EnvFilter;
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 fn main() -> glib::ExitCode {
+    // Initialise tracing first so the dhat-heap feature can use info!
+    // (project convention: never println!/eprintln!). The subscriber's
+    // own setup allocations land in the dhat capture for free — < 1 ms
+    // worth of churn at startup, negligible against a sync run.
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("moments=info")),
+        )
+        .init();
+
     // Heap profiler. Captures every allocation/deallocation and writes a
     // JSON dump on drop; viewer: https://nnethercote.github.io/dh_view/.
-    // Lives at the top of `main` and is moved into a binding that drops
+    // Lives near the top of `main` and is moved into a binding that drops
     // when `main` returns — the JSON is written from `Drop`.
     #[cfg(feature = "dhat-heap")]
     let _dhat_profiler = {
         let path = glib::user_cache_dir().join("moments-dhat-heap.json");
         let profiler = dhat::Profiler::builder().file_name(&path).build();
-        eprintln!("dhat-heap: writing to {}", path.display());
+        info!(path = %path.display(), "dhat-heap profiler active");
         profiler
     };
 
@@ -51,13 +61,6 @@ fn main() -> glib::ExitCode {
 
     // Initialise GStreamer for video poster-frame extraction.
     gstreamer::init().expect("failed to initialise GStreamer");
-
-    // Initialise tracing — RUST_LOG controls verbosity (e.g. RUST_LOG=moments=debug)
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("moments=info")),
-        )
-        .init();
 
     info!(version = config::VERSION, "Moments starting");
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -84,6 +84,13 @@ else
   rust_target = 'debug'
 endif
 
+# Heap profiling — only used when explicitly opted into via -Ddhat-heap=true.
+# Replaces the global allocator with dhat::Alloc and writes a JSON dump to
+# the cache dir on exit. Real per-allocation overhead, so off by default.
+if get_option('dhat-heap')
+  cargo_opt += [ '--features', 'dhat-heap' ]
+endif
+
 
 cargo_build = custom_target(
   'cargo-build',


### PR DESCRIPTION
## Summary
Wires the [\`dhat\`](https://crates.io/crates/dhat) crate behind a \`dhat-heap\` Cargo feature and matching \`-Ddhat-heap=true\` meson option. When enabled, replaces the global allocator with \`dhat::Alloc\` and writes a heap capture JSON to the cache dir on clean exit; viewable at <https://nnethercote.github.io/dh_view/dh_view.html> (loads locally, no upload).

Off by default. Release builds and CI are unaffected.

Adds \`make run-dhat\`: a one-shot target that flips the meson option on, rebuilds + runs the dev Flatpak, then flips it back off. Also threads document portal access (\`--talk-name=org.freedesktop.portal.*\` and the \`/run/user/\$UID/doc/by-app/…\` bind-mount) into the existing \`make dev\` target so the FileChooser portal works under raw \`flatpak build\` — needed for testing imports without going through the full \`flatpak-builder\` path.

## Why
Sysprof's heap interceptor produced 2.9 GB captures that its GUI couldn't surface usefully and \`sysprof-cat\` doesn't decode. \`dhat-rs\` speaks Rust natively, gives per-call-path byte counts, and the \`dh_view\` UI is a flame-graph + sortable table — much better signal-to-noise for finding leaks. Already paid for itself by surfacing the viewer-buffer leak fixed in #637.

## Test plan
- [ ] \`make check\` passes (default features).
- [ ] \`cargo check --features dhat-heap\` passes (verified locally inside the SDK).
- [ ] \`make run-dhat\` rebuilds with the feature, runs the dev Flatpak, exits cleanly, and writes \`~/.var/app/io.github.justinf555.Moments.Devel/cache/moments-dhat-heap.json\`.
- [ ] After the run-dhat exit, \`make dev\` works again (option was flipped back off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)