### PR TITLE
fix(sync): track orphans by local MediaId, not Immich UUID (#628)

### DIFF
--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -52,6 +52,7 @@ impl SyncEntityHandler for AlbumHandler {
 
         Ok(HandlerResult {
             entity_id: external_id,
+            local_media_id: None,
             audit_action: "upsert",
             counter: CounterKind::Albums,
         })
@@ -89,6 +90,7 @@ impl SyncEntityHandler for AlbumDeleteHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: external_id,
+                    local_media_id: None,
                     audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
@@ -98,6 +100,7 @@ impl SyncEntityHandler for AlbumDeleteHandler {
         ctx.library.albums().delete_album(&local_id).await?;
         Ok(HandlerResult {
             entity_id: external_id,
+            local_media_id: None,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/album_asset.rs
+++ b/src/sync/providers/immich/handlers/album_asset.rs
@@ -43,6 +43,7 @@ impl SyncEntityHandler for AlbumAssetHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: id,
+                    local_media_id: None,
                     audit_action: "upsert",
                     counter: CounterKind::Albums,
                 });
@@ -70,6 +71,7 @@ impl SyncEntityHandler for AlbumAssetHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: id,
+                    local_media_id: None,
                     audit_action: "upsert",
                     counter: CounterKind::Albums,
                 });
@@ -84,6 +86,7 @@ impl SyncEntityHandler for AlbumAssetHandler {
 
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "upsert",
             counter: CounterKind::Albums,
         })
@@ -131,6 +134,7 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: id,
+                    local_media_id: None,
                     audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
@@ -155,6 +159,7 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: id,
+                    local_media_id: None,
                     audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
@@ -168,6 +173,7 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
 
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -23,10 +23,15 @@ impl SyncEntityHandler for AssetHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let asset: SyncAssetV1 = deserialize_entity(data, "AssetV1", line_number)?;
-        let id = asset.id.clone();
-        handle_asset(asset, ctx).await?;
+        let entity_id = asset.id.clone();
+        let media_id = handle_asset(asset, ctx).await?;
         Ok(HandlerResult {
-            entity_id: id,
+            entity_id,
+            // Issue #628: report the local `MediaId` so a `SyncResetV1`
+            // orphan-cleanup pass checks the right namespace off its
+            // tracking set. Without this, every local row stays
+            // "unseen" and gets deleted when the stream ends.
+            local_media_id: Some(media_id.as_str().to_string()),
             audit_action: "upsert",
             counter: CounterKind::Assets,
         })
@@ -34,7 +39,7 @@ impl SyncEntityHandler for AssetHandler {
 }
 
 #[instrument(skip(ctx, asset), fields(asset_id = %asset.id))]
