### PR TITLE
Editing prep: refactor renderer into ordered stages + add DetailState + RenderTarget

### DIFF
--- a/docs/design-photo-editing.md
+++ b/docs/design-photo-editing.md
@@ -91,26 +91,64 @@ Added to the `Library` supertrait in `src/library.rs`. DB methods in new `src/li
 
 ## 4. Rendering Pipeline
 
-New file: `src/library/edit_renderer.rs`
-
-Pure function, no I/O:
+Lives in `src/renderer/edits.rs`. Pure function, no I/O:
 
 ```rust
-pub fn apply_edits(img: DynamicImage, state: &EditState) -> DynamicImage;
+pub fn apply_edits(
+    img: &DynamicImage,
+    state: &EditState,
+    target: RenderTarget,
+) -> DynamicImage;
 ```
 
-Fixed application order:
-1. Rotate (90° steps) → Flip → Straighten (freeform)
-2. Crop (denormalize coordinates)
-3. Brightness → Contrast → Highlights → Shadows → White balance
-4. Saturation → Vibrance → Hue shift → Temperature → Tint
+`RenderTarget` (`src/renderer/target.rs`) is a hint for neighbourhood-operation
+stages — per-pixel stages ignore it. There is intentionally no `Default` impl;
+every call site states intent so the performance-sensitive `Preview` path is
+never selected by accident.
 
-**Real-time preview strategy**: downscaled preview (~1200px), full-res only on save.
+| Variant | When | Behaviour |
+|---------|------|-----------|
+| `Preview` | Live edit-panel slider drag | Neighbourhood stages may use cheaper kernels for snappy response |
+| `Final` | Persisted thumbnails, viewer full-res, exports, Immich upload | Full-quality kernels |
+
+### Canonical stage order
+
+Stages are applied in a fixed order, encoded as a sequence of function calls
+in `apply_edits`. Industry-standard convention places noise reduction before
+tonal adjustments (so we don't smooth out detail that exposure has shaped) and
+sharpness after them (so it operates on corrected colour/tone, not raw input).
+Vignette is intentionally last so it darkens the final composition.
+
+| # | Stage | Type | Status |
+|---|-------|------|--------|
+| 1 | Geometric transforms (rotate / flip / crop) | Per-pixel | Implemented |
+| 2 | Noise reduction (bilateral filter) | Neighbourhood | Pending #251 |
+| 3 | Pixel pass — exposure + color (+ vignette + HSL) | Per-pixel | Implemented (vignette pending #252, HSL pending #473) |
+| 4 | Sharpness (convolution / unsharp mask) | Neighbourhood | Pending #250 |
+
+Per-pixel stages merge into a single per-pixel loop for cache locality.
+Neighbourhood stages are separate passes because they read pixel neighbours.
+**When adding a new stage, place it at the canonical position above and add a
+function call at the matching point in `apply_edits` — do not reorder existing
+stages without considering the visual impact.**
+
+### Real-time preview strategy
+
+Downscaled preview (~1200px), full-res only on save.
 
 ```
