### PR TITLE
fix(sync): heartbeat-based reset reconciliation (#628)

### DIFF
--- a/docs/design-immich-backend.md
+++ b/docs/design-immich-backend.md
@@ -83,13 +83,21 @@ All reads delegate to `self.db` — identical SQL to `LocalLibrary`. Writes go t
 - Transient errors don't abort the polling loop — logged and retried next cycle
 
 **Reset Sync (>30 days stale):**
-When the server sends `SyncResetV1`, we do NOT wipe the local cache. Instead:
-1. Load all existing MediaIds into a `HashSet<String>` (~24 MB for 200k library)
-2. Process the full stream normally — `INSERT OR REPLACE` handles create/update
-3. Remove each seen ID from the HashSet
-4. After `SyncCompleteV1`: batch delete anything remaining (orphaned entries)
+When the server sends `SyncResetV1`, we do NOT wipe the local cache. Reconciliation runs through per-row `last_seen_at` heartbeats (issue #628):
 
-This preserves existing cached data and thumbnails — no visible disruption to the user.
+1. **Enter reset mode.** On `SyncResetV1`, capture the unix-timestamp checkpoint in memory and clear the per-entity-type ack cursors (`sync_checkpoints`). The `SyncResetHandler` audit row's `started_at` is the durable copy of the checkpoint, used to resume reset mode after a crash or mid-stream disconnect.
+2. **Heartbeat each entity the stream emits.** `AssetV1`, `AlbumV1`, `PersonV1`, and `AssetFaceV1` handlers each `UPDATE … SET last_seen_at = now() WHERE id = ?` on the row they touched. Any locally-driven server interaction (push completion, favorite/restore round-trip) bumps the same column.
+3. **Sweep on `SyncCompleteV1`.** If a checkpoint is set, run four DELETEs in `finish_sync`:
+   - `media WHERE last_seen_at < checkpoint AND external_id IS NOT NULL` (via `delete_permanently_from_sync` so on-disk originals + recorder fire correctly)
+   - `albums WHERE last_seen_at < checkpoint AND external_id IS NOT NULL` (cascades through `album_media` in the same transaction)
+   - `people WHERE last_seen_at < checkpoint` (no local-only counterpart, so no `external_id` gate; orphan faces have their `person_id` nulled via `ON DELETE SET NULL`)
+   - `asset_faces WHERE last_seen_at < checkpoint`
+
+The `external_id IS NOT NULL` filter on `media`/`albums` keeps locally-imported / not-yet-pushed rows immune from server-driven orphan deletion.
+
+**Resuming after a disconnect.** On stream startup, `SyncStateRepository::current_reset_checkpoint()` queries the audit log for the most recent settled `SyncResetV1` / `SyncCompleteV1` row (`action IN ('reset', 'complete')`). If the latest is a `SyncResetV1`, we're resuming an interrupted cycle — re-populate the in-memory checkpoint from its `started_at` so heartbeats keep accumulating against the right deadline. Mid-flight (`'started'`) and errored rows don't influence state. This handles the case where Immich resumes from the last ack rather than re-issuing `SyncResetV1`.
+
+**Why per-row heartbeats instead of a HashSet snapshot.** The original design loaded every local `media.id` into a HashSet, removed each as the stream re-emitted it, and deleted the rest at end-of-stream. That had three latent bugs: (1) it used the wrong namespace — `media.id` is the local UUID; the stream's `entity_id` is the Immich UUID — so under #626's namespace separation the set never shrank and every reset cycle wiped the library; (2) locally-imported rows (`external_id IS NULL`) shouldn't have been candidates at all but were; (3) albums and `asset_faces` had no orphan tracking, so they leaked across resets. The heartbeat model fixes all three at once and is also crash-safe — partial heartbeats persist, so an interrupted reset cycle finishes correctly on the next pull.
 
 **Thumbnail Download Worker Pool:**
 ```

--- a/docs/design-immich-backend.md
+++ b/docs/design-immich-backend.md
@@ -87,7 +87,7 @@ When the server sends `SyncResetV1`, we do NOT wipe the local cache. Reconciliat
 
 1. **Enter reset mode.** On `SyncResetV1`, capture the unix-timestamp checkpoint in memory and clear the per-entity-type ack cursors (`sync_checkpoints`). The `SyncResetHandler` audit row's `started_at` is the durable copy of the checkpoint, used to resume reset mode after a crash or mid-stream disconnect.
 2. **Heartbeat each entity the stream emits.** `AssetV1`, `AlbumV1`, `PersonV1`, and `AssetFaceV1` handlers each `UPDATE … SET last_seen_at = now() WHERE id = ?` on the row they touched. Any locally-driven server interaction (push completion, favorite/restore round-trip) bumps the same column.
-3. **Sweep on `SyncCompleteV1`.** If a checkpoint is set, run four DELETEs in `finish_sync`:
+3. **Sweep on `SyncCompleteV1`.** If a checkpoint is set, run four DELETE passes in `finish_sync`:
    - `media WHERE last_seen_at < checkpoint AND external_id IS NOT NULL` (via `delete_permanently_from_sync` so on-disk originals + recorder fire correctly)
    - `albums WHERE last_seen_at < checkpoint AND external_id IS NOT NULL` (cascades through `album_media` in the same transaction)
    - `people WHERE last_seen_at < checkpoint` (no local-only counterpart, so no `external_id` gate; orphan faces have their `person_id` nulled via `ON DELETE SET NULL`)

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -418,6 +418,60 @@ impl AlbumRepository {
         Ok(rows.into_iter().map(|(id,)| MediaId::new(id)).collect())
     }
 
+    /// Delete albums whose heartbeat lags the checkpoint and have a
+    /// non-null `external_id`. Cascades to `album_media` membership rows
+    /// in the same transaction.
+    ///
+    /// Issue #628: the reset-cycle orphan sweep on the `albums` table.
+    /// `external_id IS NOT NULL` excludes locally-created albums the
+    /// server has never seen. Returns the deleted album ids for
+    /// logging.
+    pub async fn delete_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<AlbumId>, LibraryError> {
+        let mut tx = self.db.pool().begin().await.map_err(LibraryError::Db)?;
+
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT id FROM albums
+             WHERE last_seen_at < ? AND external_id IS NOT NULL",
+        )
+        .bind(checkpoint)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(LibraryError::Db)?;
+
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let ids: Vec<AlbumId> = rows
+            .into_iter()
+            .map(|(id,)| AlbumId::from_raw(id))
+            .collect();
+
+        // Cascade-delete membership rows first, then the album rows
+        // themselves. Mirrors the manual cascade in `delete()` —
+        // `album_media.album_id` references `albums(id)` without
+        // ON DELETE CASCADE, so SQLite would reject the album DELETE
+        // otherwise.
+        for id in &ids {
+            sqlx::query("DELETE FROM album_media WHERE album_id = ?")
+                .bind(id.as_str())
+                .execute(&mut *tx)
+                .await
+                .map_err(LibraryError::Db)?;
+            sqlx::query("DELETE FROM albums WHERE id = ?")
+                .bind(id.as_str())
+                .execute(&mut *tx)
+                .await
+                .map_err(LibraryError::Db)?;
+        }
+
+        tx.commit().await.map_err(LibraryError::Db)?;
+        Ok(ids)
+    }
+
     /// Update `last_seen_at` to the given unix timestamp for one album row.
     ///
     /// Issue #628: heartbeat for the reset-cycle orphan sweep on
@@ -923,5 +977,68 @@ mod tests {
         let (repo, _media, _db) = test_repo(dir.path()).await;
         let id = AlbumId::from_raw("nonexistent".to_string());
         repo.bump_last_seen_at(&id, 12345).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_with_stale_heartbeat_removes_only_eligible_rows() {
+        let dir = tempdir().unwrap();
+        let (repo, media, db) = test_repo(dir.path()).await;
+
+        // Insert one media row so we can attach an album_media membership
+        // and verify the cascade delete.
+        let media_id = MediaId::new("a".repeat(64));
+        media
+            .insert(&record_with_taken_at(media_id.clone(), "a.jpg", Some(1000)))
+            .await
+            .unwrap();
+
+        // Server-sourced album, stale heartbeat → orphan.
+        let stale_synced = repo.create("Stale Synced").await.unwrap();
+        sqlx::query("UPDATE albums SET external_id = 'immich-1', last_seen_at = 100 WHERE id = ?")
+            .bind(stale_synced.as_str())
+            .execute(db.pool())
+            .await
+            .unwrap();
+        repo.add_media(&stale_synced, std::slice::from_ref(&media_id))
+            .await
+            .unwrap();
+
+        // Server-sourced album, fresh heartbeat → safe.
+        let fresh_synced = repo.create("Fresh Synced").await.unwrap();
+        sqlx::query("UPDATE albums SET external_id = 'immich-2', last_seen_at = 300 WHERE id = ?")
+            .bind(fresh_synced.as_str())
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        // Locally-created album (no external_id) → immune.
+        let local_only = repo.create("Local Only").await.unwrap();
+
+        let deleted = repo.delete_with_stale_heartbeat(200).await.unwrap();
+        assert_eq!(deleted.len(), 1);
+        assert_eq!(deleted[0].as_str(), stale_synced.as_str());
+
+        // Stale synced album is gone, fresh + local survive.
+        assert!(repo.get(&stale_synced).await.unwrap().is_none());
+        assert!(repo.get(&fresh_synced).await.unwrap().is_some());
+        assert!(repo.get(&local_only).await.unwrap().is_some());
+
+        // Membership row for the deleted album is gone too.
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM album_media WHERE album_id = ?",
+        )
+        .bind(stale_synced.as_str())
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(count.0, 0, "membership rows must cascade with the album");
+    }
+
+    #[tokio::test]
+    async fn delete_with_stale_heartbeat_empty_returns_empty() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, _db) = test_repo(dir.path()).await;
+        let deleted = repo.delete_with_stale_heartbeat(100).await.unwrap();
+        assert!(deleted.is_empty());
     }
 }

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -417,6 +417,25 @@ impl AlbumRepository {
 
         Ok(rows.into_iter().map(|(id,)| MediaId::new(id)).collect())
     }
+
+    /// Update `last_seen_at` to the given unix timestamp for one album row.
+    ///
+    /// Issue #628: heartbeat for the reset-cycle orphan sweep on
+    /// `albums`. Bumped from `AlbumHandler` (pull) and any
+    /// server-confirmed album mutation (push).
+    pub async fn bump_last_seen_at(
+        &self,
+        id: &AlbumId,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE albums SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(id.as_str())
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
 }
 
 /// Convert an `AlbumRow` into an `Album`.
@@ -880,5 +899,29 @@ mod tests {
 
         repo.set_pinned(&id, false).await.unwrap();
         assert!(!repo.get(&id).await.unwrap().unwrap().is_pinned);
+    }
+
+    #[tokio::test]
+    async fn bump_last_seen_at_writes_value() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, db) = test_repo(dir.path()).await;
+        let id = repo.create("Heartbeat").await.unwrap();
+
+        repo.bump_last_seen_at(&id, 12345).await.unwrap();
+
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM albums WHERE id = ?")
+            .bind(id.as_str())
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(row.0, 12345);
+    }
+
+    #[tokio::test]
+    async fn bump_last_seen_at_missing_id_is_noop() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, _db) = test_repo(dir.path()).await;
+        let id = AlbumId::from_raw("nonexistent".to_string());
+        repo.bump_last_seen_at(&id, 12345).await.unwrap();
     }
 }

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -477,11 +477,7 @@ impl AlbumRepository {
     /// Issue #628: heartbeat for the reset-cycle orphan sweep on
     /// `albums`. Bumped from `AlbumHandler` (pull) and any
     /// server-confirmed album mutation (push).
-    pub async fn bump_last_seen_at(
-        &self,
-        id: &AlbumId,
-        now: i64,
-    ) -> Result<(), LibraryError> {
+    pub async fn bump_last_seen_at(&self, id: &AlbumId, now: i64) -> Result<(), LibraryError> {
         sqlx::query("UPDATE albums SET last_seen_at = ? WHERE id = ?")
             .bind(now)
             .bind(id.as_str())
@@ -1024,13 +1020,11 @@ mod tests {
         assert!(repo.get(&local_only).await.unwrap().is_some());
 
         // Membership row for the deleted album is gone too.
-        let count: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM album_media WHERE album_id = ?",
-        )
-        .bind(stale_synced.as_str())
-        .fetch_one(db.pool())
-        .await
-        .unwrap();
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM album_media WHERE album_id = ?")
+            .bind(stale_synced.as_str())
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
         assert_eq!(count.0, 0, "membership rows must cascade with the album");
     }
 

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -265,11 +265,7 @@ impl AlbumService {
     /// Sync-only: bump `last_seen_at` for one album row. See issue
     /// #628 — the heartbeat that the reset-cycle orphan sweep
     /// compares against.
-    pub async fn bump_last_seen_at(
-        &self,
-        id: &AlbumId,
-        now: i64,
-    ) -> Result<(), LibraryError> {
+    pub async fn bump_last_seen_at(&self, id: &AlbumId, now: i64) -> Result<(), LibraryError> {
         self.repo.bump_last_seen_at(id, now).await
     }
 

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -271,12 +271,18 @@ impl AlbumService {
 
     /// Sync-only: delete albums whose heartbeat lags `checkpoint`
     /// and which have a non-null `external_id`. Returns the deleted
-    /// album ids. See issue #628.
+    /// album ids. Emits [`AlbumEvent::AlbumRemoved`] for each so
+    /// client `ListStore`s drop the rows without waiting for a UI
+    /// refresh. See issue #628.
     pub async fn delete_with_stale_heartbeat(
         &self,
         checkpoint: i64,
     ) -> Result<Vec<AlbumId>, LibraryError> {
-        self.repo.delete_with_stale_heartbeat(checkpoint).await
+        let removed_ids = self.repo.delete_with_stale_heartbeat(checkpoint).await?;
+        for id in &removed_ids {
+            self.emit(AlbumEvent::AlbumRemoved(id.clone()));
+        }
+        Ok(removed_ids)
     }
 }
 
@@ -340,5 +346,41 @@ mod tests {
             AlbumEvent::AlbumUpdated(id) => assert_eq!(id, local_id),
             other => panic!("expected AlbumUpdated; got {other:?}"),
         }
+    }
+
+    /// Issue #628: the orphan sweep at end-of-reset must emit
+    /// `AlbumRemoved` for each deleted album so client `ListStore`s
+    /// patch in real time instead of waiting for a UI reload.
+    #[tokio::test]
+    async fn delete_with_stale_heartbeat_emits_album_removed_per_id() {
+        let (_dir, svc) = make_service().await;
+
+        let stale = svc.create_album("Stale Synced").await.unwrap();
+        let fresh = svc.create_album("Fresh Synced").await.unwrap();
+        // Promote both to server-sourced and pin heartbeats.
+        svc.upsert_album(stale.as_str(), "Stale Synced", 0, 0, Some("immich-1"))
+            .await
+            .unwrap();
+        svc.upsert_album(fresh.as_str(), "Fresh Synced", 0, 0, Some("immich-2"))
+            .await
+            .unwrap();
+        svc.bump_last_seen_at(&stale, 100).await.unwrap();
+        svc.bump_last_seen_at(&fresh, 300).await.unwrap();
+
+        // Subscribe AFTER setup so we don't see upsert events.
+        let mut rx = svc.subscribe();
+
+        let removed = svc.delete_with_stale_heartbeat(200).await.unwrap();
+        assert_eq!(removed, vec![stale.clone()]);
+
+        let event = rx.try_recv().expect("expected one event");
+        match event {
+            AlbumEvent::AlbumRemoved(id) => assert_eq!(id, stale),
+            other => panic!("expected AlbumRemoved; got {other:?}"),
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "fresh album wasn't swept; only one event expected"
+        );
     }
 }

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -261,6 +261,17 @@ impl AlbumService {
     ) -> Result<Vec<MediaId>, LibraryError> {
         self.repo.cover_media_ids(album_id, limit).await
     }
+
+    /// Sync-only: bump `last_seen_at` for one album row. See issue
+    /// #628 — the heartbeat that the reset-cycle orphan sweep
+    /// compares against.
+    pub async fn bump_last_seen_at(
+        &self,
+        id: &AlbumId,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        self.repo.bump_last_seen_at(id, now).await
+    }
 }
 
 #[cfg(test)]

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -272,6 +272,16 @@ impl AlbumService {
     ) -> Result<(), LibraryError> {
         self.repo.bump_last_seen_at(id, now).await
     }
+
+    /// Sync-only: delete albums whose heartbeat lags `checkpoint`
+    /// and which have a non-null `external_id`. Returns the deleted
+    /// album ids. See issue #628.
+    pub async fn delete_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<AlbumId>, LibraryError> {
+        self.repo.delete_with_stale_heartbeat(checkpoint).await
+    }
 }
 
 #[cfg(test)]

--- a/src/library/db/migrations/022_add_last_seen_at.sql
+++ b/src/library/db/migrations/022_add_last_seen_at.sql
@@ -1,0 +1,29 @@
+-- Issue #628: heartbeat-based reset reconciliation.
+--
+-- Each reconciled row gains a `last_seen_at` (unix seconds) that's
+-- bumped on every successful server interaction:
+--   - Pull side: AssetV1 / AssetDeleteV1 / AlbumV1 / AlbumDeleteV1 /
+--     PersonV1 / AssetFaceV1 handlers update the corresponding row.
+--   - Push side: external_id stamping after upload, and any
+--     server-confirmed write-through (favorite, restore, album
+--     mutation) bumps the affected row.
+--
+-- On a reset cycle (`SyncResetV1` → ... → `SyncCompleteV1`), rows
+-- whose `last_seen_at` is older than the reset's checkpoint are
+-- treated as deleted server-side and removed locally. For media and
+-- albums the sweep is gated on `external_id IS NOT NULL`, which
+-- excludes locally-imported rows that have never been pushed (they
+-- don't belong to the server's namespace and aren't candidates for
+-- server-side orphaning). People and asset_faces don't have a
+-- locally-only counterpart, so the gate doesn't apply there.
+--
+-- Existing rows are backfilled to `0`. On the first post-migration
+-- reset cycle the stream re-emits every live row and bumps it past
+-- the checkpoint before `SyncCompleteV1` runs the sweep, so the
+-- literal backfill value is immaterial as long as it's ≤ that
+-- checkpoint. Local-only rows survive via the external_id filter.
+
+ALTER TABLE media       ADD COLUMN last_seen_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE albums      ADD COLUMN last_seen_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE people      ADD COLUMN last_seen_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE asset_faces ADD COLUMN last_seen_at INTEGER NOT NULL DEFAULT 0;

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -261,8 +261,8 @@ impl FacesRepository {
     ///
     /// Issue #628: the reset-cycle orphan sweep on the `people` table.
     /// People are always server-sourced (no local-only counterpart),
-    /// so the sweep doesn't gate on `external_id`. Returns the number
-    /// of rows removed for logging.
+    /// so the sweep doesn't gate on `external_id`. Returns the deleted
+    /// person ids so the caller can emit `PersonRemoved` events.
     ///
     /// Asset face rows that referenced any of the deleted people have
     /// their `person_id` set to NULL via the FK's ON DELETE SET NULL
@@ -270,13 +270,47 @@ impl FacesRepository {
     pub async fn delete_people_with_stale_heartbeat(
         &self,
         checkpoint: i64,
-    ) -> Result<u64, LibraryError> {
-        let result = sqlx::query("DELETE FROM people WHERE last_seen_at < ?")
+    ) -> Result<Vec<String>, LibraryError> {
+        let mut tx = self.db.pool().begin().await.map_err(LibraryError::Db)?;
+        let rows: Vec<(String,)> =
+            sqlx::query_as("SELECT id FROM people WHERE last_seen_at < ?")
+                .bind(checkpoint)
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(LibraryError::Db)?;
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+        let ids: Vec<String> = rows.into_iter().map(|(id,)| id).collect();
+        sqlx::query("DELETE FROM people WHERE last_seen_at < ?")
             .bind(checkpoint)
-            .execute(self.db.pool())
+            .execute(&mut *tx)
             .await
             .map_err(LibraryError::Db)?;
-        Ok(result.rows_affected())
+        tx.commit().await.map_err(LibraryError::Db)?;
+        Ok(ids)
+    }
+
+    /// Distinct non-null `person_id` values among asset_face rows
+    /// whose heartbeat lags the checkpoint.
+    ///
+    /// Issue #628: the reset-cycle face sweep needs to know which
+    /// surviving people had faces removed so their denormalised
+    /// `face_count` can be recomputed. Called by the service before
+    /// `delete_asset_faces_with_stale_heartbeat`.
+    pub async fn persons_with_stale_faces(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<String>, LibraryError> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT DISTINCT person_id FROM asset_faces
+             WHERE last_seen_at < ? AND person_id IS NOT NULL",
+        )
+        .bind(checkpoint)
+        .fetch_all(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(rows.into_iter().map(|(p,)| p).collect())
     }
 
     /// Delete asset face rows whose heartbeat lags the given checkpoint.
@@ -300,7 +334,7 @@ impl FacesRepository {
     /// Issue #628: heartbeat for the reset-cycle orphan sweep on
     /// `people`. Bumped from `PersonHandler` (pull). People are
     /// always server-sourced (no local-only counterpart), so the
-    /// sweep DELETEs without an `external_id` filter.
+    /// sweep deletes without an `external_id` filter.
     pub async fn bump_person_last_seen_at(&self, id: &str, now: i64) -> Result<(), LibraryError> {
         sqlx::query("UPDATE people SET last_seen_at = ? WHERE id = ?")
             .bind(now)
@@ -708,7 +742,7 @@ mod tests {
         repo.bump_person_last_seen_at("p2", 300).await.unwrap();
 
         let removed = repo.delete_people_with_stale_heartbeat(200).await.unwrap();
-        assert_eq!(removed, 1);
+        assert_eq!(removed, vec!["p1".to_string()]);
 
         let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM people")
             .fetch_one(db.pool())

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -257,24 +257,6 @@ impl FacesRepository {
         Ok(())
     }
 
-    /// Delete all people (used during sync reset).
-    pub async fn clear_people(&self) -> Result<(), LibraryError> {
-        sqlx::query("DELETE FROM people")
-            .execute(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-        Ok(())
-    }
-
-    /// Delete all asset faces (used during sync reset).
-    pub async fn clear_asset_faces(&self) -> Result<(), LibraryError> {
-        sqlx::query("DELETE FROM asset_faces")
-            .execute(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-        Ok(())
-    }
-
     /// Delete people whose heartbeat lags the given checkpoint.
     ///
     /// Issue #628: the reset-cycle orphan sweep on the `people` table.
@@ -615,41 +597,6 @@ mod tests {
 
         let media = repo.list_media_for_person("p1").await.unwrap();
         assert_eq!(media, vec!["m1"]); // m2 is trashed
-    }
-
-    #[tokio::test]
-    async fn clear_people_and_faces() {
-        let dir = tempdir().unwrap();
-        let (repo, media, _db) = test_repo(dir.path()).await;
-
-        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
-            .await
-            .unwrap();
-        let rec = test_record(MediaId::new("m1".to_string()));
-        media.insert(&rec).await.unwrap();
-
-        let face = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
-        repo.upsert_asset_face(&face).await.unwrap();
-
-        repo.clear_asset_faces().await.unwrap();
-        repo.clear_people().await.unwrap();
-
-        let people = repo.list_people().await.unwrap();
-        assert!(people.is_empty());
-
-        let media = repo.list_media_for_person("p1").await.unwrap();
-        assert!(media.is_empty());
     }
 
     #[tokio::test]

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -275,6 +275,44 @@ impl FacesRepository {
         Ok(())
     }
 
+    /// Delete people whose heartbeat lags the given checkpoint.
+    ///
+    /// Issue #628: the reset-cycle orphan sweep on the `people` table.
+    /// People are always server-sourced (no local-only counterpart),
+    /// so the sweep doesn't gate on `external_id`. Returns the number
+    /// of rows removed for logging.
+    ///
+    /// Asset face rows that referenced any of the deleted people have
+    /// their `person_id` set to NULL via the FK's ON DELETE SET NULL
+    /// — the face stays, just unattributed.
+    pub async fn delete_people_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<u64, LibraryError> {
+        let result = sqlx::query("DELETE FROM people WHERE last_seen_at < ?")
+            .bind(checkpoint)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(result.rows_affected())
+    }
+
+    /// Delete asset face rows whose heartbeat lags the given checkpoint.
+    ///
+    /// Issue #628: the reset-cycle orphan sweep on the `asset_faces`
+    /// table. As with people, all rows are server-sourced.
+    pub async fn delete_asset_faces_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<u64, LibraryError> {
+        let result = sqlx::query("DELETE FROM asset_faces WHERE last_seen_at < ?")
+            .bind(checkpoint)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(result.rows_affected())
+    }
+
     /// Update `last_seen_at` to the given unix timestamp for one person row.
     ///
     /// Issue #628: heartbeat for the reset-cycle orphan sweep on
@@ -710,5 +748,111 @@ mod tests {
         repo.bump_asset_face_last_seen_at("ghost", 12345)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_people_with_stale_heartbeat_removes_only_eligible_rows() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, db) = test_repo(dir.path()).await;
+        repo.upsert_person("p1", "Stale", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        repo.bump_person_last_seen_at("p1", 100).await.unwrap();
+        repo.upsert_person("p2", "Fresh", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        repo.bump_person_last_seen_at("p2", 300).await.unwrap();
+
+        let removed = repo
+            .delete_people_with_stale_heartbeat(200)
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM people")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(count.0, 1, "only the fresh person remains");
+    }
+
+    #[tokio::test]
+    async fn delete_people_with_stale_heartbeat_nullifies_referencing_face_person_id() {
+        let dir = tempdir().unwrap();
+        let (repo, media, db) = test_repo(dir.path()).await;
+
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+        repo.upsert_person("p1", "Stale", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        repo.bump_person_last_seen_at("p1", 100).await.unwrap();
+
+        let face = AssetFaceRow {
+            id: "f1".to_string(),
+            asset_id: "m1".to_string(),
+            person_id: Some("p1".to_string()),
+            image_width: 100,
+            image_height: 100,
+            bbox_x1: 0,
+            bbox_y1: 0,
+            bbox_x2: 50,
+            bbox_y2: 50,
+            source_type: "MachineLearning".to_string(),
+        };
+        repo.upsert_asset_face(&face).await.unwrap();
+
+        repo.delete_people_with_stale_heartbeat(200).await.unwrap();
+
+        // Face row survives but is detached from the deleted person.
+        let person_id: (Option<String>,) =
+            sqlx::query_as("SELECT person_id FROM asset_faces WHERE id = 'f1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(person_id.0, None);
+    }
+
+    #[tokio::test]
+    async fn delete_asset_faces_with_stale_heartbeat_removes_only_eligible_rows() {
+        let dir = tempdir().unwrap();
+        let (repo, media, db) = test_repo(dir.path()).await;
+
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+
+        for (id, beat) in [("stale", 100), ("fresh", 300)] {
+            let face = AssetFaceRow {
+                id: id.to_string(),
+                asset_id: "m1".to_string(),
+                person_id: None,
+                image_width: 100,
+                image_height: 100,
+                bbox_x1: 0,
+                bbox_y1: 0,
+                bbox_x2: 50,
+                bbox_y2: 50,
+                source_type: "MachineLearning".to_string(),
+            };
+            repo.upsert_asset_face(&face).await.unwrap();
+            repo.bump_asset_face_last_seen_at(id, beat).await.unwrap();
+        }
+
+        let removed = repo
+            .delete_asset_faces_with_stale_heartbeat(200)
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+
+        let surviving: (String,) =
+            sqlx::query_as("SELECT id FROM asset_faces")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(surviving.0, "fresh");
     }
 }

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -274,6 +274,44 @@ impl FacesRepository {
             .map_err(LibraryError::Db)?;
         Ok(())
     }
+
+    /// Update `last_seen_at` to the given unix timestamp for one person row.
+    ///
+    /// Issue #628: heartbeat for the reset-cycle orphan sweep on
+    /// `people`. Bumped from `PersonHandler` (pull). People are
+    /// always server-sourced (no local-only counterpart), so the
+    /// sweep DELETEs without an `external_id` filter.
+    pub async fn bump_person_last_seen_at(
+        &self,
+        id: &str,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE people SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(id)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Update `last_seen_at` to the given unix timestamp for one asset face row.
+    ///
+    /// Issue #628: heartbeat for the reset-cycle orphan sweep on
+    /// `asset_faces`. Bumped from `AssetFaceHandler` (pull).
+    pub async fn bump_asset_face_last_seen_at(
+        &self,
+        id: &str,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE asset_faces SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(id)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -607,5 +645,70 @@ mod tests {
         // Face still exists but with no person.
         let media = repo.list_media_for_person("p1").await.unwrap();
         assert!(media.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bump_person_last_seen_at_writes_value() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, db) = test_repo(dir.path()).await;
+        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
+            .await
+            .unwrap();
+
+        repo.bump_person_last_seen_at("p1", 12345).await.unwrap();
+
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM people WHERE id = 'p1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(row.0, 12345);
+    }
+
+    #[tokio::test]
+    async fn bump_person_last_seen_at_missing_id_is_noop() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, _db) = test_repo(dir.path()).await;
+        repo.bump_person_last_seen_at("ghost", 12345).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bump_asset_face_last_seen_at_writes_value() {
+        let dir = tempdir().unwrap();
+        let (repo, media, db) = test_repo(dir.path()).await;
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+        let face = AssetFaceRow {
+            id: "f1".to_string(),
+            asset_id: "m1".to_string(),
+            person_id: None,
+            image_width: 100,
+            image_height: 100,
+            bbox_x1: 0,
+            bbox_y1: 0,
+            bbox_x2: 50,
+            bbox_y2: 50,
+            source_type: "MachineLearning".to_string(),
+        };
+        repo.upsert_asset_face(&face).await.unwrap();
+
+        repo.bump_asset_face_last_seen_at("f1", 12345).await.unwrap();
+
+        let row: (i64,) =
+            sqlx::query_as("SELECT last_seen_at FROM asset_faces WHERE id = 'f1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(row.0, 12345);
+    }
+
+    #[tokio::test]
+    async fn bump_asset_face_last_seen_at_missing_id_is_noop() {
+        let dir = tempdir().unwrap();
+        let (repo, _media, _db) = test_repo(dir.path()).await;
+        repo.bump_asset_face_last_seen_at("ghost", 12345)
+            .await
+            .unwrap();
     }
 }

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -272,12 +272,11 @@ impl FacesRepository {
         checkpoint: i64,
     ) -> Result<Vec<String>, LibraryError> {
         let mut tx = self.db.pool().begin().await.map_err(LibraryError::Db)?;
-        let rows: Vec<(String,)> =
-            sqlx::query_as("SELECT id FROM people WHERE last_seen_at < ?")
-                .bind(checkpoint)
-                .fetch_all(&mut *tx)
-                .await
-                .map_err(LibraryError::Db)?;
+        let rows: Vec<(String,)> = sqlx::query_as("SELECT id FROM people WHERE last_seen_at < ?")
+            .bind(checkpoint)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(LibraryError::Db)?;
         if rows.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -301,11 +301,7 @@ impl FacesRepository {
     /// `people`. Bumped from `PersonHandler` (pull). People are
     /// always server-sourced (no local-only counterpart), so the
     /// sweep DELETEs without an `external_id` filter.
-    pub async fn bump_person_last_seen_at(
-        &self,
-        id: &str,
-        now: i64,
-    ) -> Result<(), LibraryError> {
+    pub async fn bump_person_last_seen_at(&self, id: &str, now: i64) -> Result<(), LibraryError> {
         sqlx::query("UPDATE people SET last_seen_at = ? WHERE id = ?")
             .bind(now)
             .bind(id)
@@ -678,13 +674,14 @@ mod tests {
         };
         repo.upsert_asset_face(&face).await.unwrap();
 
-        repo.bump_asset_face_last_seen_at("f1", 12345).await.unwrap();
+        repo.bump_asset_face_last_seen_at("f1", 12345)
+            .await
+            .unwrap();
 
-        let row: (i64,) =
-            sqlx::query_as("SELECT last_seen_at FROM asset_faces WHERE id = 'f1'")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM asset_faces WHERE id = 'f1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
         assert_eq!(row.0, 12345);
     }
 
@@ -710,10 +707,7 @@ mod tests {
             .unwrap();
         repo.bump_person_last_seen_at("p2", 300).await.unwrap();
 
-        let removed = repo
-            .delete_people_with_stale_heartbeat(200)
-            .await
-            .unwrap();
+        let removed = repo.delete_people_with_stale_heartbeat(200).await.unwrap();
         assert_eq!(removed, 1);
 
         let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM people")
@@ -795,11 +789,10 @@ mod tests {
             .unwrap();
         assert_eq!(removed, 1);
 
-        let surviving: (String,) =
-            sqlx::query_as("SELECT id FROM asset_faces")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        let surviving: (String,) = sqlx::query_as("SELECT id FROM asset_faces")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
         assert_eq!(surviving.0, "fresh");
     }
 }

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -385,7 +385,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = open_test_db(dir.path()).await;
         let media = MediaRepository::new(db.clone());
-        let svc = FacesService::new(db.clone(), thumb_root.path().to_path_buf(), Arc::new(NoOpRecorder));
+        let svc = FacesService::new(
+            db.clone(),
+            thumb_root.path().to_path_buf(),
+            Arc::new(NoOpRecorder),
+        );
 
         media
             .insert(&test_record(MediaId::new("m1".to_string())))
@@ -394,7 +398,10 @@ mod tests {
         svc.upsert_person("p1", "Survivor", None, false, false, None, None, None)
             .await
             .unwrap();
-        svc.repo.bump_person_last_seen_at("p1", 1_000).await.unwrap();
+        svc.repo
+            .bump_person_last_seen_at("p1", 1_000)
+            .await
+            .unwrap();
 
         // Two faces attached to the same surviving person — one stale,
         // one fresh.
@@ -412,7 +419,10 @@ mod tests {
                 source_type: "MachineLearning".to_string(),
             };
             svc.repo.upsert_asset_face(&row).await.unwrap();
-            svc.repo.bump_asset_face_last_seen_at(id, beat).await.unwrap();
+            svc.repo
+                .bump_asset_face_last_seen_at(id, beat)
+                .await
+                .unwrap();
         }
         // Pin face_count to a wrong value so we can prove the recompute fired.
         sqlx::query("UPDATE people SET face_count = 99 WHERE id = 'p1'")

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -262,26 +262,42 @@ impl FacesService {
     }
 
     /// Sync-only: delete people whose heartbeat lags `checkpoint`.
-    /// Returns the count of deleted rows. See issue #628.
+    /// Returns the deleted person ids. Emits
+    /// [`FacesEvent::PersonRemoved`] for each so client `ListStore`s
+    /// drop the rows without waiting for a UI refresh. See issue #628.
     pub async fn delete_people_with_stale_heartbeat(
         &self,
         checkpoint: i64,
-    ) -> Result<u64, LibraryError> {
-        self.repo
+    ) -> Result<Vec<String>, LibraryError> {
+        let removed_ids = self
+            .repo
             .delete_people_with_stale_heartbeat(checkpoint)
-            .await
+            .await?;
+        for id in &removed_ids {
+            self.emit(FacesEvent::PersonRemoved(PersonId::from_raw(id.clone())));
+        }
+        Ok(removed_ids)
     }
 
     /// Sync-only: delete asset_face rows whose heartbeat lags
-    /// `checkpoint`. Returns the count of deleted rows. See issue
-    /// #628.
+    /// `checkpoint`. Returns the count of deleted rows.
+    ///
+    /// Recomputes `face_count` on every surviving person whose stale
+    /// faces were swept — without this the denormalised count drifts
+    /// until the next sync cycle re-emits the person. See issue #628.
     pub async fn delete_asset_faces_with_stale_heartbeat(
         &self,
         checkpoint: i64,
     ) -> Result<u64, LibraryError> {
-        self.repo
+        let affected_persons = self.repo.persons_with_stale_faces(checkpoint).await?;
+        let removed = self
+            .repo
             .delete_asset_faces_with_stale_heartbeat(checkpoint)
-            .await
+            .await?;
+        for person_id in &affected_persons {
+            self.repo.update_face_count(person_id).await?;
+        }
+        Ok(removed)
     }
 }
 
@@ -322,5 +338,101 @@ mod tests {
 
         let (_dir, svc) = make_service(thumb_root.path().to_path_buf()).await;
         assert!(svc.person_thumbnail_path(&person_id).is_none());
+    }
+
+    /// Issue #628: orphan sweep emits `PersonRemoved` per deleted
+    /// person so client `ListStore`s drop them in real time.
+    #[tokio::test]
+    async fn delete_people_with_stale_heartbeat_emits_person_removed_per_id() {
+        let thumb_root = tempfile::tempdir().unwrap();
+        let (_dir, svc) = make_service(thumb_root.path().to_path_buf()).await;
+
+        svc.upsert_person("p1", "Stale", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        svc.upsert_person("p2", "Fresh", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        svc.repo.bump_person_last_seen_at("p1", 100).await.unwrap();
+        svc.repo.bump_person_last_seen_at("p2", 300).await.unwrap();
+
+        // Subscribe AFTER setup so the upsert events don't pollute the channel.
+        let mut rx = svc.subscribe();
+
+        let removed = svc.delete_people_with_stale_heartbeat(200).await.unwrap();
+        assert_eq!(removed, vec!["p1".to_string()]);
+
+        let event = rx.try_recv().expect("expected one event");
+        match event {
+            FacesEvent::PersonRemoved(id) => assert_eq!(id.as_str(), "p1"),
+            other => panic!("expected PersonRemoved; got {other:?}"),
+        }
+        assert!(rx.try_recv().is_err(), "fresh person wasn't swept");
+    }
+
+    /// Issue #628: when stale faces are swept, every surviving person
+    /// who lost faces gets their denormalised `face_count` recomputed.
+    /// Without this the count drifts until the next sync cycle re-emits
+    /// the person.
+    #[tokio::test]
+    async fn delete_asset_faces_with_stale_heartbeat_recomputes_face_count() {
+        use crate::library::db::test_helpers::test_record;
+        use crate::library::faces::repository::AssetFaceRow;
+        use crate::library::media::repository::MediaRepository;
+        use crate::library::media::MediaId;
+
+        let thumb_root = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let media = MediaRepository::new(db.clone());
+        let svc = FacesService::new(db.clone(), thumb_root.path().to_path_buf(), Arc::new(NoOpRecorder));
+
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+        svc.upsert_person("p1", "Survivor", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        svc.repo.bump_person_last_seen_at("p1", 1_000).await.unwrap();
+
+        // Two faces attached to the same surviving person — one stale,
+        // one fresh.
+        for (id, beat) in [("stale-face", 100), ("fresh-face", 1_000)] {
+            let row = AssetFaceRow {
+                id: id.to_string(),
+                asset_id: "m1".to_string(),
+                person_id: Some("p1".to_string()),
+                image_width: 100,
+                image_height: 100,
+                bbox_x1: 0,
+                bbox_y1: 0,
+                bbox_x2: 50,
+                bbox_y2: 50,
+                source_type: "MachineLearning".to_string(),
+            };
+            svc.repo.upsert_asset_face(&row).await.unwrap();
+            svc.repo.bump_asset_face_last_seen_at(id, beat).await.unwrap();
+        }
+        // Pin face_count to a wrong value so we can prove the recompute fired.
+        sqlx::query("UPDATE people SET face_count = 99 WHERE id = 'p1'")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let removed = svc
+            .delete_asset_faces_with_stale_heartbeat(200)
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+
+        let count: (i64,) = sqlx::query_as("SELECT face_count FROM people WHERE id = 'p1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            count.0, 1,
+            "face_count must be recomputed to 1 (only fresh-face survives)"
+        );
     }
 }

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -247,11 +247,7 @@ impl FacesService {
     /// Sync-only: bump `last_seen_at` for one person row. See issue
     /// #628 — the heartbeat that the reset-cycle orphan sweep
     /// compares against.
-    pub async fn bump_person_last_seen_at(
-        &self,
-        id: &str,
-        now: i64,
-    ) -> Result<(), LibraryError> {
+    pub async fn bump_person_last_seen_at(&self, id: &str, now: i64) -> Result<(), LibraryError> {
         self.repo.bump_person_last_seen_at(id, now).await
     }
 
@@ -271,7 +267,9 @@ impl FacesService {
         &self,
         checkpoint: i64,
     ) -> Result<u64, LibraryError> {
-        self.repo.delete_people_with_stale_heartbeat(checkpoint).await
+        self.repo
+            .delete_people_with_stale_heartbeat(checkpoint)
+            .await
     }
 
     /// Sync-only: delete asset_face rows whose heartbeat lags

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -274,6 +274,27 @@ impl FacesService {
     ) -> Result<(), LibraryError> {
         self.repo.bump_asset_face_last_seen_at(id, now).await
     }
+
+    /// Sync-only: delete people whose heartbeat lags `checkpoint`.
+    /// Returns the count of deleted rows. See issue #628.
+    pub async fn delete_people_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<u64, LibraryError> {
+        self.repo.delete_people_with_stale_heartbeat(checkpoint).await
+    }
+
+    /// Sync-only: delete asset_face rows whose heartbeat lags
+    /// `checkpoint`. Returns the count of deleted rows. See issue
+    /// #628.
+    pub async fn delete_asset_faces_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<u64, LibraryError> {
+        self.repo
+            .delete_asset_faces_with_stale_heartbeat(checkpoint)
+            .await
+    }
 }
 
 #[cfg(test)]

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -152,16 +152,6 @@ impl FacesService {
         self.repo.update_face_count(person_id).await
     }
 
-    /// Clear all people (for reset sync).
-    pub async fn clear_people(&self) -> Result<(), LibraryError> {
-        self.repo.clear_people().await
-    }
-
-    /// Clear all asset faces (for reset sync).
-    pub async fn clear_asset_faces(&self) -> Result<(), LibraryError> {
-        self.repo.clear_asset_faces().await
-    }
-
     // ── Query methods ───────────────────────────────────────────────
 
     pub async fn list_people(&self) -> Result<Vec<Person>, LibraryError> {

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -253,6 +253,27 @@ impl FacesService {
             None
         }
     }
+
+    /// Sync-only: bump `last_seen_at` for one person row. See issue
+    /// #628 — the heartbeat that the reset-cycle orphan sweep
+    /// compares against.
+    pub async fn bump_person_last_seen_at(
+        &self,
+        id: &str,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        self.repo.bump_person_last_seen_at(id, now).await
+    }
+
+    /// Sync-only: bump `last_seen_at` for one asset_face row. See
+    /// issue #628.
+    pub async fn bump_asset_face_last_seen_at(
+        &self,
+        id: &str,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        self.repo.bump_asset_face_last_seen_at(id, now).await
+    }
 }
 
 #[cfg(test)]

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -494,19 +494,6 @@ impl MediaRepository {
             .map_err(LibraryError::Db)
     }
 
-    /// Load every media row's id into a set.
-    ///
-    /// Used by the Immich pull engine to detect orphans during a reset
-    /// sync: the set is seeded from this query, every `AssetV1` line in
-    /// the stream removes its id, and whatever is left at the end is
-    /// deleted as having vanished from the server.
-    pub async fn all_ids(&self) -> Result<std::collections::HashSet<String>, LibraryError> {
-        let rows: Vec<(String,)> = sqlx::query_as("SELECT id FROM media")
-            .fetch_all(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-        Ok(rows.into_iter().map(|(id,)| id).collect())
-    }
 
     /// Move assets to the trash (soft delete).
     pub async fn trash(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
@@ -573,6 +560,29 @@ impl MediaRepository {
         }
         tx.commit().await.map_err(LibraryError::Db)?;
         Ok(())
+    }
+
+    /// Return media ids whose heartbeat lags the given checkpoint and
+    /// have a non-null `external_id`.
+    ///
+    /// Issue #628: callers (the reset-cycle orphan sweep) pass the
+    /// returned ids to `delete_permanently_from_sync` so the removal
+    /// goes through the recorder + on-disk file cleanup.
+    /// `external_id IS NOT NULL` excludes locally-imported rows the
+    /// server never knew about.
+    pub async fn ids_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<MediaId>, LibraryError> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT id FROM media
+             WHERE last_seen_at < ? AND external_id IS NOT NULL",
+        )
+        .bind(checkpoint)
+        .fetch_all(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(rows.into_iter().map(|(id,)| MediaId::new(id)).collect())
     }
 
     /// Update `last_seen_at` to the given unix timestamp for one media row.
@@ -863,38 +873,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_ids_returns_every_stored_id() {
-        let dir = tempdir().unwrap();
-        let (repo, _db) = test_repo(dir.path()).await;
-        repo.insert(&record_with_taken_at(
-            MediaId::new("id-a".to_string()),
-            "2025/01/photo_a.jpg",
-            Some(1_000),
-        ))
-        .await
-        .unwrap();
-        repo.insert(&record_with_taken_at(
-            MediaId::new("id-b".to_string()),
-            "2025/01/photo_b.jpg",
-            Some(2_000),
-        ))
-        .await
-        .unwrap();
-
-        let ids = repo.all_ids().await.unwrap();
-        assert_eq!(ids.len(), 2);
-        assert!(ids.contains("id-a"));
-        assert!(ids.contains("id-b"));
-    }
-
-    #[tokio::test]
-    async fn all_ids_empty_when_no_rows() {
-        let dir = tempdir().unwrap();
-        let (repo, _db) = test_repo(dir.path()).await;
-        assert!(repo.all_ids().await.unwrap().is_empty());
-    }
-
-    #[tokio::test]
     async fn library_stats_counts() {
         let dir = tempdir().unwrap();
         let (repo, _db) = test_repo(dir.path()).await;
@@ -941,5 +919,38 @@ mod tests {
         // No row exists; the UPDATE matches nothing. Must not error —
         // sync handlers may bump after a row was deleted under them.
         repo.bump_last_seen_at(&id, 12345).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ids_with_stale_heartbeat_finds_only_eligible_rows() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        // Server-sourced row, heartbeat older than checkpoint → orphan.
+        let stale_synced = MediaId::new("a".repeat(64));
+        let mut rec = test_record(stale_synced.clone());
+        rec.external_id = Some("immich-uuid-a".to_string());
+        repo.insert(&rec).await.unwrap();
+        repo.bump_last_seen_at(&stale_synced, 100).await.unwrap();
+
+        // Server-sourced row, heartbeat newer than checkpoint → safe.
+        let fresh_synced = MediaId::new("b".repeat(64));
+        let mut rec = test_record(fresh_synced.clone());
+        rec.external_id = Some("immich-uuid-b".to_string());
+        repo.insert(&rec).await.unwrap();
+        repo.bump_last_seen_at(&fresh_synced, 300).await.unwrap();
+
+        // Local-only row (no external_id), heartbeat doesn't matter →
+        // immune via the external_id IS NOT NULL filter.
+        let local_only = MediaId::new("c".repeat(64));
+        let mut rec = test_record(local_only.clone());
+        rec.external_id = None;
+        repo.insert(&rec).await.unwrap();
+        // Heartbeat at 0 (insert default) is < checkpoint, but filter saves it.
+
+        let orphans = repo.ids_with_stale_heartbeat(200).await.unwrap();
+
+        assert_eq!(orphans.len(), 1, "only the stale synced row is orphaned");
+        assert_eq!(orphans[0].as_str(), stale_synced.as_str());
     }
 }

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -928,14 +928,14 @@ mod tests {
 
         // Server-sourced row, heartbeat older than checkpoint → orphan.
         let stale_synced = MediaId::new("a".repeat(64));
-        let mut rec = test_record(stale_synced.clone());
+        let mut rec = record_with_taken_at(stale_synced.clone(), "stale.jpg", Some(1));
         rec.external_id = Some("immich-uuid-a".to_string());
         repo.insert(&rec).await.unwrap();
         repo.bump_last_seen_at(&stale_synced, 100).await.unwrap();
 
         // Server-sourced row, heartbeat newer than checkpoint → safe.
         let fresh_synced = MediaId::new("b".repeat(64));
-        let mut rec = test_record(fresh_synced.clone());
+        let mut rec = record_with_taken_at(fresh_synced.clone(), "fresh.jpg", Some(2));
         rec.external_id = Some("immich-uuid-b".to_string());
         repo.insert(&rec).await.unwrap();
         repo.bump_last_seen_at(&fresh_synced, 300).await.unwrap();
@@ -943,7 +943,7 @@ mod tests {
         // Local-only row (no external_id), heartbeat doesn't matter →
         // immune via the external_id IS NOT NULL filter.
         let local_only = MediaId::new("c".repeat(64));
-        let mut rec = test_record(local_only.clone());
+        let mut rec = record_with_taken_at(local_only.clone(), "local.jpg", Some(3));
         rec.external_id = None;
         repo.insert(&rec).await.unwrap();
         // Heartbeat at 0 (insert default) is < checkpoint, but filter saves it.

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -494,7 +494,6 @@ impl MediaRepository {
             .map_err(LibraryError::Db)
     }
 
-
     /// Move assets to the trash (soft delete).
     pub async fn trash(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
         if ids.is_empty() {
@@ -596,11 +595,7 @@ impl MediaRepository {
     /// `external_id` are treated as deleted server-side.
     ///
     /// Missing row is a no-op — it was deleted under us, which is fine.
-    pub async fn bump_last_seen_at(
-        &self,
-        id: &MediaId,
-        now: i64,
-    ) -> Result<(), LibraryError> {
+    pub async fn bump_last_seen_at(&self, id: &MediaId, now: i64) -> Result<(), LibraryError> {
         sqlx::query("UPDATE media SET last_seen_at = ? WHERE id = ?")
             .bind(now)
             .bind(id.as_str())

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -574,6 +574,31 @@ impl MediaRepository {
         tx.commit().await.map_err(LibraryError::Db)?;
         Ok(())
     }
+
+    /// Update `last_seen_at` to the given unix timestamp for one media row.
+    ///
+    /// Issue #628: this is the heartbeat that the reset-cycle orphan
+    /// sweep compares against. Sync paths call it whenever the server
+    /// confirms an asset is still alive — pull `AssetV1` after the
+    /// upsert, push completion after stamping `external_id`, and any
+    /// server-confirmed write-through (favorite, restore). Rows whose
+    /// heartbeat lags the cycle's checkpoint and have a non-null
+    /// `external_id` are treated as deleted server-side.
+    ///
+    /// Missing row is a no-op — it was deleted under us, which is fine.
+    pub async fn bump_last_seen_at(
+        &self,
+        id: &MediaId,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE media SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(id.as_str())
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -889,5 +914,32 @@ mod tests {
         .unwrap();
         let stats = repo.library_stats().await.unwrap();
         assert_eq!(stats.photo_count, 2);
+    }
+
+    #[tokio::test]
+    async fn bump_last_seen_at_writes_value() {
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+        let id = MediaId::new("a".repeat(64));
+        repo.insert(&test_record(id.clone())).await.unwrap();
+
+        repo.bump_last_seen_at(&id, 12345).await.unwrap();
+
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM media WHERE id = ?")
+            .bind(id.as_str())
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(row.0, 12345);
+    }
+
+    #[tokio::test]
+    async fn bump_last_seen_at_missing_id_is_noop() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+        let id = MediaId::new("z".repeat(64));
+        // No row exists; the UPDATE matches nothing. Must not error —
+        // sync handlers may bump after a row was deleted under them.
+        repo.bump_last_seen_at(&id, 12345).await.unwrap();
     }
 }

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -293,11 +293,7 @@ impl MediaService {
     /// Sync-only: bump `last_seen_at` for one media row. See issue
     /// #628 — the heartbeat that the reset-cycle orphan sweep
     /// compares against.
-    pub async fn bump_last_seen_at(
-        &self,
-        id: &MediaId,
-        now: i64,
-    ) -> Result<(), LibraryError> {
+    pub async fn bump_last_seen_at(&self, id: &MediaId, now: i64) -> Result<(), LibraryError> {
         self.repo.bump_last_seen_at(id, now).await
     }
 

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -290,12 +290,6 @@ impl MediaService {
         self.repo.library_stats().await
     }
 
-    /// Sync-only: return every media id currently stored. Used by the
-    /// Immich pull engine to seed reset-sync orphan tracking.
-    pub async fn all_ids(&self) -> Result<std::collections::HashSet<String>, LibraryError> {
-        self.repo.all_ids().await
-    }
-
     /// Sync-only: bump `last_seen_at` for one media row. See issue
     /// #628 — the heartbeat that the reset-cycle orphan sweep
     /// compares against.
@@ -305,6 +299,15 @@ impl MediaService {
         now: i64,
     ) -> Result<(), LibraryError> {
         self.repo.bump_last_seen_at(id, now).await
+    }
+
+    /// Sync-only: return media ids whose heartbeat lags `checkpoint`
+    /// and which have a non-null `external_id`. See issue #628.
+    pub async fn ids_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<MediaId>, LibraryError> {
+        self.repo.ids_with_stale_heartbeat(checkpoint).await
     }
 }
 

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -295,6 +295,17 @@ impl MediaService {
     pub async fn all_ids(&self) -> Result<std::collections::HashSet<String>, LibraryError> {
         self.repo.all_ids().await
     }
+
+    /// Sync-only: bump `last_seen_at` for one media row. See issue
+    /// #628 — the heartbeat that the reset-cycle orphan sweep
+    /// compares against.
+    pub async fn bump_last_seen_at(
+        &self,
+        id: &MediaId,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        self.repo.bump_last_seen_at(id, now).await
+    }
 }
 
 #[cfg(test)]

--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -50,6 +50,11 @@ impl SyncEntityHandler for AlbumHandler {
             )
             .await?;
 
+        // Issue #628: bump heartbeat so reset-cycle orphan sweeps see
+        // this album as "still alive on the server".
+        let now = chrono::Utc::now().timestamp();
+        ctx.library.albums().bump_last_seen_at(&local_id, now).await?;
+
         Ok(HandlerResult {
             entity_id: external_id,
             audit_action: "upsert",

--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -53,7 +53,10 @@ impl SyncEntityHandler for AlbumHandler {
         // Issue #628: bump heartbeat so reset-cycle orphan sweeps see
         // this album as "still alive on the server".
         let now = chrono::Utc::now().timestamp();
-        ctx.library.albums().bump_last_seen_at(&local_id, now).await?;
+        ctx.library
+            .albums()
+            .bump_last_seen_at(&local_id, now)
+            .await?;
 
         Ok(HandlerResult {
             audit_action: "upsert",
@@ -92,7 +95,7 @@ impl SyncEntityHandler for AlbumDeleteHandler {
                     "AlbumDeleteV1: no local row for this external_id; nothing to delete"
                 );
                 return Ok(HandlerResult {
-                            audit_action: "delete",
+                    audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
             }

--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -56,7 +56,6 @@ impl SyncEntityHandler for AlbumHandler {
         ctx.library.albums().bump_last_seen_at(&local_id, now).await?;
 
         Ok(HandlerResult {
-            entity_id: external_id,
             audit_action: "upsert",
             counter: CounterKind::Albums,
         })
@@ -93,8 +92,7 @@ impl SyncEntityHandler for AlbumDeleteHandler {
                     "AlbumDeleteV1: no local row for this external_id; nothing to delete"
                 );
                 return Ok(HandlerResult {
-                    entity_id: external_id,
-                    audit_action: "delete",
+                            audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
             }
@@ -102,7 +100,6 @@ impl SyncEntityHandler for AlbumDeleteHandler {
 
         ctx.library.albums().delete_album(&local_id).await?;
         Ok(HandlerResult {
-            entity_id: external_id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/album_asset.rs
+++ b/src/sync/providers/immich/handlers/album_asset.rs
@@ -21,7 +21,6 @@ impl SyncEntityHandler for AlbumAssetHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let assoc: SyncAlbumToAssetV1 = deserialize_entity(data, "AlbumToAssetV1", line_number)?;
-        let id = format!("{}:{}", assoc.album_id, assoc.asset_id);
 
         // Issue #626: `assoc.asset_id` is the Immich UUID; `album_media.media_id`
         // references the local `MediaId`. Translate via `external_id` lookup.
@@ -42,7 +41,6 @@ impl SyncEntityHandler for AlbumAssetHandler {
                     "AlbumToAssetV1: parent asset not found locally; skipping membership row"
                 );
                 return Ok(HandlerResult {
-                    entity_id: id,
                     audit_action: "upsert",
                     counter: CounterKind::Albums,
                 });
@@ -69,7 +67,6 @@ impl SyncEntityHandler for AlbumAssetHandler {
                     "AlbumToAssetV1: parent album not found locally; skipping membership row"
                 );
                 return Ok(HandlerResult {
-                    entity_id: id,
                     audit_action: "upsert",
                     counter: CounterKind::Albums,
                 });
@@ -83,7 +80,6 @@ impl SyncEntityHandler for AlbumAssetHandler {
             .await?;
 
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "upsert",
             counter: CounterKind::Albums,
         })
@@ -106,7 +102,6 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
     ) -> Result<HandlerResult, LibraryError> {
         let assoc: SyncAlbumToAssetDeleteV1 =
             deserialize_entity(data, "AlbumToAssetDeleteV1", line_number)?;
-        let id = format!("{}:{}", assoc.album_id, assoc.asset_id);
 
         // Issue #626: `assoc.asset_id` is the Immich UUID; the
         // album_media row references the local `MediaId`. Translate
@@ -130,7 +125,6 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
                     "AlbumToAssetDeleteV1: parent asset not found locally; nothing to delete"
                 );
                 return Ok(HandlerResult {
-                    entity_id: id,
                     audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
@@ -154,7 +148,6 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
                     "AlbumToAssetDeleteV1: parent album not found locally; nothing to delete"
                 );
                 return Ok(HandlerResult {
-                    entity_id: id,
                     audit_action: "delete",
                     counter: CounterKind::Deletes,
                 });
@@ -167,7 +160,6 @@ impl SyncEntityHandler for AlbumAssetDeleteHandler {
             .await?;
 
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -119,7 +119,10 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
     // INSERT OR REPLACE resets last_seen_at to its DEFAULT (0); this
     // restores it to the cycle's wall time.
     let now = chrono::Utc::now().timestamp();
-    ctx.library.media().bump_last_seen_at(&media_id, now).await?;
+    ctx.library
+        .media()
+        .bump_last_seen_at(&media_id, now)
+        .await?;
 
     if let Err(e) = download_thumbnail(
         &ctx.client,

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -116,6 +116,13 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
     let server_id = record.external_id.clone().expect("external_id set above");
     ctx.library.media().upsert_media(&record).await?;
 
+    // Issue #628: bump heartbeat after the upsert so reset-cycle
+    // orphan sweeps see this asset as "still alive on the server".
+    // INSERT OR REPLACE resets last_seen_at to its DEFAULT (0); this
+    // restores it to the cycle's wall time.
+    let now = chrono::Utc::now().timestamp();
+    ctx.library.media().bump_last_seen_at(&media_id, now).await?;
+
     if let Err(e) = download_thumbnail(
         &ctx.client,
         &ctx.library,

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -23,10 +23,8 @@ impl SyncEntityHandler for AssetHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let asset: SyncAssetV1 = deserialize_entity(data, "AssetV1", line_number)?;
-        let id = asset.id.clone();
         handle_asset(asset, ctx).await?;
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "upsert",
             counter: CounterKind::Assets,
         })
@@ -168,7 +166,6 @@ impl SyncEntityHandler for AssetDeleteHandler {
             }
         }
         Ok(HandlerResult {
-            entity_id: external_id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/asset_exif.rs
+++ b/src/sync/providers/immich/handlers/asset_exif.rs
@@ -22,7 +22,6 @@ impl SyncEntityHandler for AssetExifHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let exif: SyncAssetExifV1 = deserialize_entity(data, "AssetExifV1", line_number)?;
-        let id = exif.asset_id.clone();
 
         // Issue #626: `exif.asset_id` is the Immich UUID; `media_metadata.media_id`
         // references the local `MediaId`. Translate via `external_id` lookup;
@@ -40,7 +39,6 @@ impl SyncEntityHandler for AssetExifHandler {
                     "AssetExifV1: parent asset not found locally; skipping metadata row"
                 );
                 return Ok(HandlerResult {
-                    entity_id: id,
                     audit_action: "upsert",
                     counter: CounterKind::Exifs,
                 });
@@ -65,7 +63,6 @@ impl SyncEntityHandler for AssetExifHandler {
         ctx.library.metadata().upsert_metadata(&record).await?;
 
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "upsert",
             counter: CounterKind::Exifs,
         })

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -41,7 +41,7 @@ impl SyncEntityHandler for AssetFaceHandler {
                     "AssetFaceV1: parent asset not found locally; skipping face row"
                 );
                 return Ok(HandlerResult {
-                            audit_action: "upsert",
+                    audit_action: "upsert",
                     counter: CounterKind::Faces,
                 });
             }

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -66,6 +66,14 @@ impl SyncEntityHandler for AssetFaceHandler {
 
         ctx.library.faces().upsert_asset_face(&row).await?;
 
+        // Issue #628: bump heartbeat so reset-cycle orphan sweeps see
+        // this face as "still alive on the server".
+        let now = chrono::Utc::now().timestamp();
+        ctx.library
+            .faces()
+            .bump_asset_face_last_seen_at(&row.id, now)
+            .await?;
+
         if let Some(ref person_id) = face.person_id {
             ctx.library.faces().update_face_count(person_id).await?;
         }

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -23,7 +23,6 @@ impl SyncEntityHandler for AssetFaceHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let face: SyncAssetFaceV1 = deserialize_entity(data, "AssetFaceV1", line_number)?;
-        let id = face.id.clone();
 
         // Issue #626: `face.asset_id` is the Immich UUID; `asset_faces.asset_id`
         // references the local `MediaId`. Translate via `external_id` lookup;
@@ -42,8 +41,7 @@ impl SyncEntityHandler for AssetFaceHandler {
                     "AssetFaceV1: parent asset not found locally; skipping face row"
                 );
                 return Ok(HandlerResult {
-                    entity_id: id,
-                    audit_action: "upsert",
+                            audit_action: "upsert",
                     counter: CounterKind::Faces,
                 });
             }
@@ -79,7 +77,6 @@ impl SyncEntityHandler for AssetFaceHandler {
         }
 
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "upsert",
             counter: CounterKind::Faces,
         })
@@ -105,7 +102,6 @@ impl SyncEntityHandler for AssetFaceDeleteHandler {
         let id = delete.asset_face_id.clone();
         ctx.library.faces().delete_asset_face(&id).await?;
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/mod.rs
+++ b/src/sync/providers/immich/handlers/mod.rs
@@ -52,8 +52,6 @@ pub enum CounterKind {
 
 /// Result of a successful handler invocation.
 pub struct HandlerResult {
-    /// Entity ID for audit logging.
-    pub entity_id: String,
     /// Audit action label (e.g. "upsert", "delete").
     pub audit_action: &'static str,
     /// Which counter to increment.

--- a/src/sync/providers/immich/handlers/person.rs
+++ b/src/sync/providers/immich/handlers/person.rs
@@ -38,6 +38,14 @@ impl SyncEntityHandler for PersonHandler {
             )
             .await?;
 
+        // Issue #628: bump heartbeat so reset-cycle orphan sweeps see
+        // this person as "still alive on the server".
+        let now = chrono::Utc::now().timestamp();
+        ctx.library
+            .faces()
+            .bump_person_last_seen_at(&person.id, now)
+            .await?;
+
         // Download person face thumbnail.
         let person_thumb_dir = ctx.thumbnails_dir.join("people");
         let thumb_path = person_thumb_dir.join(format!("{}.jpg", person.id));

--- a/src/sync/providers/immich/handlers/person.rs
+++ b/src/sync/providers/immich/handlers/person.rs
@@ -22,7 +22,6 @@ impl SyncEntityHandler for PersonHandler {
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         let person: SyncPersonV1 = deserialize_entity(data, "PersonV1", line_number)?;
-        let id = person.id.clone();
 
         ctx.library
             .faces()
@@ -66,7 +65,6 @@ impl SyncEntityHandler for PersonHandler {
         }
 
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "upsert",
             counter: CounterKind::People,
         })
@@ -91,7 +89,6 @@ impl SyncEntityHandler for PersonDeleteHandler {
         let id = delete.person_id.clone();
         ctx.library.faces().delete_person_by_id(&id).await?;
         Ok(HandlerResult {
-            entity_id: id,
             audit_action: "delete",
             counter: CounterKind::Deletes,
         })

--- a/src/sync/providers/immich/handlers/sync_lifecycle.rs
+++ b/src/sync/providers/immich/handlers/sync_lifecycle.rs
@@ -39,8 +39,13 @@ impl SyncEntityHandler for SyncResetHandler {
     }
 }
 
-/// Marks the end of the sync stream. The PullManager breaks the loop
-/// when it sees this entity type. The handler itself is a no-op.
+/// Marks the end of the sync stream.
+///
+/// The handler itself is a no-op — its job is to produce a
+/// `complete` audit row so `current_reset_checkpoint()` can see the
+/// reset cycle was closed cleanly. The pull loop exits when the
+/// server closes the stream after `SyncCompleteV1`; there's no
+/// explicit `break` in `pull.rs`.
 pub struct SyncCompleteHandler;
 
 #[async_trait]

--- a/src/sync/providers/immich/handlers/sync_lifecycle.rs
+++ b/src/sync/providers/immich/handlers/sync_lifecycle.rs
@@ -27,7 +27,6 @@ impl SyncEntityHandler for SyncResetHandler {
         ctx.library.faces().clear_people().await?;
         ctx.state.clear_checkpoints().await?;
         Ok(HandlerResult {
-            entity_id: String::new(),
             audit_action: "reset",
             counter: CounterKind::None,
         })
@@ -51,7 +50,6 @@ impl SyncEntityHandler for SyncCompleteHandler {
         _ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
         Ok(HandlerResult {
-            entity_id: String::new(),
             audit_action: "complete",
             counter: CounterKind::None,
         })

--- a/src/sync/providers/immich/handlers/sync_lifecycle.rs
+++ b/src/sync/providers/immich/handlers/sync_lifecycle.rs
@@ -4,11 +4,19 @@ use crate::library::error::LibraryError;
 
 use super::{CounterKind, HandlerResult, SyncContext, SyncEntityHandler};
 
-/// Signals a full resync — clears faces/people and loads existing IDs.
+/// Signals a full resync — clears stream-resume state.
 ///
-/// The caller (PullManager) checks `entity_type == "SyncResetV1"` to set
-/// its reset-tracking state *before* delegating here. This handler
-/// performs the database cleanup.
+/// The caller (PullManager) inspects `entity_type == "SyncResetV1"`
+/// to set its in-memory reset checkpoint before delegating here. This
+/// handler clears the per-entity-type ack checkpoints so the next
+/// pull starts at the head of each stream.
+///
+/// Issue #628: previously this also wiped `asset_faces` and `people`
+/// to be rebuilt by the stream. The heartbeat reconciliation makes
+/// that destructive clear unnecessary — those tables now reconcile
+/// the same way as `media` and `albums` (rows whose `last_seen_at`
+/// lags the cycle's checkpoint are deleted at `SyncCompleteV1`),
+/// preserving cached data through the reset window.
 pub struct SyncResetHandler;
 
 #[async_trait]
@@ -23,8 +31,6 @@ impl SyncEntityHandler for SyncResetHandler {
         _line_number: usize,
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
-        ctx.library.faces().clear_asset_faces().await?;
-        ctx.library.faces().clear_people().await?;
         ctx.state.clear_checkpoints().await?;
         Ok(HandlerResult {
             audit_action: "reset",

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -271,22 +271,14 @@ impl PullManager {
                 if counters.assets % 500 == 0 && counters.assets > 0 {
                     info!(assets = counters.assets, "sync progress");
                 }
-            } else if entity_type == "SyncCompleteV1" {
-                // Not dispatched through handlers — breaks the loop.
-                info!(
-                    assets = counters.assets,
-                    exifs = counters.exifs,
-                    deletes = counters.deletes,
-                    albums = counters.albums,
-                    people = counters.people,
-                    faces = counters.faces,
-                    errors = counters.errors,
-                    lines = line_number,
-                    "sync stream complete"
-                );
-                acks.push(sync_line.ack);
-                break;
             } else {
+                // Includes `SyncCompleteV1` only if the handler list
+                // didn't pick it up — `SyncCompleteHandler` is
+                // registered in `all_handlers()` so the normal
+                // dispatch path handles it. The stream then ends
+                // naturally when the server closes the connection;
+                // `lines.next_line()` returns `None` and we exit the
+                // loop. This branch covers genuinely-unknown types.
                 debug!(
                     entity_type,
                     line_number, "ignoring unknown sync entity type"
@@ -358,9 +350,9 @@ impl PullManager {
                 .faces()
                 .delete_people_with_stale_heartbeat(checkpoint)
                 .await?;
-            if people_removed > 0 {
+            if !people_removed.is_empty() {
                 info!(
-                    count = people_removed,
+                    count = people_removed.len(),
                     "removing orphaned people after reset sync"
                 );
             }

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -3,7 +3,6 @@
 //! Connects to `POST /sync/stream`, processes NDJSON entity records,
 //! and flushes acks incrementally. See `docs/design-immich-backend.md`.
 
-use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -12,7 +11,6 @@ use tokio::io::AsyncBufReadExt;
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::library::error::LibraryError;
-use crate::library::media::MediaId;
 use crate::library::Library;
 use crate::sync::event::SyncEvent;
 use crate::sync::state::SyncStateRepository;
@@ -166,10 +164,25 @@ impl PullManager {
         let mut acks: Vec<String> = Vec::new();
         let mut counters = SyncCounters::default();
         let mut notified_processing = false;
-        let mut is_reset = false;
-        let mut existing_ids: Option<HashSet<String>> = None;
         let mut line_number: usize = 0;
         let sync_cycle = chrono::Utc::now().to_rfc3339();
+
+        // Issue #628: heartbeat-based reset reconciliation. The
+        // checkpoint is `Some(unix_seconds)` while a reset cycle is
+        // open; rows whose `last_seen_at` lags it (and have a non-null
+        // external_id, for media/albums) are deleted at end-of-stream.
+        //
+        // Seed from the audit log so a stream that resumes mid-reset
+        // — server picked up from last ack rather than re-sending
+        // SyncResetV1 — still finishes the reconciliation correctly.
+        let mut reset_checkpoint_at: Option<i64> =
+            self.state.current_reset_checkpoint().await?;
+        if reset_checkpoint_at.is_some() {
+            info!(
+                checkpoint = ?reset_checkpoint_at,
+                "resuming reset reconciliation from prior cycle"
+            );
+        }
 
         let entity_handlers = handlers::all_handlers();
         let ctx = SyncContext {
@@ -203,17 +216,14 @@ impl PullManager {
             let entity_type = sync_line.entity_type.as_str();
 
             // ── Reset tracking ──────────────────────────────────────
-            // SyncResetV1 sets the reset flag and loads existing IDs.
-            // AssetV1/AssetDeleteV1 remove IDs from the tracking set.
+            // Issue #628: SyncResetV1 enters heartbeat-reconcile mode.
+            // The checkpoint is wall time at receipt — assets the
+            // stream re-emits will bump their `last_seen_at` past it,
+            // and anything left below the line at SyncCompleteV1 is
+            // an orphan. No HashSet snapshot needed.
             if entity_type == "SyncResetV1" {
                 warn!("server requested sync reset — performing full resync");
-                is_reset = true;
-                let ids = self.library.media().all_ids().await?;
-                info!(
-                    existing_count = ids.len(),
-                    "loaded existing media IDs for reset tracking"
-                );
-                existing_ids = Some(ids);
+                reset_checkpoint_at = Some(chrono::Utc::now().timestamp());
             }
 
             // ── Dispatch to handler ─────────────────────────────────
@@ -246,12 +256,9 @@ impl PullManager {
                             notified_processing = true;
                         }
 
-                        // Track asset IDs for reset orphan detection.
-                        if let Some(ref mut ids) = existing_ids {
-                            if !result.entity_id.is_empty() {
-                                ids.remove(&result.entity_id);
-                            }
-                        }
+                        // Issue #628: orphan tracking is handled by
+                        // per-row `last_seen_at` heartbeats in the
+                        // handlers themselves. Nothing per-line here.
                     }
                     Err(e) => {
                         warn!(entity_type, error = %e, "skipping sync entity");
@@ -298,7 +305,7 @@ impl PullManager {
             }
         }
 
-        self.finish_sync(is_reset, existing_ids, &mut acks, &counters)
+        self.finish_sync(reset_checkpoint_at, &mut acks, &counters)
             .await
     }
 
@@ -306,21 +313,63 @@ impl PullManager {
 
     async fn finish_sync(
         &self,
-        is_reset: bool,
-        existing_ids: Option<HashSet<String>>,
+        reset_checkpoint_at: Option<i64>,
         acks: &mut Vec<String>,
         counters: &SyncCounters,
     ) -> Result<(usize, usize), LibraryError> {
-        if is_reset {
-            if let Some(orphaned_ids) = existing_ids {
-                if !orphaned_ids.is_empty() {
-                    info!(
-                        count = orphaned_ids.len(),
-                        "removing orphaned assets after reset sync"
-                    );
-                    let ids: Vec<MediaId> = orphaned_ids.into_iter().map(MediaId::new).collect();
-                    self.library.delete_permanently_from_sync(&ids).await?;
-                }
+        // Issue #628: if a reset cycle was open, the stream just
+        // closed it. Sweep rows whose heartbeat didn't catch up to
+        // the cycle's checkpoint — these are entities the server has
+        // dropped since the checkpoint was taken.
+        //
+        // Media and albums gate on `external_id IS NOT NULL` so
+        // locally-imported / not-yet-pushed rows are immune. People
+        // and asset_faces have no local-only counterpart and sweep
+        // unconditionally below the checkpoint.
+        if let Some(checkpoint) = reset_checkpoint_at {
+            let media_orphans = self
+                .library
+                .media()
+                .ids_with_stale_heartbeat(checkpoint)
+                .await?;
+            if !media_orphans.is_empty() {
+                info!(
+                    count = media_orphans.len(),
+                    "removing orphaned assets after reset sync"
+                );
+                self.library
+                    .delete_permanently_from_sync(&media_orphans)
+                    .await?;
+            }
+
+            let album_orphans = self
+                .library
+                .albums()
+                .delete_with_stale_heartbeat(checkpoint)
+                .await?;
+            if !album_orphans.is_empty() {
+                info!(
+                    count = album_orphans.len(),
+                    "removing orphaned albums after reset sync"
+                );
+            }
+
+            let people_removed = self
+                .library
+                .faces()
+                .delete_people_with_stale_heartbeat(checkpoint)
+                .await?;
+            if people_removed > 0 {
+                info!(count = people_removed, "removing orphaned people after reset sync");
+            }
+
+            let faces_removed = self
+                .library
+                .faces()
+                .delete_asset_faces_with_stale_heartbeat(checkpoint)
+                .await?;
+            if faces_removed > 0 {
+                info!(count = faces_removed, "removing orphaned asset_faces after reset sync");
             }
         }
 

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -175,8 +175,7 @@ impl PullManager {
         // Seed from the audit log so a stream that resumes mid-reset
         // — server picked up from last ack rather than re-sending
         // SyncResetV1 — still finishes the reconciliation correctly.
-        let mut reset_checkpoint_at: Option<i64> =
-            self.state.current_reset_checkpoint().await?;
+        let mut reset_checkpoint_at: Option<i64> = self.state.current_reset_checkpoint().await?;
         if reset_checkpoint_at.is_some() {
             info!(
                 checkpoint = ?reset_checkpoint_at,
@@ -360,7 +359,10 @@ impl PullManager {
                 .delete_people_with_stale_heartbeat(checkpoint)
                 .await?;
             if people_removed > 0 {
-                info!(count = people_removed, "removing orphaned people after reset sync");
+                info!(
+                    count = people_removed,
+                    "removing orphaned people after reset sync"
+                );
             }
 
             let faces_removed = self
@@ -369,7 +371,10 @@ impl PullManager {
                 .delete_asset_faces_with_stale_heartbeat(checkpoint)
                 .await?;
             if faces_removed > 0 {
-                info!(count = faces_removed, "removing orphaned asset_faces after reset sync");
+                info!(
+                    count = faces_removed,
+                    "removing orphaned asset_faces after reset sync"
+                );
             }
         }
 

--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -219,14 +219,16 @@ impl PushManager {
                             "isFavorite": favorite,
                         }),
                     )
-                    .await
+                    .await?;
+                self.bump_media_heartbeat(id.as_str()).await
             }
 
             OutboxMutation::AssetTrashed { id } => {
                 let external_id = self.lookup_media_external_id(id.as_str()).await?;
                 self.client
                     .delete_with_body("/assets", &serde_json::json!({ "ids": [external_id] }))
-                    .await
+                    .await?;
+                self.bump_media_heartbeat(id.as_str()).await
             }
 
             OutboxMutation::AssetRestored { id } => {
@@ -236,7 +238,8 @@ impl PushManager {
                         "/trash/restore/assets",
                         &serde_json::json!({ "ids": [external_id] }),
                     )
-                    .await
+                    .await?;
+                self.bump_media_heartbeat(id.as_str()).await
             }
 
             OutboxMutation::AssetDeleted { id, external_id } => {
@@ -274,7 +277,8 @@ impl PushManager {
                         &format!("/albums/{external_id}"),
                         &serde_json::json!({ "albumName": name }),
                     )
-                    .await
+                    .await?;
+                self.bump_album_heartbeat(id.as_str()).await
             }
 
             OutboxMutation::AlbumDeleted { id, external_id } => {
@@ -298,7 +302,8 @@ impl PushManager {
                         &format!("/albums/{external_id}/assets"),
                         &serde_json::json!({ "ids": external_media_ids }),
                     )
-                    .await
+                    .await?;
+                self.bump_album_heartbeat(album_id.as_str()).await
             }
 
             OutboxMutation::AlbumMediaRemoved {
@@ -312,7 +317,8 @@ impl PushManager {
                         &format!("/albums/{external_id}/assets"),
                         &serde_json::json!({ "ids": external_media_ids }),
                     )
-                    .await
+                    .await?;
+                self.bump_album_heartbeat(album_id.as_str()).await
             }
 
             // ── People mutations ────────────────────────────────────
@@ -323,7 +329,8 @@ impl PushManager {
                         &format!("/people/{external_id}"),
                         &serde_json::json!({ "name": name }),
                     )
-                    .await
+                    .await?;
+                self.bump_person_heartbeat(id.as_str()).await
             }
 
             OutboxMutation::PersonHidden { id, hidden } => {
@@ -333,7 +340,8 @@ impl PushManager {
                         &format!("/people/{external_id}"),
                         &serde_json::json!({ "isHidden": hidden }),
                     )
-                    .await
+                    .await?;
+                self.bump_person_heartbeat(id.as_str()).await
             }
         }
     }
@@ -605,8 +613,13 @@ impl PushManager {
         local_id: &str,
         external_id: &str,
     ) -> Result<(), LibraryError> {
-        sqlx::query("UPDATE media SET external_id = ? WHERE id = ?")
+        // Issue #628: stamping `external_id` after upload is also a
+        // server-confirmed mutation — bump the heartbeat so a future
+        // reset cycle's orphan sweep treats the row as alive.
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE media SET external_id = ?, last_seen_at = ? WHERE id = ?")
             .bind(external_id)
+            .bind(now)
             .bind(local_id)
             .execute(self.db.pool())
             .await
@@ -619,8 +632,51 @@ impl PushManager {
         local_id: &str,
         external_id: &str,
     ) -> Result<(), LibraryError> {
-        sqlx::query("UPDATE albums SET external_id = ? WHERE id = ?")
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE albums SET external_id = ?, last_seen_at = ? WHERE id = ?")
             .bind(external_id)
+            .bind(now)
+            .bind(local_id)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Issue #628: bump `media.last_seen_at` after a server-confirmed
+    /// non-stamping mutation (favorite, trash, restore). Mirrors
+    /// `MediaRepository::bump_last_seen_at` but via raw SQL, since
+    /// `PushManager` holds a `Database` rather than an `Arc<Library>`.
+    async fn bump_media_heartbeat(&self, local_id: &str) -> Result<(), LibraryError> {
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE media SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(local_id)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Issue #628: bump `albums.last_seen_at` after a server-confirmed
+    /// album mutation (rename, membership change).
+    async fn bump_album_heartbeat(&self, local_id: &str) -> Result<(), LibraryError> {
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE albums SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(local_id)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Issue #628: bump `people.last_seen_at` after a server-confirmed
+    /// person mutation (rename, hide).
+    async fn bump_person_heartbeat(&self, local_id: &str) -> Result<(), LibraryError> {
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE people SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
             .bind(local_id)
             .execute(self.db.pool())
             .await
@@ -1256,17 +1312,25 @@ mod tests {
             .await
             .unwrap();
 
+        let before = chrono::Utc::now().timestamp();
         let push = make_push_manager(db.clone()).await;
         push.set_media_external_id("local-m", "new-ext-id")
             .await
             .unwrap();
 
-        let row: (Option<String>,) =
-            sqlx::query_as("SELECT external_id FROM media WHERE id = 'local-m'")
+        let row: (Option<String>, i64) =
+            sqlx::query_as("SELECT external_id, last_seen_at FROM media WHERE id = 'local-m'")
                 .fetch_one(db.pool())
                 .await
                 .unwrap();
         assert_eq!(row.0.as_deref(), Some("new-ext-id"));
+        // Issue #628: stamping bumps the heartbeat too — the row was
+        // just confirmed-alive by the server.
+        assert!(
+            row.1 >= before,
+            "last_seen_at ({}) should be >= now ({before})",
+            row.1
+        );
     }
 
     #[tokio::test]
@@ -1283,17 +1347,86 @@ mod tests {
             .await
             .unwrap();
 
+        let before = chrono::Utc::now().timestamp();
         let push = make_push_manager(db.clone()).await;
         push.set_album_external_id("alb-local", "alb-ext-id")
             .await
             .unwrap();
 
-        let row: (Option<String>,) =
-            sqlx::query_as("SELECT external_id FROM albums WHERE id = 'alb-local'")
+        let row: (Option<String>, i64) =
+            sqlx::query_as("SELECT external_id, last_seen_at FROM albums WHERE id = 'alb-local'")
                 .fetch_one(db.pool())
                 .await
                 .unwrap();
         assert_eq!(row.0.as_deref(), Some("alb-ext-id"));
+        assert!(row.1 >= before);
+    }
+
+    #[tokio::test]
+    async fn bump_media_heartbeat_writes_last_seen_at() {
+        let (_dir, db) = setup_push_db().await;
+        let record = test_record(MediaId::new("local-m".to_string()));
+        MediaRepository::new(db.clone())
+            .upsert(&record)
+            .await
+            .unwrap();
+
+        let before = chrono::Utc::now().timestamp();
+        let push = make_push_manager(db.clone()).await;
+        push.bump_media_heartbeat("local-m").await.unwrap();
+
+        let row: (i64,) =
+            sqlx::query_as("SELECT last_seen_at FROM media WHERE id = 'local-m'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(row.0 >= before);
+    }
+
+    #[tokio::test]
+    async fn bump_album_heartbeat_writes_last_seen_at() {
+        let (_dir, db) = setup_push_db().await;
+
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("INSERT INTO albums (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)")
+            .bind("alb-1")
+            .bind("Test")
+            .bind(now)
+            .bind(now)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let before = chrono::Utc::now().timestamp();
+        let push = make_push_manager(db.clone()).await;
+        push.bump_album_heartbeat("alb-1").await.unwrap();
+
+        let row: (i64,) =
+            sqlx::query_as("SELECT last_seen_at FROM albums WHERE id = 'alb-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(row.0 >= before);
+    }
+
+    #[tokio::test]
+    async fn bump_person_heartbeat_writes_last_seen_at() {
+        let (_dir, db) = setup_push_db().await;
+        sqlx::query("INSERT INTO people (id, name) VALUES ('p1', 'Alice')")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let before = chrono::Utc::now().timestamp();
+        let push = make_push_manager(db.clone()).await;
+        push.bump_person_heartbeat("p1").await.unwrap();
+
+        let row: (i64,) =
+            sqlx::query_as("SELECT last_seen_at FROM people WHERE id = 'p1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(row.0 >= before);
     }
 
     #[tokio::test]

--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -1375,11 +1375,10 @@ mod tests {
         let push = make_push_manager(db.clone()).await;
         push.bump_media_heartbeat("local-m").await.unwrap();
 
-        let row: (i64,) =
-            sqlx::query_as("SELECT last_seen_at FROM media WHERE id = 'local-m'")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM media WHERE id = 'local-m'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
         assert!(row.0 >= before);
     }
 
@@ -1401,11 +1400,10 @@ mod tests {
         let push = make_push_manager(db.clone()).await;
         push.bump_album_heartbeat("alb-1").await.unwrap();
 
-        let row: (i64,) =
-            sqlx::query_as("SELECT last_seen_at FROM albums WHERE id = 'alb-1'")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM albums WHERE id = 'alb-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
         assert!(row.0 >= before);
     }
 
@@ -1421,11 +1419,10 @@ mod tests {
         let push = make_push_manager(db.clone()).await;
         push.bump_person_heartbeat("p1").await.unwrap();
 
-        let row: (i64,) =
-            sqlx::query_as("SELECT last_seen_at FROM people WHERE id = 'p1'")
-                .fetch_one(db.pool())
-                .await
-                .unwrap();
+        let row: (i64,) = sqlx::query_as("SELECT last_seen_at FROM people WHERE id = 'p1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
         assert!(row.0 >= before);
     }
 

--- a/src/sync/state/repository.rs
+++ b/src/sync/state/repository.rs
@@ -111,6 +111,47 @@ impl SyncStateRepository {
         .map_err(LibraryError::Db)?;
         Ok(())
     }
+
+    /// Determine whether a reset reconciliation is in progress, and
+    /// return its checkpoint timestamp if so.
+    ///
+    /// Issue #628: looks at the most recent successfully-handled
+    /// `SyncResetV1` / `SyncCompleteV1` audit row. If the latest one
+    /// is `SyncResetV1` (action `'reset'`), a reset cycle started
+    /// but hasn't been closed by a `SyncCompleteV1` — return
+    /// `Some(started_at_unix_seconds)` so the dispatch loop can
+    /// resume in reset mode. This covers the case where a previous
+    /// stream disconnected mid-reset and the server resumes from its
+    /// last ack rather than re-issuing `SyncResetV1`.
+    ///
+    /// The filter `action IN ('reset', 'complete')` excludes rows
+    /// whose dispatch crashed before completion (`'started'`) and
+    /// rows whose handler errored (`'error'`). Both should leave the
+    /// state machine in whatever mode the prior settled row implies.
+    pub async fn current_reset_checkpoint(&self) -> Result<Option<i64>, LibraryError> {
+        let row: Option<(String, String)> = sqlx::query_as(
+            "SELECT entity_type, started_at FROM sync_audit
+             WHERE entity_type IN ('SyncResetV1', 'SyncCompleteV1')
+               AND action IN ('reset', 'complete')
+             ORDER BY id DESC
+             LIMIT 1",
+        )
+        .fetch_optional(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+
+        match row {
+            Some((entity_type, started_at)) if entity_type == "SyncResetV1" => {
+                let dt = chrono::DateTime::parse_from_rfc3339(&started_at).map_err(|e| {
+                    LibraryError::Immich(format!(
+                        "current_reset_checkpoint: invalid started_at {started_at:?}: {e}"
+                    ))
+                })?;
+                Ok(Some(dt.timestamp()))
+            }
+            _ => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -229,5 +270,107 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(count.0, 0);
+    }
+
+    #[tokio::test]
+    async fn current_reset_checkpoint_none_when_no_audit_rows() {
+        let (_dir, db) = open_db().await;
+        let repo = SyncStateRepository::new(db.clone());
+        assert_eq!(repo.current_reset_checkpoint().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn current_reset_checkpoint_some_when_latest_is_reset() {
+        let (_dir, db) = open_db().await;
+        let repo = SyncStateRepository::new(db.clone());
+
+        let row_id = repo
+            .start_audit("SyncResetV1", "", "cycle-1")
+            .await
+            .unwrap();
+        repo.complete_audit(row_id, "reset").await.unwrap();
+
+        let result = repo.current_reset_checkpoint().await.unwrap();
+        assert!(result.is_some(), "expected checkpoint after SyncResetV1");
+    }
+
+    #[tokio::test]
+    async fn current_reset_checkpoint_none_when_latest_is_complete() {
+        let (_dir, db) = open_db().await;
+        let repo = SyncStateRepository::new(db.clone());
+
+        let reset_id = repo
+            .start_audit("SyncResetV1", "", "cycle-1")
+            .await
+            .unwrap();
+        repo.complete_audit(reset_id, "reset").await.unwrap();
+        let complete_id = repo
+            .start_audit("SyncCompleteV1", "", "cycle-1")
+            .await
+            .unwrap();
+        repo.complete_audit(complete_id, "complete").await.unwrap();
+
+        // Reset was closed by SyncCompleteV1; no longer in reset mode.
+        assert_eq!(repo.current_reset_checkpoint().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn current_reset_checkpoint_excludes_started_but_uncompleted() {
+        let (_dir, db) = open_db().await;
+        let repo = SyncStateRepository::new(db.clone());
+
+        // start_audit was called but neither complete_audit nor
+        // fail_audit followed — handler was still running when we
+        // crashed. action stays 'started', completed_at is NULL.
+        let _row_id = repo
+            .start_audit("SyncResetV1", "", "cycle-1")
+            .await
+            .unwrap();
+
+        // We can't trust that this cycle made any progress; treat as
+        // not-in-reset-mode. A future SyncResetV1 will start fresh.
+        assert_eq!(repo.current_reset_checkpoint().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn current_reset_checkpoint_excludes_errored_resets() {
+        let (_dir, db) = open_db().await;
+        let repo = SyncStateRepository::new(db.clone());
+
+        let row_id = repo
+            .start_audit("SyncResetV1", "", "cycle-1")
+            .await
+            .unwrap();
+        repo.fail_audit(row_id, "boom").await.unwrap();
+
+        // An errored reset shouldn't pin us in reset mode.
+        assert_eq!(repo.current_reset_checkpoint().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn current_reset_checkpoint_ignores_other_entity_types() {
+        let (_dir, db) = open_db().await;
+        let repo = SyncStateRepository::new(db.clone());
+
+        // Most recent reset/complete is the reset; AssetV1 rows after
+        // it (the dispatch in the resumed stream) shouldn't shift us
+        // out of reset mode.
+        let reset_id = repo
+            .start_audit("SyncResetV1", "", "cycle-1")
+            .await
+            .unwrap();
+        repo.complete_audit(reset_id, "reset").await.unwrap();
+        for _ in 0..3 {
+            let aid = repo
+                .start_audit("AssetV1", "", "cycle-1")
+                .await
+                .unwrap();
+            repo.complete_audit(aid, "upsert").await.unwrap();
+        }
+
+        assert!(
+            repo.current_reset_checkpoint().await.unwrap().is_some(),
+            "AssetV1 audit rows must not close the reset cycle"
+        );
     }
 }

--- a/src/sync/state/repository.rs
+++ b/src/sync/state/repository.rs
@@ -361,10 +361,7 @@ mod tests {
             .unwrap();
         repo.complete_audit(reset_id, "reset").await.unwrap();
         for _ in 0..3 {
-            let aid = repo
-                .start_audit("AssetV1", "", "cycle-1")
-                .await
-                .unwrap();
+            let aid = repo.start_audit("AssetV1", "", "cycle-1").await.unwrap();
             repo.complete_audit(aid, "upsert").await.unwrap();
         }
 


### PR DESCRIPTION
## Summary

Replaces the in-memory HashSet snapshot with a per-row `last_seen_at` heartbeat. The reset cycle now reconciles four tables (`media`, `albums`, `people`, `asset_faces`) durably and crash-safely, fixing the original #628 data-loss bug and two latent bugs the in-flight HashSet design didn't catch.

## The bug

`SyncResetV1` reconciliation loaded `media.id`s into a `HashSet<String>`, removed each as the stream re-emitted it, and deleted what was left at end-of-stream. Three problems with that:

1. **Namespace mismatch (the original #628 data-loss path).** The set was loaded from `media.id` (locally-minted UUIDs) but removed by `result.entity_id` (the Immich UUID). Pre-#626 the two namespaces happened to coincide; #626 separated them and the orphan set never shrank — every reset cycle wiped the library and on-disk originals.
2. **Locally-imported rows were misclassified.** `all_ids()` returned every `media.id` including rows with `external_id IS NULL` (local imports / not-yet-pushed). The server doesn't know about them and never re-emits them, so they ended up in the orphan set even when correctly tracked.
3. **Albums and `asset_faces` had no orphan tracking at all.** Faces and people were destructively wiped at reset start (`clear_asset_faces` / `clear_people`); albums leaked entirely across resets.

## The design

Per-row `last_seen_at` (unix seconds) on each reconciled table. Bumped on every server-confirmed touch:

- **Pull side** — `AssetV1`, `AlbumV1`, `PersonV1`, `AssetFaceV1` handlers each `UPDATE … SET last_seen_at = now() WHERE id = ?` after their existing upsert.
- **Push side** — folded into the `set_*_external_id` stamping helpers; standalone `bump_*_heartbeat` calls after server-confirmed favorite, trash, restore, rename, hide, and album membership mutations.

Reset state derives from the audit log:

- On stream startup, `SyncStateRepository::current_reset_checkpoint()` looks at the most recent settled (`action IN ('reset', 'complete')`) `SyncResetV1` / `SyncCompleteV1` row. If the latest is `SyncResetV1`, we're in (or resuming) a reset cycle — its `started_at` is the durable checkpoint.
- `SyncResetV1` arriving on the wire refreshes the in-memory checkpoint to wall time.
- `SyncCompleteV1` runs the four-table sweep:
  - `media WHERE last_seen_at < checkpoint AND external_id IS NOT NULL` — via `delete_permanently_from_sync` so file cleanup + recorder fire correctly
  - `albums WHERE last_seen_at < checkpoint AND external_id IS NOT NULL` — cascades to `album_media` in one transaction
  - `people WHERE last_seen_at < checkpoint` — orphan faces have `person_id` nulled via `ON DELETE SET NULL`
  - `asset_faces WHERE last_seen_at < checkpoint`
- The `external_id IS NOT NULL` gate keeps locally-imported / not-yet-pushed rows immune from server-driven deletion.

Crash semantics: if the stream interrupts mid-reset and Immich resumes from the last ack rather than re-issuing `SyncResetV1`, the audit-log query finds the open `SyncResetV1` from the prior cycle and re-populates the in-memory checkpoint. Heartbeats persist across crashes, so a future clean `SyncCompleteV1` finishes the reconciliation correctly.

## Commits

| | |
|---|---|
| `27b203b` | feat(db): `last_seen_at` migration on four tables |
| `f06ddf4` | feat(sync): pull-side heartbeat bumps |
| `3e24d9f` | feat(sync): audit-derived reset state + four-table sweep |
| `b0c3942` | fix(sync): test fixture path uniqueness; drop dead `HandlerResult.entity_id` |
| `0054e9e` | feat(sync): push-side heartbeat bumps |
| `e54e037` | refactor(sync): `SyncResetV1` only clears checkpoints (no destructive wipes) |
| `66dfd4e` | docs(immich): replace HashSet section with heartbeat description |
| `d7e5b93` | style: cargo fmt |

## Test plan

- [x] `make lint` — fmt + clippy clean
- [x] `make test` — 516 passed / 0 failed; covers all new repository, service, push, and audit-log methods
- [ ] `make test-integration`
- [ ] Manual: against a real Immich backend, trigger a `SyncResetV1` (server-side reset or >30-day-stale checkpoint) and confirm the local library survives, faces/people aren't wiped, and locally-imported rows aren't deleted.
- [ ] Manual: import a local photo, leave `external_id` NULL, run a sync cycle that includes a `SyncResetV1`, confirm the local row remains.
- [ ] Manual: kill the app mid-reset stream, restart, confirm the reset reconciliation resumes and completes correctly.

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)