### PR TITLE
feat(editing): add vignette adjustment (#252)

### DIFF
--- a/src/library/editing/mod.rs
+++ b/src/library/editing/mod.rs
@@ -2,5 +2,5 @@ pub mod model;
 pub mod repository;
 mod service;
 
-pub use model::{ColorState, CropRect, EditState, ExposureState, TransformState};
+pub use model::{ColorState, CropRect, DetailState, EditState, ExposureState, TransformState};
 pub use service::EditingService;

--- a/src/library/editing/model.rs
+++ b/src/library/editing/model.rs
@@ -44,11 +44,16 @@ pub struct ColorState {
 
 /// Detail-section adjustments — vignette, clarity, sharpness, noise reduction.
 ///
-/// Empty until the per-feature issues land (#252, #474, #250, #251). The
-/// struct exists now so `EditState` is shape-stable: each new field can be
-/// added with `#[serde(default)]` without a schema migration.
+/// Fields land per-feature (#252 vignette, #474 clarity, #250 sharpness,
+/// #251 noise reduction). Each field uses `#[serde(default)]` so adding
+/// the next one doesn't require a schema migration.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-pub struct DetailState {}
+pub struct DetailState {
+    /// Radial darkening (positive) or brightening (negative) of the
+    /// corners. -1.0 to 1.0, 0.0 = no effect.
+    #[serde(default)]
+    pub vignette: f64,
+}
 
 /// Complete non-destructive edit state for a media asset.
 ///
@@ -105,17 +110,20 @@ impl EditState {
             && self.filter.is_none()
     }
 
-    /// Apply a filter preset's exposure/color values scaled by strength.
+    /// Apply a filter preset's exposure/color/detail values scaled by strength.
     ///
-    /// Sets this state's exposure and color fields to the preset values
-    /// multiplied by `strength` (0.0–1.0), and records the filter strength.
+    /// Sets this state's exposure, color, and detail fields to the preset
+    /// values multiplied by `strength` (0.0–1.0), and records the filter
+    /// strength.
     ///
     /// **Filter-preset policy for new sections:** when fields land in
-    /// `DetailState` (#252/#474/#250/#251) and a future `HslState` (#473),
-    /// decide per-field whether filters should scale into them. Suggested
-    /// defaults: scale clarity (it's a "look" component), don't scale
-    /// noise reduction (it's a per-photo cleanup, not stylistic). Update
-    /// this method when each field lands.
+    /// `DetailState` (#474 clarity, #250 sharpness, #251 noise reduction)
+    /// and a future `HslState` (#473), decide per-field whether filters
+    /// should scale into them. Defaults so far: scale vignette (stylistic
+    /// — Vintage/Noir presets often include darkened corners); scale
+    /// clarity when it lands (also stylistic); don't scale noise reduction
+    /// (per-photo cleanup, not stylistic). Update this method when each
+    /// field lands.
     pub fn apply_filter_at_strength(&mut self, preset: &EditState, strength: f64) {
         self.exposure.brightness = preset.exposure.brightness * strength;
         self.exposure.contrast = preset.exposure.contrast * strength;
@@ -126,6 +134,7 @@ impl EditState {
         self.color.hue_shift = preset.color.hue_shift * strength;
         self.color.temperature = preset.color.temperature * strength;
         self.color.tint = preset.color.tint * strength;
+        self.detail.vignette = preset.detail.vignette * strength;
         self.filter_strength = strength;
     }
 }
@@ -186,7 +195,7 @@ mod tests {
                 temperature: 0.3,
                 tint: -0.05,
             },
-            detail: DetailState::default(),
+            detail: DetailState { vignette: 0.4 },
             filter: Some("vintage".to_string()),
             filter_strength: 0.75,
         };
@@ -194,6 +203,17 @@ mod tests {
         let json = serde_json::to_string(&state).unwrap();
         let restored: EditState = serde_json::from_str(&json).unwrap();
         assert_eq!(state, restored);
+    }
+
+    #[test]
+    fn filter_scales_into_vignette() {
+        let preset = EditState {
+            detail: DetailState { vignette: 0.6 },
+            ..Default::default()
+        };
+        let mut state = EditState::default();
+        state.apply_filter_at_strength(&preset, 0.5);
+        assert!((state.detail.vignette - 0.3).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/renderer/edits.rs
+++ b/src/renderer/edits.rs
@@ -432,12 +432,27 @@ mod tests {
     }
 
     #[test]
-    fn vignette_zero_is_noop() {
+    fn vignette_zero_in_pixel_pass_does_not_perturb_other_adjustments() {
+        // Default `EditState` would short-circuit via `is_identity()` and
+        // never enter the pixel pass, so `vignette = 0.0` would be
+        // trivially exercised. Force entry by setting brightness, then
+        // assert the output matches the same brightness without any
+        // vignette influence — proves the in-loop `skip_vignette` branch
+        // is a true no-op.
         let img = test_image();
-        let result = apply_edits(&img, &EditState::default(), RenderTarget::Final);
+
+        let mut with_zero_vignette = EditState::default();
+        with_zero_vignette.exposure.brightness = 0.3;
+        with_zero_vignette.detail.vignette = 0.0;
+
+        let mut brightness_only = EditState::default();
+        brightness_only.exposure.brightness = 0.3;
+
+        let a = apply_edits(&img, &with_zero_vignette, RenderTarget::Final);
+        let b = apply_edits(&img, &brightness_only, RenderTarget::Final);
         assert_eq!(
-            img.as_rgba8().unwrap().as_raw(),
-            result.as_rgba8().unwrap().as_raw()
+            a.as_rgba8().unwrap().as_raw(),
+            b.as_rgba8().unwrap().as_raw()
         );
     }
 

--- a/src/renderer/edits.rs
+++ b/src/renderer/edits.rs
@@ -5,7 +5,7 @@
 
 use image::{DynamicImage, GenericImageView, Rgba};
 
-use crate::library::editing::{ColorState, EditState, ExposureState, TransformState};
+use crate::library::editing::{ColorState, DetailState, EditState, ExposureState, TransformState};
 use crate::renderer::target::RenderTarget;
 
 /// Apply all edit operations to an image and return the result.
@@ -37,7 +37,7 @@ pub fn apply_edits(img: &DynamicImage, state: &EditState, _target: RenderTarget)
     // ─────────────────────────────────────────────────────────────────────
 
     let img = apply_transforms(img, &state.transforms);
-    apply_pixel_adjustments(img, &state.exposure, &state.color)
+    apply_pixel_adjustments(img, &state.exposure, &state.color, &state.detail)
 }
 
 // ---------------------------------------------------------------------------
@@ -84,14 +84,20 @@ fn apply_transforms(img: &DynamicImage, t: &TransformState) -> DynamicImage {
 }
 
 // ---------------------------------------------------------------------------
-// Merged pixel adjustments (exposure + color in a single pass)
+// Merged pixel adjustments (exposure + color + detail in a single pass)
 // ---------------------------------------------------------------------------
 
-fn apply_pixel_adjustments(img: DynamicImage, e: &ExposureState, c: &ColorState) -> DynamicImage {
+fn apply_pixel_adjustments(
+    img: DynamicImage,
+    e: &ExposureState,
+    c: &ColorState,
+    d: &DetailState,
+) -> DynamicImage {
     let skip_exposure = *e == ExposureState::default();
     let skip_color = *c == ColorState::default();
+    let skip_vignette = d.vignette == 0.0;
 
-    if skip_exposure && skip_color {
+    if skip_exposure && skip_color && skip_vignette {
         return img;
     }
 
@@ -100,6 +106,13 @@ fn apply_pixel_adjustments(img: DynamicImage, e: &ExposureState, c: &ColorState)
 
     // Pre-compute contrast factor outside the loop.
     let contrast_factor = 1.0 + e.contrast;
+
+    // Pre-compute vignette geometry. Distance is squared and pre-normalised
+    // by the max squared distance (centre-to-corner) so the per-pixel path
+    // needs no sqrt — just a multiply.
+    let cx = w as f64 / 2.0;
+    let cy = h as f64 / 2.0;
+    let inv_max_dist_sq = 1.0 / (cx * cx + cy * cy);
 
     for y in 0..h {
         for x in 0..w {
@@ -166,6 +179,20 @@ fn apply_pixel_adjustments(img: DynamicImage, e: &ExposureState, c: &ColorState)
                 gf += c.tint * 0.1;
                 rf -= c.tint * 0.05;
                 bf -= c.tint * 0.05;
+            }
+
+            // ── Vignette ─────────────────────────────────────────────
+            // Last in the pixel pass so it darkens (or brightens) the
+            // composed result. Squared-distance falloff, no sqrt: the
+            // ratio dist^2 / max_dist^2 is what the curve already wants.
+            if !skip_vignette {
+                let dx = x as f64 - cx;
+                let dy = y as f64 - cy;
+                let norm_dist_sq = (dx * dx + dy * dy) * inv_max_dist_sq;
+                let factor = 1.0 - d.vignette * norm_dist_sq;
+                rf *= factor;
+                gf *= factor;
+                bf *= factor;
             }
 
             rgba.put_pixel(x, y, Rgba([clamp_u8(rf), clamp_u8(gf), clamp_u8(bf), a]));
@@ -402,6 +429,80 @@ mod tests {
         let result = apply_edits(&img, &state, RenderTarget::Final);
         let px = result.as_rgba8().unwrap().get_pixel(0, 0);
         assert_eq!(px[3], 128); // Alpha unchanged
+    }
+
+    #[test]
+    fn vignette_zero_is_noop() {
+        let img = test_image();
+        let result = apply_edits(&img, &EditState::default(), RenderTarget::Final);
+        assert_eq!(
+            img.as_rgba8().unwrap().as_raw(),
+            result.as_rgba8().unwrap().as_raw()
+        );
+    }
+
+    #[test]
+    fn positive_vignette_darkens_corners_more_than_centre() {
+        // Uniform mid-grey image so the only effect we measure is the
+        // radial darkening curve.
+        let mut img = RgbaImage::new(20, 20);
+        for px in img.pixels_mut() {
+            *px = Rgba([200, 200, 200, 255]);
+        }
+        let img = DynamicImage::ImageRgba8(img);
+
+        let mut state = EditState::default();
+        state.detail.vignette = 0.8;
+        let result = apply_edits(&img, &state, RenderTarget::Final);
+        let rgba = result.as_rgba8().unwrap();
+
+        let corner = rgba.get_pixel(0, 0)[0];
+        let centre = rgba.get_pixel(10, 10)[0];
+        assert!(
+            corner < centre,
+            "corner ({corner}) should be darker than centre ({centre})"
+        );
+        // Centre should also be ~unchanged at distance≈0.
+        assert!(
+            centre >= 195,
+            "centre should be barely affected, got {centre}"
+        );
+    }
+
+    #[test]
+    fn negative_vignette_brightens_corners() {
+        let mut img = RgbaImage::new(20, 20);
+        for px in img.pixels_mut() {
+            *px = Rgba([100, 100, 100, 255]);
+        }
+        let img = DynamicImage::ImageRgba8(img);
+
+        let mut state = EditState::default();
+        state.detail.vignette = -0.8;
+        let result = apply_edits(&img, &state, RenderTarget::Final);
+        let rgba = result.as_rgba8().unwrap();
+
+        let corner = rgba.get_pixel(0, 0)[0];
+        let centre = rgba.get_pixel(10, 10)[0];
+        assert!(
+            corner > centre,
+            "corner ({corner}) should be brighter than centre ({centre})"
+        );
+    }
+
+    #[test]
+    fn vignette_preserves_alpha() {
+        let mut img = RgbaImage::new(4, 4);
+        for px in img.pixels_mut() {
+            *px = Rgba([200, 200, 200, 128]);
+        }
+        let img = DynamicImage::ImageRgba8(img);
+        let mut state = EditState::default();
+        state.detail.vignette = 0.5;
+        let result = apply_edits(&img, &state, RenderTarget::Final);
+        for px in result.as_rgba8().unwrap().pixels() {
+            assert_eq!(px[3], 128);
+        }
     }
 
     #[test]

--- a/src/ui/viewer/edit_panel/adjust_section.rs
+++ b/src/ui/viewer/edit_panel/adjust_section.rs
@@ -93,6 +93,7 @@ impl EditAdjustSection {
                 let group_name = match group {
                     AdjustGroup::Light => "LIGHT",
                     AdjustGroup::Colour => "COLOUR",
+                    AdjustGroup::Detail => "DETAIL",
                 };
                 let label = section_label(group_name);
                 imp.expander.add_row(&wrap_in_row(&label));

--- a/src/ui/viewer/edit_panel/adjustments/mod.rs
+++ b/src/ui/viewer/edit_panel/adjustments/mod.rs
@@ -6,6 +6,7 @@ mod shadows;
 mod temperature;
 mod tint;
 mod vibrance;
+mod vignette;
 
 use crate::library::editing::EditState;
 
@@ -14,6 +15,7 @@ use crate::library::editing::EditState;
 pub enum AdjustGroup {
     Light,
     Colour,
+    Detail,
 }
 
 /// A single adjustment parameter that reads/writes one field of `EditState`.
@@ -34,7 +36,7 @@ pub trait Adjustment: Send + Sync {
     fn set(&self, state: &mut EditState, value: f64);
 }
 
-/// Return all built-in adjustments in display order (Light group first, then Colour).
+/// Return all built-in adjustments in display order: Light, Colour, Detail.
 pub fn adjustment_registry() -> Vec<Box<dyn Adjustment>> {
     vec![
         // Light group
@@ -47,6 +49,8 @@ pub fn adjustment_registry() -> Vec<Box<dyn Adjustment>> {
         Box::new(vibrance::Vibrance),
         Box::new(temperature::Temperature),
         Box::new(tint::Tint),
+        // Detail group
+        Box::new(vignette::Vignette),
     ]
 }
 
@@ -55,8 +59,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registry_returns_eight_adjustments() {
-        assert_eq!(adjustment_registry().len(), 8);
+    fn registry_returns_nine_adjustments() {
+        assert_eq!(adjustment_registry().len(), 9);
     }
 
     #[test]
@@ -67,17 +71,28 @@ mod tests {
     }
 
     #[test]
-    fn light_group_comes_first() {
+    fn groups_appear_in_canonical_order() {
+        // Display order: Light → Colour → Detail. Each group's last entry
+        // must come before the next group's first entry.
         let adjustments = adjustment_registry();
-        let first_colour = adjustments
-            .iter()
-            .position(|a| a.group() == AdjustGroup::Colour)
-            .unwrap();
         let last_light = adjustments
             .iter()
             .rposition(|a| a.group() == AdjustGroup::Light)
             .unwrap();
+        let first_colour = adjustments
+            .iter()
+            .position(|a| a.group() == AdjustGroup::Colour)
+            .unwrap();
+        let last_colour = adjustments
+            .iter()
+            .rposition(|a| a.group() == AdjustGroup::Colour)
+            .unwrap();
+        let first_detail = adjustments
+            .iter()
+            .position(|a| a.group() == AdjustGroup::Detail)
+            .unwrap();
         assert!(last_light < first_colour);
+        assert!(last_colour < first_detail);
     }
 
     #[test]

--- a/src/ui/viewer/edit_panel/adjustments/vignette.rs
+++ b/src/ui/viewer/edit_panel/adjustments/vignette.rs
@@ -1,0 +1,25 @@
+use super::{AdjustGroup, Adjustment, EditState};
+
+pub struct Vignette;
+
+impl Adjustment for Vignette {
+    fn display_name(&self) -> &'static str {
+        "Vignette"
+    }
+
+    fn group(&self) -> AdjustGroup {
+        AdjustGroup::Detail
+    }
+
+    fn range(&self) -> (f64, f64) {
+        (-1.0, 1.0)
+    }
+
+    fn get(&self, state: &EditState) -> f64 {
+        state.detail.vignette
+    }
+
+    fn set(&self, state: &mut EditState, value: f64) {
+        state.detail.vignette = value;
+    }
+}

--- a/src/ui/viewer/edit_panel/filters/noir.rs
+++ b/src/ui/viewer/edit_panel/filters/noir.rs
@@ -19,6 +19,7 @@ impl Filter for Noir {
         state.color.saturation = -1.0;
         state.exposure.contrast = 0.3;
         state.exposure.brightness = -0.05;
+        state.detail.vignette = 0.35;
         state
     }
 }
@@ -32,5 +33,11 @@ mod tests {
         let preset = Noir.preset();
         assert_eq!(preset.color.saturation, -1.0);
         assert!(preset.exposure.contrast > 0.2);
+    }
+
+    #[test]
+    fn noir_has_pronounced_vignette() {
+        let preset = Noir.preset();
+        assert!(preset.detail.vignette > 0.0);
     }
 }

--- a/src/ui/viewer/edit_panel/filters/vintage.rs
+++ b/src/ui/viewer/edit_panel/filters/vintage.rs
@@ -20,6 +20,7 @@ impl Filter for Vintage {
         state.color.temperature = 0.3;
         state.exposure.contrast = -0.1;
         state.exposure.brightness = 0.05;
+        state.detail.vignette = 0.25;
         state
     }
 }
@@ -33,5 +34,11 @@ mod tests {
         let preset = Vintage.preset();
         assert!(preset.color.saturation < 0.0);
         assert!(preset.color.temperature > 0.0);
+    }
+
+    #[test]
+    fn vintage_has_subtle_vignette() {
+        let preset = Vintage.preset();
+        assert!(preset.detail.vignette > 0.0);
     }
 }


### PR DESCRIPTION
Closes #252.

## Summary

Adds the first `DetailState` field — a vignette slider that darkens (positive) or brightens (negative) the image corners.

- **Renderer:** new vignette block at the end of the pixel pass — applied after exposure and colour so it composes over the corrected image. Squared-distance falloff with pre-normalised geometry, no sqrt: \`factor = 1.0 - vignette * (dx² + dy²) / max_dist²\`. Pre-computed centre + inverse max-squared-distance outside the loop; per-pixel cost is two multiplies and an add.
- **Data model:** \`DetailState::vignette: f64\` (range -1.0 to 1.0, default 0.0). Range matches every other slider in \`EditState\`. Field uses \`#[serde(default)]\` so future \`DetailState\` additions don't need a migration.
- **Filter scaling:** \`apply_filter_at_strength\` now scales into vignette. Classic looks (Vintage, Noir) traditionally include darkened corners as part of their identity. Doc comment records the policy decision and tees up the call for the remaining detail fields (#474 clarity = scale, #251 noise reduction = don't).
- **UI:** new \`AdjustGroup::Detail\` as the third sub-group inside the Adjustments panel, with a "DETAIL" header. Vignette widget follows the existing \`Adjustment\` trait pattern.

## Test plan

- [x] \`make lint\` passes
- [x] \`make test\` passes (4 new renderer tests, 1 new model test, registry test updated to 9)
- [x] \`make dev\` — Adjustments panel shows Light / Colour / Detail sub-sections; Vignette slider in Detail darkens corners on positive, brightens on negative, identity at 0
- [x] Vignette composes with exposure/colour adjustments correctly

## Notes for reviewers

- Distance is in pixel space (not aspect-normalised) — on a 16:9 image the dark corners follow the image's aspect ratio, which matches user expectation (the "circle of attention" matches the frame). Inscribing a circle would leave corners bright, which isn't what people want.
- \`white_balance\` cleanup landed in #646; this branch is built on top of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)