-Slider change → debounce (50ms) → apply_edits on spawn_blocking
+Slider change → debounce (50ms) → apply_edits(.., RenderTarget::Preview) on spawn_blocking
   → MemoryTexture → set_paintable on gtk::Picture
 ```
+
+### Filter-preset policy
+
+`EditState::apply_filter_at_strength` currently scales exposure + color. When
+`DetailState` and a future `HslState` get fields, decide per-field whether
+filter presets should scale into them. Suggested defaults: scale clarity
+(stylistic), don't scale noise reduction (per-photo cleanup, not stylistic).
+Update the doc comment on `apply_filter_at_strength` whenever a new field
+lands.
 
 ## 5. Immich Integration
 

--- a/src/importer/thumbnail.rs
+++ b/src/importer/thumbnail.rs
@@ -16,6 +16,7 @@ use crate::library::media::MediaId;
 use crate::library::thumbnail::{sharded_thumbnail_path, ThumbnailService};
 use crate::renderer::output;
 use crate::renderer::pipeline::{RenderOptions, RenderPipeline, RenderSize};
+use crate::renderer::target::RenderTarget;
 
 /// Longest edge in pixels for the grid thumbnail.
 const GRID_SIZE: u32 = 360;
@@ -70,6 +71,7 @@ async fn try_generate(
         let options = RenderOptions {
             size: RenderSize::Thumbnail(GRID_SIZE),
             edits: None,
+            target: RenderTarget::Final,
         };
         let img = pipeline.render(&source, &options)?;
         let webp_bytes = output::to_webp(&img)?;

--- a/src/library/editing/model.rs
+++ b/src/library/editing/model.rs
@@ -43,6 +43,14 @@ pub struct ColorState {
     pub tint: f64,
 }
 
+/// Detail-section adjustments — vignette, clarity, sharpness, noise reduction.
+///
+/// Empty until the per-feature issues land (#252, #474, #250, #251). The
+/// struct exists now so `EditState` is shape-stable: each new field can be
+/// added with `#[serde(default)]` without a schema migration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct DetailState {}
+
 /// Complete non-destructive edit state for a media asset.
 ///
 /// Stored as JSON in the `edits` table. All fields default to identity
@@ -59,6 +67,8 @@ pub struct EditState {
     pub exposure: ExposureState,
     #[serde(default)]
     pub color: ColorState,
+    #[serde(default)]
+    pub detail: DetailState,
     /// Name of the applied filter preset, or `None`.
     #[serde(default)]
     pub filter: Option<String>,
@@ -79,6 +89,7 @@ impl Default for EditState {
             transforms: TransformState::default(),
             exposure: ExposureState::default(),
             color: ColorState::default(),
+            detail: DetailState::default(),
             filter: None,
             filter_strength: 1.0,
         }
@@ -91,6 +102,7 @@ impl EditState {
         self.transforms == TransformState::default()
             && self.exposure == ExposureState::default()
             && self.color == ColorState::default()
+            && self.detail == DetailState::default()
             && self.filter.is_none()
     }
 
@@ -98,6 +110,13 @@ impl EditState {
     ///
     /// Sets this state's exposure and color fields to the preset values
     /// multiplied by `strength` (0.0–1.0), and records the filter strength.
+    ///
+    /// **Filter-preset policy for new sections:** when fields land in
+    /// `DetailState` (#252/#474/#250/#251) and a future `HslState` (#473),
+    /// decide per-field whether filters should scale into them. Suggested
+    /// defaults: scale clarity (it's a "look" component), don't scale
+    /// noise reduction (it's a per-photo cleanup, not stylistic). Update
+    /// this method when each field lands.
     pub fn apply_filter_at_strength(&mut self, preset: &EditState, strength: f64) {
         self.exposure.brightness = preset.exposure.brightness * strength;
         self.exposure.contrast = preset.exposure.contrast * strength;
@@ -170,6 +189,7 @@ mod tests {
                 temperature: 0.3,
                 tint: -0.05,
             },
+            detail: DetailState::default(),
             filter: Some("vintage".to_string()),
             filter_strength: 0.75,
         };
@@ -184,5 +204,20 @@ mod tests {
         let json = r#"{"version": 1}"#;
         let state: EditState = serde_json::from_str(json).unwrap();
         assert!(state.is_identity());
+    }
+
+    #[test]
+    fn deserialize_v1_json_without_detail_uses_default_detail() {
+        // Simulates an EditState row written before DetailState existed:
+        // a real edit (filter set), no `detail` key. The new field must
+        // default rather than fail deserialization.
+        let json = r#"{
+            "version": 1,
+            "filter": "vintage"
+        }"#;
+        let state: EditState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.detail, DetailState::default());
+        assert_eq!(state.filter.as_deref(), Some("vintage"));
+        assert!(!state.is_identity());
     }
 }