-async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), LibraryError> {
+async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<MediaId, LibraryError> {
     let media_type = match asset.asset_type.as_str() {
         "VIDEO" => MediaType::Video,
         _ => MediaType::Image,
@@ -128,7 +133,7 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
         debug!(id = %media_id, "thumbnail download failed: {e}");
     }
 
-    Ok(())
+    Ok(media_id)
 }
 
 pub struct AssetDeleteHandler;
@@ -150,18 +155,24 @@ impl SyncEntityHandler for AssetDeleteHandler {
         // Issue #626: the stream carries the Immich UUID; translate to
         // the local `MediaId` before deleting. Missing row is a no-op —
         // the asset was already gone or never reached us.
-        match ctx.library.media().id_by_external_id(&external_id).await? {
+        let local_media_id = match ctx.library.media().id_by_external_id(&external_id).await? {
             Some(media_id) => {
+                let local_str = media_id.as_str().to_string();
                 ctx.library
                     .delete_permanently_from_sync(std::slice::from_ref(&media_id))
                     .await?;
+                Some(local_str)
             }
             None => {
                 debug!(external_id = %external_id, "asset delete: no local row, skipping");
+                None
             }
-        }
+        };
         Ok(HandlerResult {
             entity_id: external_id,
+            // Issue #628: a delete during reset is also "we've seen
+            // this id", so check it off the orphan tracking set.
+            local_media_id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -31,7 +31,7 @@ impl SyncEntityHandler for AssetHandler {
             // orphan-cleanup pass checks the right namespace off its
             // tracking set. Without this, every local row stays
             // "unseen" and gets deleted when the stream ends.
-            local_media_id: Some(media_id.as_str().to_string()),
+            local_media_id: Some(media_id),
             audit_action: "upsert",
             counter: CounterKind::Assets,
         })
@@ -157,11 +157,10 @@ impl SyncEntityHandler for AssetDeleteHandler {
         // the asset was already gone or never reached us.
         let local_media_id = match ctx.library.media().id_by_external_id(&external_id).await? {
             Some(media_id) => {
-                let local_str = media_id.as_str().to_string();
                 ctx.library
                     .delete_permanently_from_sync(std::slice::from_ref(&media_id))
                     .await?;
-                Some(local_str)
+                Some(media_id)
             }
             None => {
                 debug!(external_id = %external_id, "asset delete: no local row, skipping");

--- a/src/sync/providers/immich/handlers/asset_exif.rs
+++ b/src/sync/providers/immich/handlers/asset_exif.rs
@@ -41,6 +41,7 @@ impl SyncEntityHandler for AssetExifHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: id,
+                    local_media_id: None,
                     audit_action: "upsert",
                     counter: CounterKind::Exifs,
                 });
@@ -66,6 +67,7 @@ impl SyncEntityHandler for AssetExifHandler {
 
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "upsert",
             counter: CounterKind::Exifs,
         })

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -43,6 +43,7 @@ impl SyncEntityHandler for AssetFaceHandler {
                 );
                 return Ok(HandlerResult {
                     entity_id: id,
+                    local_media_id: None,
                     audit_action: "upsert",
                     counter: CounterKind::Faces,
                 });
@@ -72,6 +73,7 @@ impl SyncEntityHandler for AssetFaceHandler {
 
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "upsert",
             counter: CounterKind::Faces,
         })
@@ -98,6 +100,7 @@ impl SyncEntityHandler for AssetFaceDeleteHandler {
         ctx.library.faces().delete_asset_face(&id).await?;
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/mod.rs
+++ b/src/sync/providers/immich/handlers/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::library::error::LibraryError;
+use crate::library::media::MediaId;
 use crate::library::Library;
 use crate::sync::state::SyncStateRepository;
 
@@ -55,16 +56,20 @@ pub struct HandlerResult {
     /// Entity ID for audit logging — typically the Immich-side UUID
     /// from the sync payload.
     pub entity_id: String,
-    /// Local [`MediaId`](crate::library::media::MediaId) for the row this
-    /// handler touched, if any. Populated by `AssetHandler` and
-    /// `AssetDeleteHandler` so that pull-side orphan tracking during a
-    /// `SyncResetV1` cycle compares like-for-like — the orphan set is
-    /// loaded from `media.id` (local namespace) and must be checked off
-    /// against handler results in that same namespace, not against the
-    /// Immich UUID. See issue #628 for the data-loss bug this prevents.
-    /// Other handlers (album, exif, face, lifecycle) leave this `None`;
-    /// they don't drive orphan tracking.
-    pub local_media_id: Option<String>,
+    /// Local [`MediaId`] for the row this handler touched, if any.
+    /// Populated by `AssetHandler` and `AssetDeleteHandler` so that
+    /// pull-side orphan tracking during a `SyncResetV1` cycle
+    /// compares like-for-like — the orphan set is loaded from
+    /// `media.id` (local namespace) and must be checked off against
+    /// handler results in that same namespace, not against the Immich
+    /// UUID. See issue #628 for the data-loss bug this prevents.
+    /// Other handlers (album, exif, face, lifecycle) leave this
+    /// `None`; they don't drive orphan tracking.
+    ///
+    /// Typed as [`MediaId`] rather than `String` so the namespace
+    /// invariant is enforced at compile time — it's not possible to
+    /// accidentally store an Immich UUID here.
+    pub local_media_id: Option<MediaId>,
     /// Audit action label (e.g. "upsert", "delete").
     pub audit_action: &'static str,
     /// Which counter to increment.

--- a/src/sync/providers/immich/handlers/mod.rs
+++ b/src/sync/providers/immich/handlers/mod.rs
@@ -52,8 +52,19 @@ pub enum CounterKind {
 
 /// Result of a successful handler invocation.
 pub struct HandlerResult {
-    /// Entity ID for audit logging.
+    /// Entity ID for audit logging — typically the Immich-side UUID
+    /// from the sync payload.
     pub entity_id: String,
+    /// Local [`MediaId`](crate::library::media::MediaId) for the row this
+    /// handler touched, if any. Populated by `AssetHandler` and
+    /// `AssetDeleteHandler` so that pull-side orphan tracking during a
+    /// `SyncResetV1` cycle compares like-for-like — the orphan set is
+    /// loaded from `media.id` (local namespace) and must be checked off
+    /// against handler results in that same namespace, not against the
+    /// Immich UUID. See issue #628 for the data-loss bug this prevents.
+    /// Other handlers (album, exif, face, lifecycle) leave this `None`;
+    /// they don't drive orphan tracking.
+    pub local_media_id: Option<String>,
     /// Audit action label (e.g. "upsert", "delete").
     pub audit_action: &'static str,
     /// Which counter to increment.

--- a/src/sync/providers/immich/handlers/person.rs
+++ b/src/sync/providers/immich/handlers/person.rs
@@ -59,6 +59,7 @@ impl SyncEntityHandler for PersonHandler {
 
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "upsert",
             counter: CounterKind::People,
         })
@@ -84,6 +85,7 @@ impl SyncEntityHandler for PersonDeleteHandler {
         ctx.library.faces().delete_person_by_id(&id).await?;
         Ok(HandlerResult {
             entity_id: id,
+            local_media_id: None,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/sync_lifecycle.rs
+++ b/src/sync/providers/immich/handlers/sync_lifecycle.rs
@@ -28,6 +28,7 @@ impl SyncEntityHandler for SyncResetHandler {
         ctx.state.clear_checkpoints().await?;
         Ok(HandlerResult {
             entity_id: String::new(),
+            local_media_id: None,
             audit_action: "reset",
             counter: CounterKind::None,
         })
@@ -52,6 +53,7 @@ impl SyncEntityHandler for SyncCompleteHandler {
     ) -> Result<HandlerResult, LibraryError> {
         Ok(HandlerResult {
             entity_id: String::new(),
+            local_media_id: None,
             audit_action: "complete",
             counter: CounterKind::None,
         })

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -246,11 +246,21 @@ impl PullManager {
                             notified_processing = true;
                         }
 
-                        // Track asset IDs for reset orphan detection.
-                        if let Some(ref mut ids) = existing_ids {
-                            if !result.entity_id.is_empty() {
-                                ids.remove(&result.entity_id);
-                            }
+                        // Issue #628: track *local* MediaIds for reset
+                        // orphan detection. `existing_ids` is loaded
+                        // from `media.id` (local namespace); only
+                        // AssetHandler / AssetDeleteHandler populate
+                        // `local_media_id` and they're the only
+                        // handlers whose results affect orphan
+                        // tracking. Removing by `entity_id` (the
+                        // Immich UUID) — as the previous version did —
+                        // never matched anything, leaving every local
+                        // row classified as orphaned and silently
+                        // wiping the library on a `SyncResetV1`.
+                        if let (Some(ref mut ids), Some(local)) =
+                            (existing_ids.as_mut(), result.local_media_id.as_deref())
+                        {
+                            ids.remove(local);
                         }
                     }
                     Err(e) => {
@@ -384,6 +394,91 @@ impl PullManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use super::handlers::{CounterKind, HandlerResult};
+
+    /// Drive the same `(existing_ids, result) → existing_ids` reduction
+    /// the dispatch loop does. Mirrors the conditional in
+    /// `run_sync` so a contract test can assert the namespace
+    /// invariant without spinning up an HTTP-backed sync stream.
+    fn apply_handler_result(existing_ids: &mut Option<HashSet<String>>, result: &HandlerResult) {
+        if let (Some(ids), Some(local)) = (existing_ids.as_mut(), result.local_media_id.as_deref())
+        {
+            ids.remove(local);
+        }
+    }
+
+    fn asset_result(entity_id: &str, local_media_id: &str) -> HandlerResult {
+        HandlerResult {
+            entity_id: entity_id.to_string(),
+            local_media_id: Some(local_media_id.to_string()),
+            audit_action: "upsert",
+            counter: CounterKind::Assets,
+        }
+    }
+
+    fn non_asset_result(entity_id: &str, kind: CounterKind) -> HandlerResult {
+        HandlerResult {
+            entity_id: entity_id.to_string(),
+            // Album / Face / Exif / Person handlers don't drive
+            // orphan tracking; their `local_media_id` is None.
+            local_media_id: None,
+            audit_action: "upsert",
+            counter: kind,
+        }
+    }
+
+    /// Issue #628: regression. After a `SyncResetV1`, the dispatch
+    /// loop must check seen assets off `existing_ids` using the
+    /// *local* `MediaId`, not the Immich UUID. With the old code
+    /// (removed by passing `result.entity_id`, which carried the
+    /// Immich UUID), the set never shrank and every locally-stored
+    /// asset got classified as orphaned and deleted in
+    /// `finish_sync`. This test pins the namespace.
+    #[test]
+    fn orphan_tracking_uses_local_media_id_not_immich_uuid() {
+        let mut existing: Option<HashSet<String>> = Some(
+            ["local-a", "local-b", "local-c", "local-d"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        );
+
+        // Stream re-emits assets a and c (both with Immich UUIDs that
+        // are deliberately *different* from the local ids the rows
+        // were stored under — exactly the gap the bug exploited).
+        apply_handler_result(&mut existing, &asset_result("immich-1", "local-a"));
+        apply_handler_result(&mut existing, &asset_result("immich-2", "local-c"));
+        // Album-membership and face entities arrive too; these must
+        // not affect orphan tracking.
+        apply_handler_result(
+            &mut existing,
+            &non_asset_result("immich-album:immich-1", CounterKind::Albums),
+        );
+        apply_handler_result(
+            &mut existing,
+            &non_asset_result("immich-face-x", CounterKind::Faces),
+        );
+
+        let remaining = existing.expect("set still present");
+        let expected: HashSet<String> = ["local-b", "local-d"]
+            .into_iter()
+            .map(String::from)
+            .collect();
+        assert_eq!(
+            remaining, expected,
+            "orphan set must contain only rows the stream did not re-emit"
+        );
+    }
+
+    /// Sanity: when the server doesn't request a reset, `existing_ids`
+    /// is `None` and handler results don't try to mutate it.
+    #[test]
+    fn apply_handler_result_no_op_when_not_in_reset() {
+        let mut existing: Option<HashSet<String>> = None;
+        apply_handler_result(&mut existing, &asset_result("any", "local-x"));
+        assert!(existing.is_none());
+    }
 
     // ── SyncCounters ───────────────────────────────────────────────
 

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -258,9 +258,9 @@ impl PullManager {
                         // row classified as orphaned and silently
                         // wiping the library on a `SyncResetV1`.
                         if let (Some(ref mut ids), Some(local)) =
-                            (existing_ids.as_mut(), result.local_media_id.as_deref())
+                            (existing_ids.as_mut(), result.local_media_id.as_ref())
                         {
-                            ids.remove(local);
+                            ids.remove(local.as_str());
                         }
                     }
                     Err(e) => {
@@ -402,16 +402,15 @@ mod tests {
     /// `run_sync` so a contract test can assert the namespace
     /// invariant without spinning up an HTTP-backed sync stream.
     fn apply_handler_result(existing_ids: &mut Option<HashSet<String>>, result: &HandlerResult) {
-        if let (Some(ids), Some(local)) = (existing_ids.as_mut(), result.local_media_id.as_deref())
-        {
-            ids.remove(local);
+        if let (Some(ids), Some(local)) = (existing_ids.as_mut(), result.local_media_id.as_ref()) {
+            ids.remove(local.as_str());
         }
     }
 
     fn asset_result(entity_id: &str, local_media_id: &str) -> HandlerResult {
         HandlerResult {
             entity_id: entity_id.to_string(),
-            local_media_id: Some(local_media_id.to_string()),
+            local_media_id: Some(MediaId::new(local_media_id.to_string())),
             audit_action: "upsert",
             counter: CounterKind::Assets,
         }


### PR DESCRIPTION
## Summary

Re-applies the #628 data-loss fix on top of `main`. The original PR (#629) was stacked on `feat/626-stable-media-id`; that base merged via #627 (`f0a3a8f`), but the fix commits never got retargeted, leaving them stranded on the merged feature branch and not in `main`'s history.

This PR cherry-picks the two fix commits (`396f634` + `84dbdad`) and resolves drift from #586 (per-feature DB shim removal) and #585 (album external_id translation).

## The bug

`SyncResetV1` cleanup in `src/sync/providers/immich/pull.rs` seeded `existing_ids` from local `media.id`s but removed by `result.entity_id` (the Immich UUID). Namespaces never overlapped, so the orphan set never shrank and `finish_sync` deleted every local row — including originals on disk — on every reset cycle.

Pre-#626 it accidentally worked (`media.id == external_id`); #627 cleanly split the namespaces and exposed the latent path.

## Fix

`HandlerResult` gains a typed `local_media_id: Option<MediaId>`. `AssetHandler` and `AssetDeleteHandler` populate it with the resolved local id; other handlers leave it `None`. The dispatch loop in `pull.rs` removes by `result.local_media_id.as_str()` instead of `result.entity_id`, so the orphan tracking set is checked off in the same namespace it was loaded from.

Includes the `orphan_tracking_uses_local_media_id_not_immich_uuid` regression test that exercises the namespace gap explicitly.

## Conflict resolution notes

Three conflicts on cherry-pick, all from drift on `main`:

- `src/library/db/sync.rs` — deleted in #586. Dropped the file's diff. The audit-log side-fix it carried (recording `entity_id` in `complete_sync_audit`) is orthogonal to the data-loss bug and the audit code has been refactored into `SyncStateRepository` since #629; **left as a separate follow-up** — `SyncStateRepository::start_audit` is currently called with an empty `entity_id` at `pull.rs:226`, same blank-audit issue but no longer a data-loss path.
- `src/sync/providers/immich/handlers/album.rs` and `album_asset.rs` — variable-name drift (`id` / `id_str` → `external_id`) and warn-skip branches added in #585 were missing the new `local_media_id: None` field. Resolved both.
- `src/sync/providers/immich/pull.rs` — `db.complete_sync_audit(...)` call site has moved to `state.complete_audit(aid, action)`. Kept main's call. Dropped the appended `Database`-test block (~180 lines) — every test in it targeted `Database` methods that no longer exist (`db.complete_sync_audit`, `db.save_sync_checkpoints`, `db.upsert_album_media` etc.); their replacements live in the new repositories' own tests.

## Test plan

- [ ] `make lint`
- [ ] `make test` — `orphan_tracking_uses_local_media_id_not_immich_uuid` exercises the namespace invariant
- [ ] `make test-integration`
- [ ] Manual: with an Immich backend, trigger a `SyncResetV1` (server-side admin reset or checkpoint inconsistency) and confirm local rows are not wiped

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)