### PR TITLE
Editing: hold-to-compare button

### DIFF
--- a/src/ui/viewer/edit_panel/edit_panel.blp
+++ b/src/ui/viewer/edit_panel/edit_panel.blp
@@ -22,15 +22,26 @@ template $MomentsEditPanel : Gtk.Widget {
       };
     }
 
-    Gtk.Button revert_btn {
-      label: "Revert to Original";
-      tooltip-text: _("Remove all edits and restore the original image");
-      hexpand: true;
+    Gtk.Box {
+      orientation: horizontal;
+      spacing: 6;
       margin-top: 12;
       margin-bottom: 12;
       margin-start: 12;
       margin-end: 12;
-      styles ["destructive-action"]
+
+      Gtk.Button compare_btn {
+        icon-name: "view-reveal-symbolic";
+        tooltip-text: _("Hold to compare with the original");
+        valign: center;
+      }
+
+      Gtk.Button revert_btn {
+        label: "Revert to Original";
+        tooltip-text: _("Remove all edits and restore the original image");
+        hexpand: true;
+        styles ["destructive-action"]
+      }
     }
   }
 }

--- a/src/ui/viewer/edit_panel/edit_panel.blp
+++ b/src/ui/viewer/edit_panel/edit_panel.blp
@@ -34,6 +34,10 @@ template $MomentsEditPanel : Gtk.Widget {
         icon-name: "view-reveal-symbolic";
         tooltip-text: _("Hold to compare with the original");
         valign: center;
+
+        accessibility {
+          label: _("Compare with original");
+        }
       }
 
       Gtk.Button revert_btn {

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -60,6 +60,8 @@ mod imp {
         pub adjust_section: TemplateChild<EditAdjustSection>,
         #[template_child]
         pub revert_btn: TemplateChild<gtk::Button>,
+        #[template_child]
+        pub compare_btn: TemplateChild<gtk::Button>,
 
         // Service dependencies (set once in setup)
         pub picture: OnceCell<gtk::Picture>,
@@ -154,6 +156,7 @@ impl EditPanel {
         imp.adjust_section.setup(Rc::clone(&session), changed);
 
         self.wire_revert_button();
+        self.wire_compare_button();
     }
 
     /// Create a callback closure that sections call after mutating the session.
@@ -444,5 +447,62 @@ impl EditPanel {
                 });
             }
         });
+    }
+
+    /// Wire the hold-to-compare button.
+    ///
+    /// Press → render the original (no edits applied). Release / cancel →
+    /// render the current edited state. Uses a `GestureClick` controller so
+    /// we get the press and release events the bare `clicked` signal can't
+    /// give us. The button's own `clicked` is intentionally not wired.
+    fn wire_compare_button(&self) {
+        let gesture = gtk::GestureClick::new();
+
+        let weak_press = self.downgrade();
+        gesture.connect_pressed(move |_, _, _, _| {
+            if let Some(panel) = weak_press.upgrade() {
+                panel.render_compare(true);
+            }
+        });
+
+        let weak_release = self.downgrade();
+        gesture.connect_released(move |_, _, _, _| {
+            if let Some(panel) = weak_release.upgrade() {
+                panel.render_compare(false);
+            }
+        });
+
+        // If the gesture is cancelled (pointer leaves the button while held,
+        // touch sequence cancelled, etc.) we must still restore the edited
+        // view — otherwise the user is stuck looking at the original.
+        let weak_cancel = self.downgrade();
+        gesture.connect_cancel(move |_, _| {
+            if let Some(panel) = weak_cancel.upgrade() {
+                panel.render_compare(false);
+            }
+        });
+
+        self.imp().compare_btn.add_controller(gesture);
+    }
+
+    /// Render either the original (no edits) or the current edited state.
+    ///
+    /// Bumps `render_gen` to ensure the compare render wins any in-flight
+    /// slider-driven render — and so the eventual restore-to-edited render
+    /// also wins this one.
+    fn render_compare(&self, show_original: bool) {
+        let imp = self.imp();
+        let preview = {
+            let mut session = imp.session_rc().borrow_mut();
+            let Some(s) = session.as_mut() else { return };
+            s.render_gen += 1;
+            let state = if show_original {
+                EditState::default()
+            } else {
+                s.state.clone()
+            };
+            (Arc::clone(&s.preview_image), state, s.render_gen)
+        };
+        self.render_to_picture(preview);
     }
 }


### PR DESCRIPTION
## Summary

Adds a press-and-hold button to the edit panel for momentary comparison with the original. Closes #472.

- New eye-icon button (`view-reveal-symbolic`) in a horizontal action row alongside Revert at the bottom of the panel.
- `GestureClick` controller handles `pressed` / `released` / **`cancel`** — the cancel handler is load-bearing: if the pointer leaves the button mid-hold (or a touch is cancelled) we must still restore the edited view, otherwise the user is stuck looking at the original.
- New `render_compare(show_original)` helper bumps `render_gen` (so it wins any in-flight slider render and the eventual restore-render also wins this one) and dispatches `EditState::default()` or the current state through the existing `render_to_picture` path.
- No new texture infrastructure needed — `apply_edits` already short-circuits to `img.clone()` when `is_identity()`.

## Stacked on #643

Based on `feat/640-renderer-stages` (PR #643). GitHub will auto-retarget this PR to `main` once #643 merges. Diff in this PR shows only the #472 work.

## Scope decisions

- **Hold-to-compare** chosen over toggle / split-screen — it's the dominant pattern across photo editors (Lightroom, Snapseed, Apple Photos), the gesture is intuitive, and it's the smallest implementation. Split-screen slider is explicitly marked optional in the issue body and would need a custom paintable + draggable divider; deliberately deferred.
- **No keyboard shortcut** — same Ctrl+Z conflict reasoning as #642. A `\` shortcut (Lightroom convention) could land later.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `make run-dev` — open photo with saved edits, hold the eye-icon button → original; release → edited.
- [ ] Drag a slider, then immediately press compare during the debounced render — confirm the compare wins (no flicker of the in-flight slider render).
- [ ] Press the button, drag the cursor off it without releasing — confirm the edited view is restored (cancel handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)