--- a/src/renderer/edits.rs
+++ b/src/renderer/edits.rs
@@ -6,21 +6,35 @@
 use image::{DynamicImage, GenericImageView, Rgba};
 
 use crate::library::editing::{ColorState, EditState, ExposureState, TransformState};
+use crate::renderer::target::RenderTarget;
 
 /// Apply all edit operations to an image and return the result.
-///
-/// Operations are applied in a fixed order:
-/// 1. Geometric transforms (rotate 90° steps, flip, straighten)
-/// 2. Crop (normalized coordinates → pixel coordinates)
-/// 3. Pixel adjustments — exposure and color in a single pass
 ///
 /// Accepts a borrowed image to avoid cloning the source. The caller
 /// retains ownership of the original (useful for preview rendering
 /// where the same source image is reused across slider changes).
-pub fn apply_edits(img: &DynamicImage, state: &EditState) -> DynamicImage {
+///
+/// `target` is a hint for neighbourhood-operation stages — the per-pixel
+/// stages ignore it. See [`RenderTarget`] for semantics.
+pub fn apply_edits(img: &DynamicImage, state: &EditState, _target: RenderTarget) -> DynamicImage {
     if state.is_identity() {
         return img.clone();
     }
+
+    // ── Canonical stage order ────────────────────────────────────────────
+    // DO NOT REORDER without considering the visual impact. Industry-standard
+    // convention puts noise reduction *before* tonal adjustments (so we don't
+    // smooth out detail that exposure has already shaped) and sharpness *after*
+    // them (so it operates on the corrected colour/tone, not the raw input).
+    // Vignette is intentionally last so it darkens the final composition.
+    //
+    //   1. Geometric transforms — rotate / flip / crop. Must come first so all
+    //      pixel-space stages see the user-visible orientation.
+    //   2. (future #251) Noise reduction — bilateral filter, before tonal work.
+    //   3. Pixel pass — exposure + color (+ vignette + HSL once they land),
+    //      merged into a single per-pixel loop for cache locality.
+    //   4. (future #250) Sharpness — convolution after tone/colour are final.
+    // ─────────────────────────────────────────────────────────────────────
 
     let img = apply_transforms(img, &state.transforms);
     apply_pixel_adjustments(img, &state.exposure, &state.color)
@@ -260,7 +274,7 @@ mod tests {
     #[test]
     fn identity_is_noop() {
         let img = test_image();
-        let result = apply_edits(&img, &EditState::default());
+        let result = apply_edits(&img, &EditState::default(), RenderTarget::Final);
         assert_eq!(img.dimensions(), result.dimensions());
         assert_eq!(
             img.as_rgba8().unwrap().as_raw(),
@@ -273,7 +287,7 @@ mod tests {
         let img = DynamicImage::ImageRgba8(RgbaImage::new(4, 2));
         let mut state = EditState::default();
         state.transforms.rotate_degrees = 90;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
         assert_eq!(result.dimensions(), (2, 4));
     }
 
@@ -282,7 +296,7 @@ mod tests {
         let img = DynamicImage::ImageRgba8(RgbaImage::new(4, 2));
         let mut state = EditState::default();
         state.transforms.rotate_degrees = 180;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
         assert_eq!(result.dimensions(), (4, 2));
     }
 
@@ -295,7 +309,7 @@ mod tests {
 
         let mut state = EditState::default();
         state.transforms.flip_horizontal = true;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
         let rgba = result.as_rgba8().unwrap();
         assert_eq!(rgba.get_pixel(0, 0).0, [0, 255, 0, 255]);
         assert_eq!(rgba.get_pixel(1, 0).0, [255, 0, 0, 255]);
@@ -311,7 +325,7 @@ mod tests {
             width: 0.5,
             height: 0.5,
         });
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
         assert_eq!(result.dimensions(), (50, 50));
     }
 
@@ -320,7 +334,7 @@ mod tests {
         let img = test_image();
         let mut state = EditState::default();
         state.exposure.brightness = 0.5;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
 
         let orig_px = img.as_rgba8().unwrap().get_pixel(0, 0);
         let edit_px = result.as_rgba8().unwrap().get_pixel(0, 0);
@@ -334,7 +348,7 @@ mod tests {
         let img = test_image();
         let mut state = EditState::default();
         state.exposure.brightness = -0.5;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
 
         let orig_px = img.as_rgba8().unwrap().get_pixel(0, 0);
         let edit_px = result.as_rgba8().unwrap().get_pixel(0, 0);
@@ -346,7 +360,7 @@ mod tests {
         let img = test_image();
         let mut state = EditState::default();
         state.color.saturation = -1.0;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
 
         let px = result.as_rgba8().unwrap().get_pixel(0, 0);
         // In grayscale, R ≈ G ≈ B (may differ by 1 due to rounding).
@@ -376,7 +390,7 @@ mod tests {
             width: 0.5,
             height: 1.0,
         });
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
         assert_eq!(result.dimensions(), (25, 100));
     }
 
@@ -390,8 +404,24 @@ mod tests {
         let mut state = EditState::default();
         state.exposure.brightness = 0.5;
         state.color.saturation = 0.5;
-        let result = apply_edits(&img, &state);
+        let result = apply_edits(&img, &state, RenderTarget::Final);
         let px = result.as_rgba8().unwrap().get_pixel(0, 0);
         assert_eq!(px[3], 128); // Alpha unchanged
+    }
+
+    #[test]
+    fn target_does_not_affect_per_pixel_stages() {
+        // Until neighbourhood stages land, Preview and Final must produce
+        // identical output. This test guards against accidental coupling.
+        let img = test_image();
+        let mut state = EditState::default();
+        state.exposure.brightness = 0.3;
+        state.color.saturation = 0.4;
+        let preview = apply_edits(&img, &state, RenderTarget::Preview);
+        let final_render = apply_edits(&img, &state, RenderTarget::Final);
+        assert_eq!(
+            preview.as_rgba8().unwrap().as_raw(),
+            final_render.as_rgba8().unwrap().as_raw()
+        );
     }
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -7,6 +7,7 @@
 //! - [`edits`] — non-destructive edit application
 //! - [`output`] — RGBA / WebP conversion helpers
 //! - [`pipeline`] — orchestrator that composes the steps
+//! - [`target`] — `RenderTarget` hint for kernel-scaling stages
 
 pub mod decode;
 pub mod edits;
@@ -16,3 +17,4 @@ pub mod orientation;
 pub mod output;
 pub mod pipeline;
 pub mod resize;
+pub mod target;

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -19,6 +19,7 @@ use crate::library::editing::EditState;
 use crate::library::media::MediaType;
 use crate::renderer::error::RenderError;
 use crate::renderer::format::{DecodeHint, FormatRegistry};
+use crate::renderer::target::RenderTarget;
 
 /// What size to render.
 #[derive(Debug, Clone)]
@@ -30,10 +31,15 @@ pub enum RenderSize {
 }
 
 /// Options controlling what the pipeline produces.
+///
+/// `target` is forwarded to [`super::edits::apply_edits`] when `edits` is
+/// `Some`. It is required even when `edits` is `None` so that any future
+/// non-edit stage that becomes target-sensitive picks it up automatically.
 #[derive(Debug, Clone)]
 pub struct RenderOptions<'a> {
     pub size: RenderSize,
     pub edits: Option<&'a EditState>,
+    pub target: RenderTarget,
 }
 
 /// Central stateless render pipeline.
@@ -100,7 +106,7 @@ impl RenderPipeline {
 
         // Step 4: Edit — apply non-destructive edits if provided.
         let img = match options.edits {
-            Some(edits) => super::edits::apply_edits(&img, edits),
+            Some(edits) => super::edits::apply_edits(&img, edits, options.target),
             None => img,
         };
 
@@ -142,6 +148,7 @@ mod tests {
                 &RenderOptions {
                     size: RenderSize::FullRes,
                     edits: None,
+                    target: RenderTarget::Final,
                 },
             )
             .unwrap();
@@ -160,6 +167,7 @@ mod tests {
                 &RenderOptions {
                     size: RenderSize::Thumbnail(20),
                     edits: None,
+                    target: RenderTarget::Final,
                 },
             )
             .unwrap();
@@ -192,6 +200,7 @@ mod tests {
                 &RenderOptions {
                     size: RenderSize::FullRes,
                     edits: Some(&edits),
+                    target: RenderTarget::Final,
                 },
             )
             .unwrap();
@@ -212,6 +221,7 @@ mod tests {
                 &RenderOptions {
                     size: RenderSize::FullRes,
                     edits: None,
+                    target: RenderTarget::Final,
                 },
             )
             .unwrap();
@@ -230,6 +240,7 @@ mod tests {
                 &RenderOptions {
                     size: RenderSize::FullRes,
                     edits: None,
+                    target: RenderTarget::Final,
                 },
             )
             .unwrap();

--- a/src/renderer/target.rs
+++ b/src/renderer/target.rs
@@ -1,0 +1,24 @@
+//! Render-target hint for edit stages.
+//!
+//! Lives in its own module so both [`super::pipeline`] and [`super::edits`]
+//! can depend on it without creating a cycle.
+
+/// Hint to neighbourhood-operation edit stages (sharpness, noise reduction)
+/// about how the rendered image will be used.
+///
+/// Per-pixel stages (exposure, color, vignette, HSL) ignore this. Stages
+/// that use a kernel scaled to image dimensions read it to pick a kernel
+/// size appropriate for the output's intended use.
+///
+/// No `Default` impl — every call site states its intent so the
+/// performance-sensitive `Preview` path is never selected by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderTarget {
+    /// Live edit-panel preview, typically downsampled. Stages may use
+    /// cheaper kernels to keep slider response snappy.
+    Preview,
+    /// Final render at the image's natural size — persisted thumbnails,
+    /// viewer full-resolution display, exports, Immich upload. Stages
+    /// use full-quality kernels.
+    Final,
+}

--- a/src/ui/viewer/edit_panel/adjust_section.rs
+++ b/src/ui/viewer/edit_panel/adjust_section.rs
@@ -31,8 +31,11 @@ mod imp {
         pub session: OnceCell<Rc<RefCell<Option<EditSession>>>>,
         pub changed_cb: OnceCell<Rc<dyn Fn()>>,
         pub render_debounce: Cell<Option<glib::SourceId>>,
-        /// All slider scales (for reset and subtitle counting).
-        pub scales: RefCell<Vec<gtk::Scale>>,
+        /// All slider scales paired with their `value-changed` handler ID.
+        /// Stored together so programmatic `set_value` (sync/reset) can
+        /// block the handler — otherwise the synchronous re-entry into
+        /// the session `RefCell` panics.
+        pub scales: RefCell<Vec<(gtk::Scale, glib::SignalHandlerId)>>,
     }
 
     #[glib::object_subclass]
@@ -157,14 +160,11 @@ impl EditAdjustSection {
         row.append(&header_box);
         row.append(&scale);
 
-        // Register this scale for reset and subtitle tracking.
-        imp.scales.borrow_mut().push(scale.clone());
-
         let session_ref = Rc::clone(session);
         let changed_ref = Rc::clone(changed);
         let weak = self.downgrade();
 
-        scale.connect_value_changed(move |scale| {
+        let handler_id = scale.connect_value_changed(move |scale| {
             let Some(section) = weak.upgrade() else {
                 return;
             };
@@ -205,6 +205,10 @@ impl EditAdjustSection {
             simp.render_debounce.set(Some(source_id));
         });
 
+        // Register scale + handler ID for reset, subtitle counting, and
+        // signal blocking during programmatic value updates.
+        imp.scales.borrow_mut().push((scale.clone(), handler_id));
+
         row
     }
 
@@ -215,7 +219,7 @@ impl EditAdjustSection {
             .scales
             .borrow()
             .iter()
-            .filter(|s| s.value().abs() > DEADZONE)
+            .filter(|(s, _)| s.value().abs() > DEADZONE)
             .count();
 
         let text = match count {
@@ -228,30 +232,45 @@ impl EditAdjustSection {
     }
 
     /// Update slider values from the current session state.
+    ///
+    /// Snapshots the target values from the session before touching any
+    /// scale, so the session borrow is released before `set_value` can
+    /// fire the (now-blocked) `value-changed` handler.
     pub fn sync_from_state(&self) {
         let imp = self.imp();
         let Some(session_rc) = imp.session.get() else {
             return;
         };
 
-        let session = session_rc.borrow();
-        let Some(s) = session.as_ref() else { return };
-
         let adjustments = adjustment_registry();
+        let values: Vec<f64> = {
+            let session = session_rc.borrow();
+            let Some(s) = session.as_ref() else { return };
+            adjustments.iter().map(|adj| adj.get(&s.state)).collect()
+        };
+
         let scales = imp.scales.borrow();
-
-        for (adj, scale) in adjustments.iter().zip(scales.iter()) {
-            scale.set_value(adj.get(&s.state));
+        for ((scale, handler_id), value) in scales.iter().zip(values.iter()) {
+            // Block the user-edit handler so this programmatic load
+            // doesn't re-enter the session RefCell or schedule a redundant
+            // render of the just-loaded state.
+            scale.block_signal(handler_id);
+            scale.set_value(*value);
+            scale.unblock_signal(handler_id);
         }
+        drop(scales);
 
-        drop(session);
         self.update_subtitle();
     }
 
     /// Reset all sliders to 0.0 and update subtitle.
+    ///
+    /// Lets each scale's `value-changed` handler fire so it propagates
+    /// the zero into session state. Safe because we don't hold the
+    /// session borrow here.
     pub fn reset(&self) {
         let imp = self.imp();
-        for scale in imp.scales.borrow().iter() {
+        for (scale, _) in imp.scales.borrow().iter() {
             scale.set_value(0.0);
         }
         imp.subtitle_label.set_label("No changes");

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -23,6 +23,7 @@ use transform_section::EditTransformSection;
 use crate::library::editing::EditState;
 use crate::library::media::MediaId;
 use crate::renderer::edits::apply_edits;
+use crate::renderer::target::RenderTarget;
 use crate::ui::widgets::wire_single_expansion;
 
 /// Delay before auto-saving edit state to DB after the last change (milliseconds).
@@ -351,7 +352,9 @@ impl EditPanel {
             let result = tk
                 .spawn(async move {
                     tokio::task::spawn_blocking(move || {
-                        let edited = apply_edits(&preview_img, &state);
+                        // Live slider preview — neighbourhood stages may use
+                        // cheaper kernels to keep slider response snappy.
+                        let edited = apply_edits(&preview_img, &state, RenderTarget::Preview);
                         let rgba = edited.into_rgba8();
                         let (w, h) = image::GenericImageView::dimensions(&rgba);
                         (rgba.into_raw(), w as i32, h as i32)

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -5,6 +5,7 @@ use tracing::{debug, error};
 
 use crate::renderer::output;
 use crate::renderer::pipeline::{RenderOptions, RenderSize};
+use crate::renderer::target::RenderTarget;
 
 use super::PhotoViewer;
 
@@ -75,6 +76,7 @@ impl PhotoViewer {
                             let options = RenderOptions {
                                 size: RenderSize::FullRes,
                                 edits: None,
+                                target: RenderTarget::Final,
                             };
                             let img = pipeline.render(&path, &options)?;
                             Ok(output::to_rgba(&img))
@@ -193,6 +195,7 @@ impl PhotoViewer {
                                     let options = RenderOptions {
                                         size: RenderSize::Thumbnail(1200),
                                         edits: None,
+                                        target: RenderTarget::Final,
                                     };
                                     let img = pipeline
                                         .render(&path, &options)

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -192,10 +192,14 @@ impl PhotoViewer {
                         .spawn(async move {
                             tokio::task::spawn_blocking(
                                 move || -> Option<std::sync::Arc<image::DynamicImage>> {
+                                    // This image is the EditSession::preview_image base —
+                                    // it is only ever fed back into apply_edits with
+                                    // RenderTarget::Preview, so any future target-sensitive
+                                    // decode-side stage should treat it as Preview too.
                                     let options = RenderOptions {
                                         size: RenderSize::Thumbnail(1200),
                                         edits: None,
-                                        target: RenderTarget::Final,
+                                        target: RenderTarget::Preview,
                                     };
                                     let img = pipeline
                                         .render(&path, &options)


### PR DESCRIPTION
## Summary

Foundation work for the remaining v0.4.0 editing features. Closes #640.

- Adds `RenderTarget` enum (`Preview` | `Final`) in its own module so `pipeline.rs` and `edits.rs` can both import without a circular dependency. No `Default` impl — every call site states intent so the perf-sensitive `Preview` path is never selected by accident.
- `apply_edits` now accepts `RenderTarget`. Body restructured with a canonical stage-order comment block and `(future #251)` / `(future #250)` markers showing exactly where the upcoming neighbourhood stages slot in.
- Adds empty `DetailState` to `EditState` with `#[serde(default)]` so the per-feature PRs (#252, #474, #250, #251) can add fields without a schema migration. Wired into `is_identity()` and the `Default` impl.
- Doc-comment on `apply_filter_at_strength` flagging the per-field filter-scaling policy decision needed when each detail field lands.
- Threads `target: RenderTarget` through `RenderOptions`. All call sites set `Final` except the live edit-panel preview, which sets `Preview`.
- Updates `docs/design-photo-editing.md` section 4 with the staged pipeline, canonical order table, `RenderTarget` semantics, and the filter-preset policy guidance.

## Bundled fix

While testing this PR against an Immich photo with saved non-default slider values, `EditAdjustSection::sync_from_state` panicked with `RefCell already borrowed`. Latent bug surfaced now, not a regression from the renderer prep work — pulled in here to unblock end-to-end testing of v0.4.0 editing features.

- Stores each scale's `SignalHandlerId` alongside the scale.
- `sync_from_state` snapshots target values before touching scales (so the session borrow is released early), then blocks the `value-changed` handler around each `set_value` to prevent the synchronous re-entry into the session `RefCell`.
- `reset()` left unchanged — it relies on the handler firing to propagate zeros into state, and doesn't hold the session borrow.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (488 + 2 new model tests)
- [x] `make run-dev` — open edit panel on an Immich photo with saved edits → no longer crashes (was the bundled-fix repro).
- [ ] Drag a slider, save, confirm the saved render still applies on next session.
- [ ] Verify viewer full-res photo loads correctly (uses `Final`).
- [ ] Import a new photo and confirm the thumbnail generates (uses `Final`).

## Notes

- New test `target_does_not_affect_per_pixel_stages` guards that `Preview` and `Final` produce byte-identical output today — will need to be removed/replaced when #250 or #251 lands and intentionally diverges them.
- New test `deserialize_v1_json_without_detail_uses_default_detail` simulates an old-format DB row to prove the schema migration is invisible.
- Known unrelated UX gap: viewer always renders the original (`edits: None`); saved edits only appear when the edit panel is opened. Pre-existing and explicitly scoped for #225 Phase 7 polish — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)