### PR TITLE
feat(sync): Immich stacks model + grid filter + sync wiring (#224 Phase A)

### DIFF
--- a/docs/design-immich-edit-sync.md
+++ b/docs/design-immich-edit-sync.md
@@ -489,6 +489,8 @@ Edge case: corrupt or missing XMP. Surface "edit history not recoverable; revert
 
 ## 8. Grid filtering
 
+### 8.1 Generic primary-only filter (Phase A)
+
 The grid query (across All, Favorites, Recent Imports, Album views, Person views) must filter to primary-only when stacks are present:
 
 ```sql
@@ -508,6 +510,40 @@ Touch points:
 - Any direct SQL in clients (audit grep).
 
 The Recent Imports view counts edits as imports — when the user saves a pixel-adjustment edit, the rendered asset has a fresh `imported_at` and would appear in Recent Imports. That's correct behaviour.
+
+### 8.2 Phase C UX override: surface the original for Moments-edit stacks
+
+The Phase A primary-only rule is correct for Immich-native stacks (panoramas, bursts). It is **wrong** for Moments-edit stacks, where Phase C uploads a rendered JPEG as a new asset and stacks it with the original. On the server side the rendered child becomes the stack primary (Immich convention); on the user side that's the wrong artifact to surface — the rendered JPEG carries no editable state, while the original *plus* the local `edits` row is what the user thinks of as "their photo with an edit applied".
+
+The local `edits` table remains the source of truth for what edit was applied. The server-side render is a sync artifact, not a first-class user-visible asset.
+
+**Resolution (to land in Phase C):**
+
+The grid filter swaps "primary" for "non-Moments-render member" when a Moments-edit-tagged member is present in the stack. Concretely, on top of the §8.1 clause:
+
+1. Sync the `tags[]` field from `AssetV1` (Phase C work — Phase A doesn't touch tags).
+2. Hydrate `is_moments_render: bool` on `MediaItem` (true iff the asset carries the `moments-edit` tag — see §6).
+3. Extend the grid filter so a stack containing a Moments-render member surfaces the **other** sibling (the original), not the server's primary. Sketch:
+
+   ```sql
+   LEFT JOIN stacks s ON m.stack_id = s.id
+   LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
+   WHERE (
+     s.id IS NULL                                    -- not stacked → show
+     OR (render.id IS NULL                            -- ordinary stack → use server primary
+         AND s.primary_asset_id = m.id)
+     OR (render.id IS NOT NULL                        -- Moments-edit stack → surface
+         AND m.id != render.id                        --   the non-render sibling, regardless
+         AND m.stack_id = s.id)                       --   of which one is server-primary
+   )
+   ```
+
+4. Thumbnail and viewer paths render the original through `RenderPipeline` with the local `edits` row applied — the same on-the-fly edit pipeline already used for local-only edits today. The rendered JPEG asset is never user-visible inside Moments; it's strictly a sync artifact.
+5. Re-opening the editor loads the local `edits` row, not the rendered bytes. (Phase D recovery is the only path that ever parses the rendered JPEG's XMP — to rebuild a missing local `edits` row.)
+
+**Why option (a) over option (b)**: keeping the rule "filter on a property of `MediaItem` (the tag flag)" aligns with how every other filter in the project works — in-memory `MediaFilter::matches` style. The alternative (don't bind originals to Moments-edit stacks at all locally) requires the grid query to know about a sync-internal concept, which leaks abstraction. The tag-driven override is more localised.
+
+**Does Phase A need to change to make Phase C work?** No. Phase A is generic stack plumbing; the Phase C override is additive — a tag-based filter exception layered on the existing primary-only clause.
 
 ---
 

--- a/docs/design-immich-edit-sync.md
+++ b/docs/design-immich-edit-sync.md
@@ -1,0 +1,639 @@
+# Immich Edit Sync — Build Specification
+
+**Status**: Approved, ready to implement.
+**Issues**: #224 (Immich render-and-upload), #641 (sync-conflict schema — supersedes), #225 (polish — depends on this).
+**Depends on**: #628 heartbeat reconciliation (merged on `main`).
+
+This document specifies how Moments synchronises non-destructive edits with an Immich server. It is the result of an extended design conversation that included two empirical probe runs against an Immich v2.7.5 test instance and a roadmap review of the upstream project.
+
+The build splits into four phases (A–D below). Phases A and B are independent and can land in either order; C depends on A; D depends on C.
+
+---
+
+## 1. Background
+
+The previous design (`design-photo-editing.md` section 5) called for `PUT /assets/{id}/original` to overwrite the user's original on the server. **That endpoint was removed in current Immich `main`.** Empirical probing of v2.7.5 confirmed the only mutation surfaces available are:
+
+- `PUT /assets/{id}/edits` — accepts a list of crop/rotate/mirror actions, native server-side modelling, syncs via `SyncAssetEditV1`. Shipped in v2.5.0; web in v2.6.0; mobile in v2.7.x. **Crop/rotate/mirror only — no exposure, no colour, no filters, no roadmap commitment for those.**
+- `POST /assets` (multipart upload) and the stacks API (`POST /stacks`, `DELETE /stacks/{id}/assets/{aid}`).
+- `PUT /tags` (idempotent upsert by name) and `PUT /tags/{id}/assets`.
+
+The original is never replaced. Immich's "originals are sacred" architectural rule is observed.
+
+---
+
+## 2. Design summary
+
+**Two mechanisms, chosen by edit type:**
+
+| Edit family | Mechanism | Server-side representation |
+|---|---|---|
+| Crop, rotate, mirror | `PUT /assets/{id}/edits` | Action list on the original asset, `isEdited: true` |
+| Exposure, white balance, vignette, colour, curves, filters | Render local JPEG → upload as new asset → stack `[renderedId, originalId]` → tag rendered asset with `moments-edit` → embed XMP in rendered JPEG | Original + rendered child, stack relationship, custom XMP block in rendered bytes |
+
+**Original assets are never modified.** The local `edits` table remains the source of truth for what edit was applied. The server-side artifacts (action list, stacked rendered asset) are caches/projections of that local state.
+
+**Recovery** (fresh install, second machine, lost local DB): tag query enumerates Moments-edited assets; for each, the rendered sibling is downloaded on demand and XMP parsed to rebuild the local `edits` row. Geometric-only edits recover automatically via `SyncAssetEditV1` in the sync stream.
+
+---
+
+## 3. Local schema changes
+
+Two new migrations, applied in order.
+
+### 3.1 Migration `023_add_stacks.sql`
+
+```sql
+-- Issue #224: model Immich's asset stacks locally so the timeline can
+-- collapse stacked siblings to the primary, and so push-side stack
+-- mutations can be tracked.
+
+CREATE TABLE stacks (
+    id                TEXT    PRIMARY KEY NOT NULL,
+    primary_asset_id  TEXT    NOT NULL REFERENCES media(id),
+    last_seen_at      INTEGER NOT NULL DEFAULT 0  -- joins #628 reconciliation
+);
+
+CREATE INDEX idx_stacks_primary_asset_id ON stacks(primary_asset_id);
+
+ALTER TABLE media ADD COLUMN stack_id TEXT REFERENCES stacks(id);
+
+CREATE INDEX idx_media_stack_id ON media(stack_id) WHERE stack_id IS NOT NULL;
+```
+
+### 3.2 Migration `024_add_edits_render_pointer.sql`
+
+```sql
+-- Issue #224: link a local edits row to the Immich asset that holds
+-- its rendered output. Set when a pixel-adjustment edit is uploaded;
+-- null for geometric-only edits (those use the server's edits API).
+
+ALTER TABLE edits ADD COLUMN server_rendered_asset_id TEXT REFERENCES media(id);
+ALTER TABLE edits ADD COLUMN xmp_edit_version INTEGER NOT NULL DEFAULT 1;
+```
+
+`xmp_edit_version` tracks the schema version of the embedded XMP, allowing forward-compatible parsing of older renders.
+
+### 3.3 Stacks join the heartbeat reconciliation
+
+Per #628, four tables already participate in the reset-cycle orphan sweep. `stacks` becomes the fifth:
+
+- `MediaRepository::bump_stack_last_seen_at(id, now)` — mirror of the existing pattern.
+- `MediaRepository::ids_with_stale_stack_heartbeat(checkpoint) -> Vec<String>` — orphan finder.
+- New `delete_stacks_with_stale_heartbeat` in finish_sync, runs after `delete_with_stale_heartbeat` on albums and before the people/faces sweeps. Cascades to clear `media.stack_id` on affected rows.
+
+Bumped from `AssetHandler` whenever an asset's stack relationship is touched.
+
+---
+
+## 4. Sync wiring
+
+### 4.1 Pull side: `AssetV1` payload now carries stack info
+
+The Immich sync stream's `AssetV1` payload has been observed to include:
+
+```json
+{
+  "stack": {
+    "id": "<stack uuid>",
+    "primaryAssetId": "<asset uuid>",
+    "assetCount": 2
+  } | null,
+  "isEdited": false
+}
+```
+
+Update `SyncAssetV1` in `src/sync/providers/immich/types.rs` to deserialise `stack` and `isEdited`. Update `AssetHandler` in `src/sync/providers/immich/handlers/asset.rs` to:
+
+1. If `stack != null`: upsert a row in `stacks` (id, primary_asset_id) and set `media.stack_id = stack.id`. Bump the stack's `last_seen_at`.
+2. If `stack == null`: clear `media.stack_id`.
+
+No new entity type to dispatch — Immich re-emits `AssetV1` whenever a stack relationship changes, so the existing handler pipeline picks it up.
+
+### 4.2 Pull side: `SyncAssetEditV1`
+
+New entity type. Payload (from OpenAPI on `main`):
+
+```json
+{
+  "assetId": "<uuid>",
+  "edits": [
+    { "action": "crop",   "parameters": { "x": 0, "y": 0, "width": 100, "height": 100 } },
+    { "action": "rotate", "parameters": { "angle": 90 } },
+    { "action": "mirror", "parameters": { "axis": "horizontal" } }
+  ]
+}
+```
+
+New handler `AssetEditHandler` in `src/sync/providers/immich/handlers/asset_edit.rs`:
+
+1. Translate `face.asset_id` (Immich UUID) → local `MediaId` via `media().id_by_external_id()`. Warn-and-skip if parent asset isn't local yet.
+2. Convert the `edits` action list into the local `EditState` representation (see §5.3 for the mapping).
+3. `editing().upsert_edits(media_id, edit_state)` — preserves any pixel-adjustment fields already present locally.
+4. Bump the edits row's `last_seen_at`-equivalent (or just rely on `updated_at`).
+
+Register in `handlers/mod.rs::all_handlers()`.
+
+Subscribe to the new entity type in `pull.rs::run_sync` request body:
+
+```rust
+types: vec![
+    "AssetsV1".to_string(),
+    "AssetExifsV1".to_string(),
+    "AssetEditsV1".to_string(),  // new
+    "AlbumsV1".to_string(),
+    "AlbumToAssetsV1".to_string(),
+    "PeopleV1".to_string(),
+    "AssetFacesV1".to_string(),
+],
+```
+
+### 4.3 Push side: new outbox mutation types
+
+Add to `src/library/mutation.rs::Mutation`:
+
+```rust
+pub enum Mutation {
+    // ... existing ...
+
+    /// Geometric edits via PUT /assets/{id}/edits. Replaces any
+    /// existing server-side edit list for the asset.
+    AssetEditsApplied {
+        id: MediaId,
+        actions: Vec<ImmichEditAction>,  // crop/rotate/mirror with params
+    },
+
+    /// Revert geometric edits via DELETE /assets/{id}/edits.
+    AssetEditsCleared { id: MediaId },
+
+    /// A new rendered asset has been uploaded and should be stacked
+    /// with its source. The rendered asset's external_id is captured
+    /// from the upload response and stamped before this mutation
+    /// records.
+    StackCreated {
+        primary_asset_id: MediaId,    // the rendered asset
+        original_asset_id: MediaId,   // the source
+    },
+
+    /// A stack member should be removed from its stack on the server.
+    /// Used during revert (we remove the rendered child; Immich auto-
+    /// deletes the stack when it falls below 2 members).
+    StackMemberRemoved {
+        stack_id: String,
+        asset_id: MediaId,
+    },
+
+    /// Apply the moments-edit tag to a rendered asset. Idempotent.
+    /// The tag itself is created lazily by the push handler the first
+    /// time this mutation is processed for an account.
+    AssetTaggedMomentsEdit { id: MediaId },
+
+    /// Detach the moments-edit tag from a rendered asset. Used during
+    /// revert.
+    AssetUntaggedMomentsEdit { id: MediaId },
+}
+```
+
+Corresponding `OutboxMutation::from_row` decoders in `src/sync/outbox/mutation.rs`.
+
+### 4.4 Push side: `PushManager::push_one` arms
+
+Add match arms in `src/sync/providers/immich/push.rs`:
+
+```rust
+OutboxMutation::AssetEditsApplied { id, actions } => {
+    let external_id = self.lookup_media_external_id(id.as_str()).await?;
+    self.client
+        .put_no_content(
+            &format!("/assets/{external_id}/edits"),
+            &serde_json::json!({ "edits": actions }),
+        )
+        .await?;
+    self.bump_media_heartbeat(id.as_str()).await
+}
+
+OutboxMutation::AssetEditsCleared { id } => {
+    let external_id = self.lookup_media_external_id(id.as_str()).await?;
+    self.client
+        .delete_no_content(&format!("/assets/{external_id}/edits"))
+        .await?;
+    self.bump_media_heartbeat(id.as_str()).await
+}
+
+OutboxMutation::StackCreated { primary_asset_id, original_asset_id } => {
+    let primary_ext  = self.lookup_media_external_id(primary_asset_id.as_str()).await?;
+    let original_ext = self.lookup_media_external_id(original_asset_id.as_str()).await?;
+    let resp: serde_json::Value = self.client.post(
+        "/stacks",
+        &serde_json::json!({ "assetIds": [primary_ext, original_ext] }),
+    ).await?;
+    if let Some(stack_id) = resp["id"].as_str() {
+        // Upsert local stacks row, set media.stack_id on both members.
+        self.persist_stack_locally(stack_id, primary_asset_id.as_str(),
+            &[primary_asset_id.as_str(), original_asset_id.as_str()]).await?;
+    }
+    Ok(())
+}
+
+OutboxMutation::StackMemberRemoved { stack_id, asset_id } => {
+    let asset_ext = self.lookup_media_external_id(asset_id.as_str()).await?;
+    self.client
+        .delete_no_content(&format!("/stacks/{stack_id}/assets/{asset_ext}"))
+        .await?;
+    // Server auto-deletes stack at <2 members; local cleanup happens
+    // when the next AssetV1 arrives with stack: null.
+    Ok(())
+}
+
+OutboxMutation::AssetTaggedMomentsEdit { id } => {
+    let tag_id = self.ensure_moments_edit_tag().await?;
+    let external_id = self.lookup_media_external_id(id.as_str()).await?;
+    self.client.put_no_content(
+        &format!("/tags/{tag_id}/assets"),
+        &serde_json::json!({ "ids": [external_id] }),
+    ).await
+}
+
+OutboxMutation::AssetUntaggedMomentsEdit { id } => {
+    let tag_id = self.ensure_moments_edit_tag().await?;
+    let external_id = self.lookup_media_external_id(id.as_str()).await?;
+    self.client.delete_with_body(
+        &format!("/tags/{tag_id}/assets"),
+        &serde_json::json!({ "ids": [external_id] }),
+    ).await
+}
+```
+
+`ensure_moments_edit_tag` calls `PUT /tags { tags: ["moments-edit"] }` (idempotent), caches the tag id in memory for the push session, and re-derives on cache miss.
+
+---
+
+## 5. XMP specification
+
+### 5.1 Namespace
+
+```
+prefix: moments
+URI:    urn:moments:edits:1.0
+```
+
+`1.0` is the schema version. Bumped only when the embedded JSON shape changes incompatibly. Consumers parse forward-compatibly: ignore unknown fields, accept versions ≥ minimum supported.
+
+### 5.2 Fields
+
+Embedded as RDF properties under a single `rdf:Description` block:
+
+```xml
+<x:xmpmeta xmlns:x="adobe:ns:meta/">
+  <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about=""
+        xmlns:moments="urn:moments:edits:1.0">
+      <moments:originalAssetId>e4f66d10-b88f-44e7-89ce-79259805a3b3</moments:originalAssetId>
+      <moments:originalContentHash>3ed6e7c8...base64</moments:originalContentHash>
+      <moments:editVersion>1</moments:editVersion>
+      <moments:renderedAt>2026-05-08T12:34:56Z</moments:renderedAt>
+      <moments:editJson>{"exposure":0.5,"vignette":...}</moments:editJson>
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `originalAssetId` | string (UUID) | yes | Immich asset id of the source. Primary recovery key. |
+| `originalContentHash` | string (SHA-1, base64) | yes | Fallback if `originalAssetId` doesn't resolve (rare: source was re-uploaded). Must match Immich's `checksum` field format. |
+| `editVersion` | integer | yes | Schema version of `editJson`. Starts at 1; bump on incompatible changes. |
+| `renderedAt` | string (RFC 3339) | yes | When the render was produced locally. Tiebreaker if multiple Moments installs raced. |
+| `editJson` | string (JSON) | yes | The serialised `EditState`. Format defined in `library/editing/model.rs`. |
+
+### 5.3 Action mapping (geometric)
+
+When the editor's `EditState` contains only crop/rotate/mirror, the save flow does **not** produce a render or XMP. Instead it serialises to the Immich edits-API actions:
+
+```
+EditState.crop(x, y, w, h)              -> { action: "crop",   parameters: { x, y, width, height } }
+EditState.rotate(degrees: 90 | 180 | 270) -> { action: "rotate", parameters: { angle } }
+EditState.mirror(Horizontal | Vertical)   -> { action: "mirror", parameters: { axis: "horizontal"|"vertical" } }
+```
+
+Reverse map applies in `AssetEditHandler` for the pull side.
+
+### 5.4 Encoder/decoder module
+
+New module `src/renderer/xmp.rs`:
+
+```rust
+pub struct EmbeddedEdit {
+    pub original_asset_id: String,
+    pub original_content_hash: String,
+    pub edit_version: u32,
+    pub rendered_at: chrono::DateTime<chrono::Utc>,
+    pub edit_json: String,
+}
+
+pub fn encode(edit: &EmbeddedEdit) -> String { ... }
+pub fn decode(xml: &str) -> Result<EmbeddedEdit, XmpError> { ... }
+```
+
+Implementation: hand-rolled with `quick-xml`. The XMP block is wrapped in JPEG APP1 segment with the standard Adobe XMP marker `http://ns.adobe.com/xap/1.0/\0`. See [XMP Specification Part 3 §1.1.3](https://www.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf) for the segment layout.
+
+JPEG APP1 segment injection: render the JPEG via the `image` crate, then post-process the byte stream to insert the APP1 marker after the SOI. ~50 LoC. Reuse: when reading XMP back, walk the JPEG segments to find APP1 with the XMP marker.
+
+---
+
+## 6. Tag specification
+
+### 6.1 Lifecycle
+
+- **Creation**: lazy on first push of `AssetTaggedMomentsEdit`. `PUT /tags { tags: ["moments-edit"] }` is idempotent — returns existing or creates.
+- **Caching**: cache the tag id on `PushManager` for the session. Re-fetch on next session start (or cache miss).
+- **Application**: only on rendered assets, never on originals.
+- **Revert**: `AssetUntaggedMomentsEdit` detaches before the rendered asset is deleted from the stack.
+
+### 6.2 Visibility
+
+In Immich v2.7.5 web UI:
+
+- Photo info panel: **does not display tags** (verified empirically).
+- Sidebar Explore → Tags page: lists `moments-edit` as a category; clicking shows tagged assets.
+- Search bar: tag autocompletes as a filter.
+- API `AssetResponseDto.tags[]`: present, syncs through `AssetV1`.
+
+The tag should be treated as a permanent server-side marker that *may* become user-visible if Immich's UI changes. Tag name `moments-edit` is acceptable in either case.
+
+### 6.3 Discovery query
+
+For new-install enumeration (Phase D):
+
+```
+POST /api/search/metadata
+{ "tagIds": ["<moments-edit-tag-id>"], "size": 1000 }
+```
+
+Returns paged list of all assets carrying the tag — i.e., every Moments-rendered asset on this Immich account. Iterate with `page` parameter for libraries with > 1000 edits.
+
+---
+
+## 7. UI / save flows
+
+### 7.1 Save (geometric-only edit)
+
+Triggered when `EditState::is_geometric_only()` returns true.
+
+```
+1. Persist EditState to local edits table.
+2. Convert to ImmichEditAction list (§5.3).
+3. Record outbox mutation AssetEditsApplied { id, actions }.
+4. Done. PushManager flushes; server applies; SyncAssetEditV1 echoes back on next pull.
+```
+
+No render, no upload, no stack, no tag. Single API call on push.
+
+### 7.2 Save (pixel adjustments present)
+
+Triggered when `EditState::has_pixel_adjustments()` returns true.
+
+```
+1. Persist EditState to local edits table (edit_json updated).
+2. Render full-resolution JPEG via RenderPipeline.
+3. Compute SHA-1 of original (or read from media.content_hash if cached).
+4. Encode XMP block (§5.4) with EmbeddedEdit fields populated.
+5. Inject XMP into JPEG APP1 segment.
+6. If edits.server_rendered_asset_id is non-null:
+   a. Outbox: StackMemberRemoved { stack_id, asset_id: server_rendered_asset_id }.
+   b. Outbox: AssetUntaggedMomentsEdit { id: server_rendered_asset_id }.
+   c. Outbox: AssetDeleted { id: server_rendered_asset_id }.
+   d. Wait for these to drain (or interleave; idempotent).
+7. Outbox: AssetImported { rendered_bytes, filename: "<original>-edit.jpg", ... }
+8. After push completes and external_id is stamped on the new media row:
+   a. Outbox: StackCreated { primary_asset_id: rendered, original_asset_id: original }.
+   b. Outbox: AssetTaggedMomentsEdit { id: rendered }.
+9. Update edits.server_rendered_asset_id on the local row to the new render's MediaId.
+```
+
+The "delete old render, upload new render" sequence ensures at most one rendered sibling per photo. Step 6 is skipped on the first edit.
+
+### 7.3 Revert
+
+```
+1. If geometric-only edits exist: outbox AssetEditsCleared { id: original }.
+2. If edits.server_rendered_asset_id is non-null:
+   a. Outbox StackMemberRemoved.
+   b. Outbox AssetUntaggedMomentsEdit.
+   c. Outbox AssetDeleted (the rendered asset).
+3. Delete local edits row.
+4. UI: navigate back to original (it surfaces in the timeline as the stack auto-collapses).
+```
+
+### 7.4 Recovery (Phase D)
+
+Triggered when user opens edit panel on a photo whose local `edits` row is absent but whose Immich asset has the `moments-edit` tag (or is the primary of a stack containing a `moments-edit`-tagged child).
+
+```
+1. Find the rendered sibling: SELECT id FROM media WHERE stack_id = ? AND id != ?
+   (the non-primary; for an edited photo the primary IS the rendered)
+   Actually: SELECT m.id FROM media m
+     JOIN stacks s ON m.stack_id = s.id
+     WHERE s.id = <stack of this photo> AND m.id = s.primary_asset_id
+   That's the rendered. (Wait: the rendered IS primary in our model.)
+
+   Equivalent: find the Moments-tagged member of the stack the user opened.
+
+2. Download the rendered JPEG (cache locally — they were going to view it anyway).
+3. Parse XMP block; extract EmbeddedEdit.
+4. Validate: originalAssetId resolves to a local media row whose external_id matches.
+   Fallback: lookup by originalContentHash if asset id mismatches.
+5. Insert local edits row from editJson, set server_rendered_asset_id.
+6. Open editor; user continues from where the previous Moments install left off.
+```
+
+Edge case: corrupt or missing XMP. Surface "edit history not recoverable; revert and re-edit" in the UI.
+
+---
+
+## 8. Grid filtering
+
+The grid query (across All, Favorites, Recent Imports, Album views, Person views) must filter to primary-only when stacks are present:
+
+```sql
+SELECT m.*
+FROM media m
+LEFT JOIN stacks s ON m.stack_id = s.id
+WHERE m.is_trashed = 0
+  AND (s.id IS NULL OR s.primary_asset_id = m.id)
+  AND <existing filter clauses>
+```
+
+Touch points:
+
+- `MediaRepository::list_filtered` (and any pagination cursors)
+- `AlbumRepository::list_media`
+- `FacesRepository::list_media_for_person`
+- Any direct SQL in clients (audit grep).
+
+The Recent Imports view counts edits as imports — when the user saves a pixel-adjustment edit, the rendered asset has a fresh `imported_at` and would appear in Recent Imports. That's correct behaviour.
+
+---
+
+## 9. Phased plan
+
+### Phase A — schema + sync wiring (no editor UX changes)
+
+Independent of the editor. Lands the stack model and recovers any user who already uses Immich's stack feature in the wild (panoramas, bursts).
+
+- [ ] Migration `023_add_stacks.sql`
+- [ ] Migration `024_add_edits_render_pointer.sql`
+- [ ] `SyncAssetV1` deserialises `stack` and `isEdited`
+- [ ] `AssetHandler` upserts `stacks` rows and sets `media.stack_id`
+- [ ] `MediaRepository`: `bump_stack_last_seen_at`, `ids_with_stale_stack_heartbeat`, `delete_stacks_with_stale_heartbeat`
+- [ ] Service-layer accessors
+- [ ] Extend `finish_sync` in `pull.rs` to sweep stale stacks
+- [ ] Grid query filter (every list_filtered touch point)
+- [ ] Tests: stack upsert, stack stale-sweep, primary-only filter
+
+Acceptance: pulling from a fresh Immich account that contains stacks (panoramas, bursts) results in a timeline that shows only primaries; clicking a stacked thumbnail expands to siblings; no duplicate-asset bug.
+
+### Phase B — geometric edits via `/assets/{id}/edits`
+
+Independent of Phase A; can land in parallel.
+
+- [ ] `ImmichClient` methods: `get_asset_edits`, `put_asset_edits`, `delete_asset_edits`
+- [ ] `Mutation::AssetEditsApplied` and `AssetEditsCleared` enum variants
+- [ ] `OutboxMutation::from_row` decoders
+- [ ] `PushManager::push_one` arms (§4.4)
+- [ ] `AssetEditHandler` for `SyncAssetEditV1`
+- [ ] `EditState::is_geometric_only()` predicate
+- [ ] `EditState ↔ ImmichEditAction` mapping (§5.3)
+- [ ] Editor save flow §7.1
+- [ ] Tests: probe with corrected nested-`parameters` payload (open question §11.1 to resolve first)
+
+Acceptance: cropping a photo in the Moments editor + save → photo appears cropped in Immich web within a sync cycle; cropping the same photo on Immich web → Moments shows the crop after next pull; revert clears it from both sides.
+
+### Phase C — pixel-adjustment edits via render+stack+tag+XMP
+
+Depends on Phase A (stacks model).
+
+- [ ] `src/renderer/xmp.rs` encoder/decoder
+- [ ] JPEG APP1 segment injection in render pipeline output
+- [ ] `Mutation::StackCreated`, `StackMemberRemoved`, `AssetTaggedMomentsEdit`, `AssetUntaggedMomentsEdit` variants
+- [ ] `OutboxMutation::from_row` decoders
+- [ ] `PushManager::push_one` arms (§4.4) and `ensure_moments_edit_tag` helper
+- [ ] `EditState::has_pixel_adjustments()` predicate
+- [ ] Editor save flow §7.2 (two-step delete-then-upload)
+- [ ] Editor revert flow §7.3
+- [ ] Tests: XMP roundtrip, save → render → upload → stack → tag end-to-end (mocked HTTP), revert
+
+Acceptance: applying a vignette in the Moments editor + save → original photo gets stacked with a new rendered asset on Immich; the rendered asset is primary, has `moments-edit` tag, and contains the XMP block; revert removes the rendered asset and the stack auto-collapses.
+
+### Phase D — recovery
+
+Depends on Phase C.
+
+- [ ] On editor open: detect "stack with `moments-edit`-tagged child but no local `edits` row"
+- [ ] Lazy XMP fetch + decode + edits-row reconstruction (§7.4)
+- [ ] Optional: eager tag-based discovery on first sync (`GET /search/metadata?tagIds=…`)
+- [ ] Tests: simulated fresh install scenario
+
+Acceptance: deleting the local `edits` row for a Moments-edited photo and reopening the editor recovers the edit state from XMP without user-visible failure.
+
+---
+
+## 10. Test strategy
+
+### 10.1 Unit / integration
+
+- Repository layer for new tables (existing pattern).
+- XMP encoder/decoder roundtrip.
+- JPEG APP1 segment injection roundtrip.
+- `OutboxMutation::from_row` for new variants.
+- Push handler dispatch (mock ImmichClient).
+- Pull handler `AssetEditHandler`.
+
+### 10.2 End-to-end against the local Immich test instance
+
+`http://localhost:2283`, API key at `/home/justin/.config/immich-test/api_key`.
+
+Tests should be opt-in (env-gated) since CI doesn't have an Immich server. A `make test-immich` target.
+
+- Crop a known asset → assert `isEdited: true` and edit list reflects the crop.
+- Apply pixel edit → assert new asset created + stack + tag.
+- Revert → assert rendered asset gone, stack auto-collapsed.
+- Recovery: wipe local `edits` row, reopen editor, assert reconstruction.
+
+### 10.3 Empirical probe before Phase B starts
+
+Verify (open question §11.1) that the corrected `PUT /assets/{id}/edits` payload works on v2.7.5:
+
+```bash
+curl -X PUT -H "x-api-key: $KEY" -H "Content-Type: application/json" \
+  -d '{"edits":[{"action":"rotate","parameters":{"angle":90}}]}' \
+  http://localhost:2283/api/assets/<uuid>/edits
+```
+
+Expected: 200 with empty body, asset's `isEdited: true` and `edits[]` populated. Cleanup with DELETE.
+
+If still 500: open an issue upstream and reduce Phase B scope to "best-effort, fall back to render+stack for geometric ops too".
+
+---
+
+## 11. Open questions
+
+### 11.1 Does the corrected `/edits` payload work on v2.7.5?
+
+The first probe sent a flat `{action, x, y, width, height}` shape. The OpenAPI spec on `main` confirms the correct shape is `{action, parameters: {…}}`. Re-test with that before Phase B implementation begins.
+
+### 11.2 Does Immich strip XMP from uploaded JPEGs?
+
+The probe established that originals aren't transcoded. The render is uploaded *as a new asset* via `POST /assets`. Verify: upload a JPEG with embedded custom XMP, fetch it back via `GET /assets/{id}/original`, confirm bytes are identical. If Immich rewrites EXIF/XMP at ingestion time, the embedded `editJson` would be lost.
+
+### 11.3 SHA-1 dedup interaction
+
+If the user "edits" with no-op adjustments and saves, the rendered JPEG could conceivably hash-match an existing asset (rare; JPEG re-encoding usually perturbs bytes). The probe found `bulk-upload-check` returns `"reject", "duplicate"` for matching SHA-1. Implementations options:
+
+- (a) Pre-flight `bulk-upload-check`; if duplicate, skip the upload and stack with the existing matched asset.
+- (b) Add a `EditState::is_identity()` short-circuit in the editor save path so no-op saves never produce a render.
+
+(b) is cheaper and probably sufficient.
+
+### 11.4 Stack merging semantics
+
+What does `POST /stacks { assetIds: [a, b] }` do when `a` is already in another stack? Probe didn't test. Affects multi-device editing race: device A creates stack; device B tries to create overlapping stack. Possible outcomes: 4xx (we handle and refresh), merge (cleaner), or duplicate (bad).
+
+### 11.5 Multi-device editing race
+
+If devices A and B both render-and-stack the same original concurrently:
+
+```
+Server end state: stack { original, render_A, render_B }, primary = whichever POST won the race.
+```
+
+Our local `edits.server_rendered_asset_id` records "our" render. The other render is visible on every client but isn't authoritative locally. Resolution policy: TBD. Probably "newest `renderedAt` wins; older render is auto-deleted on next save". Defer to a follow-up issue if it doesn't surface in v0.4.0.
+
+### 11.6 What about the existing `design-photo-editing.md`?
+
+Section 5 of that doc describes the now-dead `PUT /assets/{id}/original` model. It must be updated — either by deleting section 5 and pointing to this document, or by replacing its content with a summary of this design.
+
+---
+
+## 12. Out of scope
+
+- **Filter API for non-geometric edits.** Immich does not currently model exposure/colour/curves server-side. No timeline. We use the render+stack path until they ship one (which would let us migrate to native if/when it appears).
+- **Three-way merge of conflicting edits.** Multi-device races resolve by last-write-wins (see §11.5). No UI for "your edit and someone else's edit conflict; merge?".
+- **Editing originals (replace bytes).** Architecturally rejected. Originals are immutable on the server.
+- **Editing other users' shared photos.** Out of scope — editing requires `AssetEditCreate` permission which is owner-only.
+- **Stacking unrelated photos as an "edit".** Stacks created in the Immich UI by users (e.g. burst grouping) must work transparently — we never assume a stack means "Moments edit". The `moments-edit` tag is the disambiguator.
+- **Sidecar XMP files.** Immich doesn't expose them via API for retrieval; even though it parses them at upload time, we can't read them back. We embed XMP in the rendered JPEG bytes directly.
+
+---
+
+## 13. References
+
+- Issue #224: <https://github.com/justinf555/Moments/issues/224>
+- Issue #641: <https://github.com/justinf555/Moments/issues/641> (supersede)
+- Issue #225: <https://github.com/justinf555/Moments/issues/225> (depends on this)
+- #628 heartbeat reconciliation: merged on `main` (PR #649)
+- Immich v2.5.0 editor PR: <https://github.com/immich-app/immich/pull/24155>
+- Immich v2.7.x mobile editor PR: <https://github.com/immich-app/immich/pull/25397>
+- Immich OpenAPI spec: <https://raw.githubusercontent.com/immich-app/immich/main/open-api/immich-openapi-specs.json>
+- Existing editing design: `docs/design-photo-editing.md` (section 5 to be updated to reference this doc)
+- XMP Specification Part 3 (storage in files): see Adobe SDK

--- a/docs/design-immich-edit-sync.md
+++ b/docs/design-immich-edit-sync.md
@@ -24,6 +24,8 @@ The original is never replaced. Immich's "originals are sacred" architectural ru
 
 ## 2. Design summary
 
+> **Status of this document**: Phase A is implemented in `feat/224-immich-stacks-phase-a`. The "actual wire shape vs. earlier draft" callouts in §4.1 and §4.2 record corrections discovered while testing against a live Immich v2.7.5 instance and cross-checking against the upstream OpenAPI spec.
+
 **Two mechanisms, chosen by edit type:**
 
 | Edit family | Mechanism | Server-side representation |
@@ -50,16 +52,18 @@ Two new migrations, applied in order.
 
 CREATE TABLE stacks (
     id                TEXT    PRIMARY KEY NOT NULL,
-    primary_asset_id  TEXT    NOT NULL REFERENCES media(id),
+    primary_asset_id  TEXT    NOT NULL REFERENCES media(id) ON DELETE CASCADE,
     last_seen_at      INTEGER NOT NULL DEFAULT 0  -- joins #628 reconciliation
 );
 
 CREATE INDEX idx_stacks_primary_asset_id ON stacks(primary_asset_id);
 
-ALTER TABLE media ADD COLUMN stack_id TEXT REFERENCES stacks(id);
+ALTER TABLE media ADD COLUMN stack_id TEXT REFERENCES stacks(id) ON DELETE SET NULL;
 
 CREATE INDEX idx_media_stack_id ON media(stack_id) WHERE stack_id IS NOT NULL;
 ```
+
+The two cascades work together: deleting a `media` row cascade-deletes any `stacks` row whose primary it was, which in turn cascade-clears `stack_id` on the surviving siblings. Both fire automatically because sqlx 0.8 enables `PRAGMA foreign_keys` per connection.
 
 ### 3.2 Migration `024_add_edits_render_pointer.sql`
 
@@ -68,7 +72,7 @@ CREATE INDEX idx_media_stack_id ON media(stack_id) WHERE stack_id IS NOT NULL;
 -- its rendered output. Set when a pixel-adjustment edit is uploaded;
 -- null for geometric-only edits (those use the server's edits API).
 
-ALTER TABLE edits ADD COLUMN server_rendered_asset_id TEXT REFERENCES media(id);
+ALTER TABLE edits ADD COLUMN server_rendered_asset_id TEXT REFERENCES media(id) ON DELETE SET NULL;
 ALTER TABLE edits ADD COLUMN xmp_edit_version INTEGER NOT NULL DEFAULT 1;
 ```
 
@@ -80,71 +84,103 @@ Per #628, four tables already participate in the reset-cycle orphan sweep. `stac
 
 - `MediaRepository::bump_stack_last_seen_at(id, now)` — mirror of the existing pattern.
 - `MediaRepository::ids_with_stale_stack_heartbeat(checkpoint) -> Vec<String>` — orphan finder.
-- New `delete_stacks_with_stale_heartbeat` in finish_sync, runs after `delete_with_stale_heartbeat` on albums and before the people/faces sweeps. Cascades to clear `media.stack_id` on affected rows.
+- New `delete_stacks_with_stale_heartbeat` in finish_sync, runs after `delete_with_stale_heartbeat` on albums and before the people/faces sweeps. The migration's `ON DELETE SET NULL` cascade clears member `stack_id` automatically (sqlx 0.8 enables `PRAGMA foreign_keys` per connection); the explicit transactional `UPDATE` in the repo is a defensive belt-and-braces.
 
-Bumped from `AssetHandler` whenever an asset's stack relationship is touched.
+Bumped from `StackHandler` whenever a `StackV1` is processed.
+
+A second one-shot deletion path, `MediaRepository::delete_stack(id)`, mirrors the same transactional cleanup for the `SyncStackDeleteV1` ingress.
 
 ---
 
 ## 4. Sync wiring
 
-### 4.1 Pull side: `AssetV1` payload now carries stack info
+### 4.1 Pull side: `AssetV1` carries flat `stackId`; stacks stream separately
 
-The Immich sync stream's `AssetV1` payload has been observed to include:
+Empirically verified against v2.7.5 and confirmed against the OpenAPI spec on `main` — the `/sync/stream` endpoint emits stacks across **two coordinated streams**: `AssetV1` carries a flat `stackId` pointer, and `StackV1` / `StackDeleteV1` carry the stack metadata (including the primary asset id).
+
+> **Earlier draft of this section assumed a nested `stack` object on `AssetV1`** (mirroring the `/api/assets/{id}` detail endpoint). That was wrong — confirmed by inspecting the live wire payload during Phase A verification. The actual sync wire shape is what this section now describes.
+
+`SyncAssetV1` payload (relevant fields):
 
 ```json
 {
-  "stack": {
-    "id": "<stack uuid>",
-    "primaryAssetId": "<asset uuid>",
-    "assetCount": 2
-  } | null,
+  "stackId": "<stack uuid>" | null,
   "isEdited": false
 }
 ```
 
-Update `SyncAssetV1` in `src/sync/providers/immich/types.rs` to deserialise `stack` and `isEdited`. Update `AssetHandler` in `src/sync/providers/immich/handlers/asset.rs` to:
-
-1. If `stack != null`: upsert a row in `stacks` (id, primary_asset_id) and set `media.stack_id = stack.id`. Bump the stack's `last_seen_at`.
-2. If `stack == null`: clear `media.stack_id`.
-
-No new entity type to dispatch — Immich re-emits `AssetV1` whenever a stack relationship changes, so the existing handler pipeline picks it up.
-
-### 4.2 Pull side: `SyncAssetEditV1`
-
-New entity type. Payload (from OpenAPI on `main`):
+`SyncStackV1` payload:
 
 ```json
 {
-  "assetId": "<uuid>",
-  "edits": [
-    { "action": "crop",   "parameters": { "x": 0, "y": 0, "width": 100, "height": 100 } },
-    { "action": "rotate", "parameters": { "angle": 90 } },
-    { "action": "mirror", "parameters": { "axis": "horizontal" } }
-  ]
+  "id": "<stack uuid>",
+  "primaryAssetId": "<asset uuid>",
+  "ownerId": "<owner uuid>",
+  "createdAt": "...",
+  "updatedAt": "..."
 }
 ```
 
+`SyncStackDeleteV1` payload:
+
+```json
+{ "stackId": "<stack uuid>" }
+```
+
+Update `SyncAssetV1` in `src/sync/providers/immich/types.rs` to deserialise `stackId: Option<String>` (flat) and `isEdited: Option<bool>`. Add `SyncStackV1` and `SyncStackDeleteV1` types. Subscribe to `"StacksV1"` in the request `types` array.
+
+Handlers:
+
+1. **`AssetHandler`** (existing) — when handling `AssetV1`: if `stackId` is set, `set_media_stack_id`; if null, `clear_media_stack_id`. Does NOT touch the `stacks` table — that's `StackHandler`'s job.
+2. **`StackHandler`** (new, `handlers/stack.rs`) — for `StackV1`: translate `primaryAssetId` (Immich UUID) to local `MediaId` via `id_by_external_id`; upsert the `stacks` row; bump heartbeat. Warn-and-skip if the primary's local row hasn't streamed yet — the next pull cycle re-emits.
+3. **`StackDeleteHandler`** (new) — for `StackDeleteV1`: call `delete_stack(stack_id)` which clears member pointers and deletes the row in one transaction.
+
+**Order independence**: `AssetV1` and `StackV1` arrive in arbitrary order. The FK on `media.stack_id REFERENCES stacks(id)` is enforced (sqlx 0.8 enables `PRAGMA foreign_keys` by default), so an asset can't bind to a non-existent stack.
+
+Resolution: when `AssetHandler` sees an `AssetV1.stackId` for a stack that hasn't yet been upserted locally, it first creates a **stub** `stacks` row via `ensure_stack_stub(id, media_id)` — `INSERT … ON CONFLICT DO NOTHING` with the current asset itself as the placeholder `primary_asset_id`. The asset can then bind. When `StackV1` for that id arrives later, `upsert_stack` overwrites the placeholder primary with the authoritative one (and the `ON CONFLICT(id) DO UPDATE SET primary_asset_id = excluded.primary_asset_id` clause leaves `last_seen_at` untouched).
+
+Until the real `StackV1` lands, the grid may show the wrong asset as primary for that brief window — accepted as a transient. The stub's `last_seen_at = 0` means it's eligible for the heartbeat sweep, but the real `StackV1` will bump it before any sweep runs.
+
+### 4.2 Pull side: `SyncAssetEditV1` (one event per action)
+
+New entity type. The OpenAPI spec on `main` shows that edits stream **one record per action**, not as a single batched payload — each `SyncAssetEditV1` carries a single action with a `sequence` number that imposes an order across the asset's actions.
+
+`SyncAssetEditV1` payload:
+
+```json
+{
+  "id":        "<edit uuid>",
+  "assetId":   "<asset uuid>",
+  "action":    "crop" | "rotate" | "mirror",
+  "parameters": { "x": 0, "y": 0, "width": 100, "height": 100 },
+  "sequence":  0
+}
+```
+
+A complementary `SyncAssetEditDeleteV1` (with the edit `id`) cancels a single action.
+
+> **Earlier draft of this section assumed a single batched payload** with an `edits[]` array. That was wrong — Immich actually emits per-action records with sequence numbers. Each handler invocation is one row in a per-asset action list, ordered by `sequence`.
+
 New handler `AssetEditHandler` in `src/sync/providers/immich/handlers/asset_edit.rs`:
 
-1. Translate `face.asset_id` (Immich UUID) → local `MediaId` via `media().id_by_external_id()`. Warn-and-skip if parent asset isn't local yet.
-2. Convert the `edits` action list into the local `EditState` representation (see §5.3 for the mapping).
-3. `editing().upsert_edits(media_id, edit_state)` — preserves any pixel-adjustment fields already present locally.
-4. Bump the edits row's `last_seen_at`-equivalent (or just rely on `updated_at`).
+1. Translate `assetId` (Immich UUID) → local `MediaId` via `media().id_by_external_id()`. Warn-and-skip if parent asset isn't local yet.
+2. Upsert a row keyed by `(media_id, edit_id)` carrying `(action, parameters_json, sequence)` — local schema TBD as part of Phase B.
+3. Recompose the asset's edit state by pulling all rows for that asset ordered by `sequence` (translation to `EditState` per §5.3).
 
-Register in `handlers/mod.rs::all_handlers()`.
+Register in `handlers/mod.rs::all_handlers()` along with `AssetEditDeleteHandler`.
 
-Subscribe to the new entity type in `pull.rs::run_sync` request body:
+Subscribe to the new entity types in `pull.rs::run_sync` request body:
 
 ```rust
 types: vec![
     "AssetsV1".to_string(),
     "AssetExifsV1".to_string(),
-    "AssetEditsV1".to_string(),  // new
+    "AssetEditsV1".to_string(),  // new (Phase B)
     "AlbumsV1".to_string(),
     "AlbumToAssetsV1".to_string(),
     "PeopleV1".to_string(),
     "AssetFacesV1".to_string(),
+    "StacksV1".to_string(),       // added in Phase A
 ],
 ```
 
@@ -481,15 +517,18 @@ The Recent Imports view counts edits as imports — when the user saves a pixel-
 
 Independent of the editor. Lands the stack model and recovers any user who already uses Immich's stack feature in the wild (panoramas, bursts).
 
-- [ ] Migration `023_add_stacks.sql`
-- [ ] Migration `024_add_edits_render_pointer.sql`
-- [ ] `SyncAssetV1` deserialises `stack` and `isEdited`
-- [ ] `AssetHandler` upserts `stacks` rows and sets `media.stack_id`
-- [ ] `MediaRepository`: `bump_stack_last_seen_at`, `ids_with_stale_stack_heartbeat`, `delete_stacks_with_stale_heartbeat`
-- [ ] Service-layer accessors
-- [ ] Extend `finish_sync` in `pull.rs` to sweep stale stacks
-- [ ] Grid query filter (every list_filtered touch point)
-- [ ] Tests: stack upsert, stack stale-sweep, primary-only filter
+- [x] Migration `023_add_stacks.sql`
+- [x] Migration `024_add_edits_render_pointer.sql`
+- [x] `SyncAssetV1` deserialises **flat** `stackId` and `isEdited`; new `SyncStackV1` / `SyncStackDeleteV1` types
+- [x] `AssetHandler` sets/clears `media.stack_id` from `AssetV1.stackId`
+- [x] `StackHandler` upserts `stacks` rows from `StackV1`; `StackDeleteHandler` removes them on `StackDeleteV1`
+- [x] Subscribe to `"StacksV1"` in sync request types
+- [x] `MediaRepository`: `upsert_stack`, `set/clear_media_stack_id`, `bump_stack_last_seen_at`, `ids_with_stale_stack_heartbeat`, `delete_stacks_with_stale_heartbeat`, `delete_stack`
+- [x] Service-layer accessors
+- [x] Extend `finish_sync` in `pull.rs` to sweep stale stacks
+- [x] Grid query filter on `MediaRepository::list`, `AlbumRepository::list_media`, `FacesRepository::list_media_for_person`
+- [x] Stack-badge overlay on photo grid cell (`edit-copy-symbolic`, top-right)
+- [x] Tests: stack upsert idempotency, stale-sweep with member rejoin, primary-only filter, clear-membership
 
 Acceptance: pulling from a fresh Immich account that contains stacks (panoramas, bursts) results in a timeline that shows only primaries; clicking a stacked thumbnail expands to siblings; no duplicate-asset bug.
 

--- a/docs/design-photo-editing.md
+++ b/docs/design-photo-editing.md
@@ -152,15 +152,11 @@ lands.
 
 ## 5. Immich Integration
 
-**Save**: Load original → apply edits → encode JPEG → `PUT /assets/{id}/original` → update `rendered_at` → regenerate thumbnail
+**Superseded by [`design-immich-edit-sync.md`](design-immich-edit-sync.md).**
 
-**Revert**: `DELETE /assets/{id}/original` → delete `edits` row → regenerate thumbnail from original
+The original design here proposed `PUT /assets/{id}/original` to overwrite the user's original on the server. That endpoint was removed in current Immich; empirical probing of v2.7.5 confirmed the only viable mutation surfaces are `/assets/{id}/edits` (crop/rotate/mirror only) and `POST /assets` + `POST /stacks` (for everything else).
 
-New `ImmichClient` methods:
-- `upload_edited_asset(asset_id, rendered_bytes, filename)`
-- `revert_asset(asset_id)`
-
-**Note**: Exact Immich API endpoints need verification against the server version. Fallback: upload as new asset linked to original.
+The replacement design uses a hybrid: native `/edits` API for geometric primitives, and render-upload-stack-tag with embedded XMP for pixel adjustments. Original assets are never modified. See the linked document for the full specification, schema changes, sync wiring, and phased plan.
 
 ## 6. UI: Edit Panel in Viewer Sidebar
 

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -999,6 +999,10 @@ impl MediaClientV2 {
                 obj.set_is_favorite(item.is_favorite);
                 obj.set_trashed_at(item.trashed_at.unwrap_or(0));
                 obj.set_duration_ms(item.duration_ms.unwrap_or(0));
+                // Issue #224: keep the stack badge in sync when an
+                // un-stacked primary later acquires siblings, or
+                // a stack is deleted server-side.
+                obj.set_is_stacked(item.stack_id.is_some());
             }
         });
     }

--- a/src/client/media/model.rs
+++ b/src/client/media/model.rs
@@ -36,6 +36,14 @@ mod imp {
         /// Video duration in milliseconds. 0 for images.
         #[property(get, set)]
         pub duration_ms: Cell<u64>,
+
+        /// Whether this item is part of an Immich asset stack. Issue
+        /// #224. Only the stack's primary surfaces in the grid (filter
+        /// applied at `MediaRepository::list`); when this property is
+        /// `true`, the cell renders a stack-badge overlay so users can
+        /// tell at a glance the photo has hidden siblings.
+        #[property(get, set)]
+        pub is_stacked: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -58,6 +66,7 @@ impl MediaItemObject {
         obj.imp().is_favorite.set(item.is_favorite);
         obj.imp().trashed_at.set(item.trashed_at.unwrap_or(0));
         obj.imp().duration_ms.set(item.duration_ms.unwrap_or(0));
+        obj.imp().is_stacked.set(item.stack_id.is_some());
         obj.imp()
             .item
             .set(item)

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -325,10 +325,12 @@ impl AlbumRepository {
             None => sqlx::query_as::<_, MediaRow>(
                 "SELECT m.id, m.taken_at, m.imported_at, m.original_filename,
                             m.width, m.height, m.orientation, m.media_type, m.is_favorite,
-                            m.is_trashed, m.trashed_at, m.duration_ms
+                            m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id
                      FROM media m
                      JOIN album_media am ON m.id = am.media_id
+                     LEFT JOIN stacks s ON m.stack_id = s.id
                      WHERE am.album_id = ? AND m.is_trashed = 0
+                       AND (s.id IS NULL OR s.primary_asset_id = m.id)
                      ORDER BY COALESCE(m.taken_at, 0) DESC, m.id DESC
                      LIMIT ?",
             )
@@ -340,13 +342,15 @@ impl AlbumRepository {
             Some(cur) => sqlx::query_as::<_, MediaRow>(
                 "SELECT m.id, m.taken_at, m.imported_at, m.original_filename,
                             m.width, m.height, m.orientation, m.media_type, m.is_favorite,
-                            m.is_trashed, m.trashed_at, m.duration_ms
+                            m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id
                      FROM media m
                      JOIN album_media am ON m.id = am.media_id
+                     LEFT JOIN stacks s ON m.stack_id = s.id
                      WHERE am.album_id = ?
                        AND (COALESCE(m.taken_at, 0) < ?
                             OR (COALESCE(m.taken_at, 0) = ? AND m.id < ?))
                        AND m.is_trashed = 0
+                       AND (s.id IS NULL OR s.primary_asset_id = m.id)
                      ORDER BY COALESCE(m.taken_at, 0) DESC, m.id DESC
                      LIMIT ?",
             )

--- a/src/library/db/migrations/023_add_stacks.sql
+++ b/src/library/db/migrations/023_add_stacks.sql
@@ -1,0 +1,24 @@
+-- Issue #224: model Immich's asset stacks locally so the timeline can
+-- collapse stacked siblings to the primary, and so push-side stack
+-- mutations can be tracked.
+--
+-- Cascade behaviour:
+--   * stacks.primary_asset_id ON DELETE CASCADE — if the primary asset
+--     is removed locally (e.g. via the heartbeat orphan sweep), the
+--     stack row goes with it; remaining members fall back to NULL via
+--     the second FK.
+--   * media.stack_id ON DELETE SET NULL — when a stack is deleted,
+--     surviving members rejoin the un-stacked timeline rather than
+--     being orphaned.
+
+CREATE TABLE stacks (
+    id                TEXT    PRIMARY KEY NOT NULL,
+    primary_asset_id  TEXT    NOT NULL REFERENCES media(id) ON DELETE CASCADE,
+    last_seen_at      INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_stacks_primary_asset_id ON stacks(primary_asset_id);
+
+ALTER TABLE media ADD COLUMN stack_id TEXT REFERENCES stacks(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_media_stack_id ON media(stack_id) WHERE stack_id IS NOT NULL;

--- a/src/library/db/migrations/024_add_edits_render_pointer.sql
+++ b/src/library/db/migrations/024_add_edits_render_pointer.sql
@@ -1,0 +1,14 @@
+-- Issue #224: link a local edits row to the Immich asset that holds
+-- its rendered output. Set when a pixel-adjustment edit is uploaded;
+-- null for geometric-only edits (those use the server's edits API).
+--
+-- xmp_edit_version tracks the schema version of the embedded XMP,
+-- allowing forward-compatible parsing of older renders.
+--
+-- ON DELETE SET NULL on server_rendered_asset_id: if the rendered
+-- child asset is removed (revert, orphan sweep), the local edits row
+-- survives — it still describes the user's edit; only the server-side
+-- render pointer is gone.
+
+ALTER TABLE edits ADD COLUMN server_rendered_asset_id TEXT REFERENCES media(id) ON DELETE SET NULL;
+ALTER TABLE edits ADD COLUMN xmp_edit_version INTEGER NOT NULL DEFAULT 1;

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -90,7 +90,9 @@ impl FacesRepository {
         let rows: Vec<(String,)> = sqlx::query_as(
             "SELECT DISTINCT af.asset_id FROM asset_faces af
              INNER JOIN media m ON m.id = af.asset_id
+             LEFT JOIN stacks s ON m.stack_id = s.id
              WHERE af.person_id = ? AND m.is_trashed = 0
+               AND (s.id IS NULL OR s.primary_asset_id = m.id)
              ORDER BY COALESCE(m.taken_at, m.imported_at) DESC",
         )
         .bind(person_id)

--- a/src/library/media/mod.rs
+++ b/src/library/media/mod.rs
@@ -4,5 +4,5 @@ pub mod repository;
 mod service;
 
 pub use event::MediaEvent;
-pub use model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, MediaType};
+pub use model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, MediaType, Stack};
 pub use service::MediaService;

--- a/src/library/media/model.rs
+++ b/src/library/media/model.rs
@@ -63,6 +63,31 @@ pub struct MediaItem {
     pub trashed_at: Option<i64>,
     /// Video duration in milliseconds. `None` for images.
     pub duration_ms: Option<u64>,
+    /// Identifier of the stack this asset belongs to, if any.
+    /// `None` for un-stacked items. Set on every member of a stack
+    /// (including the primary). The grid filters non-primary members
+    /// out via a `LEFT JOIN stacks` clause; clients can use this to
+    /// surface a "stacked" badge on the primary.
+    pub stack_id: Option<String>,
+}
+
+/// A stack of related assets on the Immich server (e.g. a panorama
+/// burst, or a Moments-rendered edit alongside its original).
+///
+/// Issue #224: Immich exposes stacks via `AssetV1.stack`. Locally we
+/// cache them as a peer table so the timeline can collapse stacked
+/// siblings to the primary, and so push-side stack mutations have a
+/// stable identifier to mutate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Stack {
+    /// Server-assigned UUID. Stable across pulls.
+    pub id: String,
+    /// The asset that surfaces in the timeline as the visible
+    /// representative of this stack.
+    pub primary_asset_id: MediaId,
+    /// Heartbeat timestamp (Unix seconds) for #628 reset-cycle
+    /// orphan reconciliation.
+    pub last_seen_at: i64,
 }
 
 /// Filter for [`super::service::MediaService::list_media`] queries.

--- a/src/library/media/model.rs
+++ b/src/library/media/model.rs
@@ -74,10 +74,16 @@ pub struct MediaItem {
 /// A stack of related assets on the Immich server (e.g. a panorama
 /// burst, or a Moments-rendered edit alongside its original).
 ///
-/// Issue #224: Immich exposes stacks via `AssetV1.stack`. Locally we
-/// cache them as a peer table so the timeline can collapse stacked
-/// siblings to the primary, and so push-side stack mutations have a
-/// stable identifier to mutate.
+/// Issue #224: Immich exposes stacks via the `StacksV1` sync stream.
+/// Locally we cache them as a peer table so the timeline can collapse
+/// stacked siblings to the primary, and so push-side stack mutations
+/// have a stable identifier to mutate.
+///
+/// Note: this struct intentionally does NOT carry `last_seen_at`.
+/// Heartbeat (#628) is a local concern managed via
+/// [`super::repository::MediaRepository::bump_stack_last_seen_at`] /
+/// [`super::repository::MediaRepository::ensure_stack_stub`] — the
+/// server's `SyncStackV1` payload doesn't include it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Stack {
     /// Server-assigned UUID. Stable across pulls.
@@ -85,9 +91,6 @@ pub struct Stack {
     /// The asset that surfaces in the timeline as the visible
     /// representative of this stack.
     pub primary_asset_id: MediaId,
-    /// Heartbeat timestamp (Unix seconds) for #628 reset-cycle
-    /// orphan reconciliation.
-    pub last_seen_at: i64,
 }
 
 /// Filter for [`super::service::MediaService::list_media`] queries.

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -712,18 +712,29 @@ impl MediaRepository {
     /// overwrites it via `upsert_stack`'s ON CONFLICT clause.
     /// Idempotent — `ON CONFLICT DO NOTHING` preserves any stub or
     /// authoritative row already present.
+    ///
+    /// `now` seeds the stub's `last_seen_at`. Issue #628 reset-cycle
+    /// reconciliation: if we left the stub at `0`, the same cycle's
+    /// sweep at `finish_sync` would delete it before the matching
+    /// `StackV1` got a chance to bump it (or before it has a chance
+    /// to arrive at all). Seeding with the cycle's wall time keeps
+    /// the stub alive for at least one cycle; if `StackV1` never
+    /// arrives, the next reset-cycle's checkpoint will be `> now` and
+    /// the orphan sweep will clean it up.
     pub async fn ensure_stack_stub(
         &self,
         stack_id: &str,
         primary_fallback: &MediaId,
+        now: i64,
     ) -> Result<(), LibraryError> {
         sqlx::query(
             "INSERT INTO stacks (id, primary_asset_id, last_seen_at)
-             VALUES (?, ?, 0)
+             VALUES (?, ?, ?)
              ON CONFLICT(id) DO NOTHING",
         )
         .bind(stack_id)
         .bind(primary_fallback.as_str())
+        .bind(now)
         .execute(self.db.pool())
         .await
         .map_err(LibraryError::Db)?;
@@ -731,30 +742,49 @@ impl MediaRepository {
     }
 
     /// Point a media row at a stack. Used when the server announces
-    /// stack membership through `AssetV1.stack`.
+    /// stack membership through `AssetV1.stackId`.
+    ///
+    /// Returns `true` if the row's `stack_id` actually changed. The
+    /// SQL guards on `(stack_id IS NULL OR stack_id != ?)` so the
+    /// UPDATE is a no-op when the asset is already bound to the
+    /// requested stack — saves a redundant `MediaEvent::Updated` on
+    /// the steady-state re-sync of an unchanged stack membership.
     pub async fn set_media_stack_id(
         &self,
         media_id: &MediaId,
         stack_id: &str,
-    ) -> Result<(), LibraryError> {
-        sqlx::query("UPDATE media SET stack_id = ? WHERE id = ?")
-            .bind(stack_id)
-            .bind(media_id.as_str())
-            .execute(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-        Ok(())
+    ) -> Result<bool, LibraryError> {
+        let result = sqlx::query(
+            "UPDATE media SET stack_id = ?
+             WHERE id = ? AND (stack_id IS NULL OR stack_id != ?)",
+        )
+        .bind(stack_id)
+        .bind(media_id.as_str())
+        .bind(stack_id)
+        .execute(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(result.rows_affected() > 0)
     }
 
     /// Clear the stack pointer on a media row. Used when an `AssetV1`
-    /// arrives with `stack: null` (the asset was un-stacked server-side).
-    pub async fn clear_media_stack_id(&self, media_id: &MediaId) -> Result<(), LibraryError> {
-        sqlx::query("UPDATE media SET stack_id = NULL WHERE id = ?")
-            .bind(media_id.as_str())
-            .execute(self.db.pool())
-            .await
-            .map_err(LibraryError::Db)?;
-        Ok(())
+    /// arrives with `stackId: null` (the asset was un-stacked
+    /// server-side).
+    ///
+    /// Returns `true` if the row's `stack_id` actually changed. The
+    /// SQL guards on `stack_id IS NOT NULL` so re-sync of an
+    /// already-un-stacked asset (the common case for the vast
+    /// majority of `AssetV1` payloads) doesn't emit a spurious event.
+    pub async fn clear_media_stack_id(&self, media_id: &MediaId) -> Result<bool, LibraryError> {
+        let result = sqlx::query(
+            "UPDATE media SET stack_id = NULL
+             WHERE id = ? AND stack_id IS NOT NULL",
+        )
+        .bind(media_id.as_str())
+        .execute(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(result.rows_affected() > 0)
     }
 
     /// Update a stack's heartbeat. Issue #628 reset-cycle reconciliation
@@ -1221,7 +1251,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stk1".to_string(),
             primary_asset_id: primary_a.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1232,7 +1261,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stk1".to_string(),
             primary_asset_id: primary_b.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1261,7 +1289,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stale".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1270,7 +1297,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "fresh".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1301,7 +1327,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "doomed".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1357,7 +1382,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1398,10 +1422,14 @@ mod tests {
             .unwrap();
 
         // Stub-then-bind, mirroring `AssetHandler::apply_stack_membership`.
-        repo.ensure_stack_stub("late-stack", &asset).await.unwrap();
+        // Pass a non-zero `now` so the stub survives a same-cycle reset
+        // sweep (issue #224 / #628).
+        repo.ensure_stack_stub("late-stack", &asset, 555)
+            .await
+            .unwrap();
         repo.set_media_stack_id(&asset, "late-stack").await.unwrap();
 
-        // Stub exists with the placeholder primary.
+        // Stub exists with the placeholder primary and a live heartbeat.
         let row: (String, i64) =
             sqlx::query_as("SELECT primary_asset_id, last_seen_at FROM stacks WHERE id = ?")
                 .bind("late-stack")
@@ -1409,7 +1437,10 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(row.0, asset.as_str(), "stub primary is the binding asset");
-        assert_eq!(row.1, 0, "stub heartbeat is 0 — overwritten by StackV1");
+        assert_eq!(
+            row.1, 555,
+            "stub heartbeat seeded from `now`, not 0 — survives same-cycle sweep"
+        );
 
         // Real StackV1 arrives later: upsert overwrites the primary.
         let real_primary = MediaId::new("b".repeat(64));
@@ -1419,7 +1450,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "late-stack".to_string(),
             primary_asset_id: real_primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1458,7 +1488,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1521,7 +1550,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -1575,7 +1603,6 @@ mod tests {
         repo.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: id.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -1,4 +1,4 @@
-use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, MediaType};
+use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, MediaType, Stack};
 use crate::library::db::{id_placeholders, Database, LibraryStats};
 use crate::library::error::LibraryError;
 
@@ -20,6 +20,7 @@ pub(crate) struct MediaRow {
     is_trashed: i64,
     trashed_at: Option<i64>,
     duration_ms: Option<i64>,
+    stack_id: Option<String>,
 }
 
 impl MediaRow {
@@ -41,6 +42,7 @@ impl MediaRow {
             is_trashed: self.is_trashed != 0,
             trashed_at: self.trashed_at,
             duration_ms: self.duration_ms.map(|v| v as u64),
+            stack_id: self.stack_id,
         }
     }
 }
@@ -86,7 +88,7 @@ impl MediaRepository {
         let row: Option<MediaRow> = sqlx::query_as(
             "SELECT id, taken_at, imported_at, original_filename,
                     width, height, orientation, media_type, is_favorite,
-                    is_trashed, trashed_at, duration_ms
+                    is_trashed, trashed_at, duration_ms, stack_id
              FROM media WHERE id = ?",
         )
         .bind(id.as_str())
@@ -101,16 +103,26 @@ impl MediaRepository {
     /// IDs that don't match any row are silently absent from the result;
     /// callers compare the returned vec length with the request length to
     /// detect missing rows.
+    ///
+    /// Issue #224: applies the same primary-only stack filter as
+    /// [`Self::list`]. Non-primary stack members are absent from the
+    /// result so `MediaClientV2`'s reconciliation path treats them
+    /// the same way it treats deleted rows — removed from any tracked
+    /// grid model. This keeps the grid in sync with stack membership
+    /// changes without a separate event channel.
     pub async fn get_many(&self, ids: &[MediaId]) -> Result<Vec<MediaItem>, LibraryError> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
         let placeholders = id_placeholders(ids.len());
         let sql = format!(
-            "SELECT id, taken_at, imported_at, original_filename,
-                    width, height, orientation, media_type, is_favorite,
-                    is_trashed, trashed_at, duration_ms
-             FROM media WHERE id IN ({placeholders})"
+            "SELECT m.id, m.taken_at, m.imported_at, m.original_filename,
+                    m.width, m.height, m.orientation, m.media_type, m.is_favorite,
+                    m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id
+             FROM media m
+             LEFT JOIN stacks s ON m.stack_id = s.id
+             WHERE m.id IN ({placeholders})
+               AND (s.id IS NULL OR s.primary_asset_id = m.id)"
         );
         let mut query = sqlx::query_as::<_, MediaRow>(&sql);
         for id in ids {
@@ -121,6 +133,58 @@ impl MediaRepository {
             .await
             .map_err(LibraryError::Db)?;
         Ok(rows.into_iter().map(MediaRow::into_item).collect())
+    }
+
+    /// For a batch of `media` ids about to be deleted, return the
+    /// surviving sibling ids that the FK cascade chain will rejoin to
+    /// the un-stacked timeline.
+    ///
+    /// Issue #224: when a stack primary is permanently deleted, the
+    /// `stacks` row cascades away and surviving members get
+    /// `stack_id` SET NULL. Those siblings need a `MediaEvent::Updated`
+    /// so they reappear in the live grid. The service-layer delete
+    /// path captures this list before the delete fires.
+    ///
+    /// Excludes ids that are themselves being deleted, and dedupes.
+    pub async fn siblings_freed_by_deletion(
+        &self,
+        deleted_ids: &[MediaId],
+    ) -> Result<Vec<MediaId>, LibraryError> {
+        if deleted_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = id_placeholders(deleted_ids.len());
+        let sql = format!(
+            "SELECT DISTINCT m.id FROM media m
+             JOIN stacks s ON m.stack_id = s.id
+             WHERE s.primary_asset_id IN ({placeholders})
+               AND m.id NOT IN ({placeholders})"
+        );
+        let mut q = sqlx::query_as::<_, (String,)>(&sql);
+        for id in deleted_ids {
+            q = q.bind(id.as_str());
+        }
+        for id in deleted_ids {
+            q = q.bind(id.as_str());
+        }
+        let rows: Vec<(String,)> = q
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(rows.into_iter().map(|(id,)| MediaId::new(id)).collect())
+    }
+
+    /// Return the local `MediaId`s of every member of a stack
+    /// (regardless of whether each member is the primary). Used by
+    /// the service layer to fan out `MediaEvent::Updated` to all
+    /// affected rows when a stack is mutated server-side.
+    pub async fn list_stack_members(&self, stack_id: &str) -> Result<Vec<MediaId>, LibraryError> {
+        let rows: Vec<(String,)> = sqlx::query_as("SELECT id FROM media WHERE stack_id = ?")
+            .bind(stack_id)
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(rows.into_iter().map(|(id,)| MediaId::new(id)).collect())
     }
 
     /// Return the `original_filename` column for `id`, or `None` if no row exists.
@@ -169,24 +233,30 @@ impl MediaRepository {
         cursor: Option<&MediaCursor>,
         limit: u32,
     ) -> Result<Vec<MediaItem>, LibraryError> {
+        // Issue #224: stacked-but-not-primary members are hidden from
+        // every grid view. The `LEFT JOIN stacks` + `(s.id IS NULL OR
+        // s.primary_asset_id = m.id)` clause keeps un-stacked rows
+        // visible while collapsing each stack to its primary. Bare
+        // column references are now qualified with `m.` to disambiguate
+        // from `stacks.id` / `stacks.primary_asset_id`.
         let (filter_clause, sort_expr) = match &filter {
-            MediaFilter::All => (" AND is_trashed = 0", "COALESCE(taken_at, 0)"),
+            MediaFilter::All => (" AND m.is_trashed = 0", "COALESCE(m.taken_at, 0)"),
             MediaFilter::Favorites => (
-                " AND is_trashed = 0 AND is_favorite = 1",
-                "COALESCE(taken_at, 0)",
+                " AND m.is_trashed = 0 AND m.is_favorite = 1",
+                "COALESCE(m.taken_at, 0)",
             ),
-            MediaFilter::Trashed => (" AND is_trashed = 1", "COALESCE(trashed_at, 0)"),
+            MediaFilter::Trashed => (" AND m.is_trashed = 1", "COALESCE(m.trashed_at, 0)"),
             MediaFilter::RecentImports { .. } => (
-                " AND is_trashed = 0 AND imported_at > ?",
-                "imported_at",
+                " AND m.is_trashed = 0 AND m.imported_at > ?",
+                "m.imported_at",
             ),
             MediaFilter::Album { .. } => (
-                " AND is_trashed = 0 AND id IN (SELECT media_id FROM album_media WHERE album_id = ?)",
-                "COALESCE(taken_at, 0)",
+                " AND m.is_trashed = 0 AND m.id IN (SELECT media_id FROM album_media WHERE album_id = ?)",
+                "COALESCE(m.taken_at, 0)",
             ),
             MediaFilter::Person { .. } => (
-                " AND is_trashed = 0 AND id IN (SELECT DISTINCT asset_id FROM asset_faces WHERE person_id = ?)",
-                "COALESCE(taken_at, 0)",
+                " AND m.is_trashed = 0 AND m.id IN (SELECT DISTINCT asset_id FROM asset_faces WHERE person_id = ?)",
+                "COALESCE(m.taken_at, 0)",
             ),
         };
 
@@ -197,17 +267,18 @@ impl MediaRepository {
             _ => None,
         };
 
-        let columns = "id, taken_at, imported_at, original_filename,
-                        width, height, orientation, media_type, is_favorite,
-                        is_trashed, trashed_at, duration_ms";
+        let columns = "m.id, m.taken_at, m.imported_at, m.original_filename,
+                        m.width, m.height, m.orientation, m.media_type, m.is_favorite,
+                        m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id";
 
         let rows = match cursor {
             None => {
                 let sql = format!(
                     "SELECT {columns}
-                     FROM media
-                     WHERE 1=1{filter_clause}
-                     ORDER BY {sort_expr} DESC, id DESC
+                     FROM media m
+                     LEFT JOIN stacks s ON m.stack_id = s.id
+                     WHERE (s.id IS NULL OR s.primary_asset_id = m.id){filter_clause}
+                     ORDER BY {sort_expr} DESC, m.id DESC
                      LIMIT ?"
                 );
                 let mut q = sqlx::query_as::<_, MediaRow>(&sql);
@@ -222,10 +293,12 @@ impl MediaRepository {
             Some(cur) => {
                 let sql = format!(
                     "SELECT {columns}
-                     FROM media
-                     WHERE ({sort_expr} < ?
-                        OR ({sort_expr} = ? AND id < ?)){filter_clause}
-                     ORDER BY {sort_expr} DESC, id DESC
+                     FROM media m
+                     LEFT JOIN stacks s ON m.stack_id = s.id
+                     WHERE (s.id IS NULL OR s.primary_asset_id = m.id)
+                       AND ({sort_expr} < ?
+                            OR ({sort_expr} = ? AND m.id < ?)){filter_clause}
+                     ORDER BY {sort_expr} DESC, m.id DESC
                      LIMIT ?"
                 );
                 let mut q = sqlx::query_as::<_, MediaRow>(&sql)
@@ -604,6 +677,182 @@ impl MediaRepository {
             .map_err(LibraryError::Db)?;
         Ok(())
     }
+
+    // ── Stacks (issue #224) ─────────────────────────────────────────
+
+    /// Upsert a stack row. Idempotent — reuses the existing id and
+    /// overwrites `primary_asset_id` if it changed (e.g. the user
+    /// re-stacked on the server). Does not bump `last_seen_at`; the
+    /// caller does that separately so the heartbeat write stays
+    /// uniform across all sync paths.
+    pub async fn upsert_stack(&self, stack: &Stack) -> Result<(), LibraryError> {
+        sqlx::query(
+            "INSERT INTO stacks (id, primary_asset_id, last_seen_at)
+             VALUES (?, ?, COALESCE((SELECT last_seen_at FROM stacks WHERE id = ?), 0))
+             ON CONFLICT(id) DO UPDATE SET primary_asset_id = excluded.primary_asset_id",
+        )
+        .bind(&stack.id)
+        .bind(stack.primary_asset_id.as_str())
+        .bind(&stack.id)
+        .execute(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Ensure a `stacks` row exists for `stack_id`, creating a stub
+    /// pointing at `primary_fallback` if it doesn't.
+    ///
+    /// Used by `AssetHandler` when it sees an `AssetV1.stackId` for a
+    /// stack we haven't received the matching `StackV1` for yet — the
+    /// FK on `media.stack_id REFERENCES stacks(id)` is enforced
+    /// (sqlx 0.8 enables `PRAGMA foreign_keys` by default), so we
+    /// can't bind the asset to a non-existent stack. The stub uses
+    /// the current asset as a placeholder primary; `StackV1` later
+    /// overwrites it via `upsert_stack`'s ON CONFLICT clause.
+    /// Idempotent — `ON CONFLICT DO NOTHING` preserves any stub or
+    /// authoritative row already present.
+    pub async fn ensure_stack_stub(
+        &self,
+        stack_id: &str,
+        primary_fallback: &MediaId,
+    ) -> Result<(), LibraryError> {
+        sqlx::query(
+            "INSERT INTO stacks (id, primary_asset_id, last_seen_at)
+             VALUES (?, ?, 0)
+             ON CONFLICT(id) DO NOTHING",
+        )
+        .bind(stack_id)
+        .bind(primary_fallback.as_str())
+        .execute(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Point a media row at a stack. Used when the server announces
+    /// stack membership through `AssetV1.stack`.
+    pub async fn set_media_stack_id(
+        &self,
+        media_id: &MediaId,
+        stack_id: &str,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE media SET stack_id = ? WHERE id = ?")
+            .bind(stack_id)
+            .bind(media_id.as_str())
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Clear the stack pointer on a media row. Used when an `AssetV1`
+    /// arrives with `stack: null` (the asset was un-stacked server-side).
+    pub async fn clear_media_stack_id(&self, media_id: &MediaId) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE media SET stack_id = NULL WHERE id = ?")
+            .bind(media_id.as_str())
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Update a stack's heartbeat. Issue #628 reset-cycle reconciliation
+    /// — stacks join the four pre-existing tables (media, albums,
+    /// people, asset_faces) in the orphan sweep.
+    pub async fn bump_stack_last_seen_at(
+        &self,
+        stack_id: &str,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE stacks SET last_seen_at = ? WHERE id = ?")
+            .bind(now)
+            .bind(stack_id)
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Return stack ids whose heartbeat lags the given checkpoint.
+    /// Unlike media/albums, stacks have no local-only counterpart —
+    /// they only exist as a server projection — so no `external_id`
+    /// gate is needed.
+    pub async fn ids_with_stale_stack_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<String>, LibraryError> {
+        let rows: Vec<(String,)> = sqlx::query_as("SELECT id FROM stacks WHERE last_seen_at < ?")
+            .bind(checkpoint)
+            .fetch_all(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Delete one stack by id, rejoining its members to the un-stacked
+    /// timeline. The matching path for `SyncStackDeleteV1` events.
+    /// Idempotent — a missing stack id is a no-op.
+    ///
+    /// `media.stack_id REFERENCES stacks(id) ON DELETE SET NULL`
+    /// (migration 023) cascades automatically with `PRAGMA
+    /// foreign_keys` enabled (the sqlx 0.8 default). The explicit
+    /// `UPDATE … SET stack_id = NULL` here is defensive — if FK
+    /// enforcement were ever flipped off, this still does the right
+    /// thing — but on a current build it's a redundant no-op.
+    pub async fn delete_stack(&self, stack_id: &str) -> Result<(), LibraryError> {
+        let mut tx = self.db.pool().begin().await.map_err(LibraryError::Db)?;
+        sqlx::query("UPDATE media SET stack_id = NULL WHERE stack_id = ?")
+            .bind(stack_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(LibraryError::Db)?;
+        sqlx::query("DELETE FROM stacks WHERE id = ?")
+            .bind(stack_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(LibraryError::Db)?;
+        tx.commit().await.map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
+    /// Delete stacks whose heartbeat lags the checkpoint, rejoining
+    /// each member to the un-stacked timeline. Returns the removed
+    /// stack ids for logging.
+    ///
+    /// As with `delete_stack`, the explicit `UPDATE` is defensive
+    /// against future FK pragma changes; under `PRAGMA foreign_keys = ON`
+    /// (sqlx 0.8 default) the `media.stack_id` `ON DELETE SET NULL`
+    /// cascade does the same work automatically.
+    pub async fn delete_stacks_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<String>, LibraryError> {
+        let ids = self.ids_with_stale_stack_heartbeat(checkpoint).await?;
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = id_placeholders(ids.len());
+        let mut tx = self.db.pool().begin().await.map_err(LibraryError::Db)?;
+
+        let unbind_sql =
+            format!("UPDATE media SET stack_id = NULL WHERE stack_id IN ({placeholders})");
+        let mut unbind = sqlx::query(&unbind_sql);
+        for id in &ids {
+            unbind = unbind.bind(id);
+        }
+        unbind.execute(&mut *tx).await.map_err(LibraryError::Db)?;
+
+        let delete_sql = format!("DELETE FROM stacks WHERE id IN ({placeholders})");
+        let mut delete = sqlx::query(&delete_sql);
+        for id in &ids {
+            delete = delete.bind(id);
+        }
+        delete.execute(&mut *tx).await.map_err(LibraryError::Db)?;
+
+        tx.commit().await.map_err(LibraryError::Db)?;
+        Ok(ids)
+    }
 }
 
 #[cfg(test)]
@@ -947,5 +1196,393 @@ mod tests {
 
         assert_eq!(orphans.len(), 1, "only the stale synced row is orphaned");
         assert_eq!(orphans[0].as_str(), stale_synced.as_str());
+    }
+
+    // ── Stacks (issue #224) ─────────────────────────────────────────
+
+    /// `upsert_stack` is idempotent on the id and overwrites the
+    /// `primary_asset_id` when re-stacking happens server-side.
+    /// `last_seen_at` must be preserved across upserts so heartbeat
+    /// state isn't reset on every pull.
+    #[tokio::test]
+    async fn upsert_stack_is_idempotent_and_preserves_heartbeat() {
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+
+        let primary_a = MediaId::new("a".repeat(64));
+        let primary_b = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(primary_a.clone(), "a.jpg", None))
+            .await
+            .unwrap();
+        repo.insert(&record_with_taken_at(primary_b.clone(), "b.jpg", None))
+            .await
+            .unwrap();
+
+        repo.upsert_stack(&Stack {
+            id: "stk1".to_string(),
+            primary_asset_id: primary_a.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.bump_stack_last_seen_at("stk1", 555).await.unwrap();
+
+        // Upsert again — primary changed (server re-pinned), heartbeat
+        // must NOT be reset to 0.
+        repo.upsert_stack(&Stack {
+            id: "stk1".to_string(),
+            primary_asset_id: primary_b.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+
+        let row: (String, i64) =
+            sqlx::query_as("SELECT primary_asset_id, last_seen_at FROM stacks WHERE id = ?")
+                .bind("stk1")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(row.0, primary_b.as_str(), "primary updated by upsert");
+        assert_eq!(row.1, 555, "heartbeat preserved across upsert");
+    }
+
+    /// Stack ids whose heartbeat lags the checkpoint are returned.
+    /// Stacks have no `external_id` gate (server-only construct), so
+    /// every stale row is eligible.
+    #[tokio::test]
+    async fn ids_with_stale_stack_heartbeat_returns_only_stale() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let primary = MediaId::new("a".repeat(64));
+        repo.insert(&test_record(primary.clone())).await.unwrap();
+
+        repo.upsert_stack(&Stack {
+            id: "stale".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.bump_stack_last_seen_at("stale", 100).await.unwrap();
+
+        repo.upsert_stack(&Stack {
+            id: "fresh".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.bump_stack_last_seen_at("fresh", 300).await.unwrap();
+
+        let mut stale = repo.ids_with_stale_stack_heartbeat(200).await.unwrap();
+        stale.sort();
+        assert_eq!(stale, vec!["stale".to_string()]);
+    }
+
+    /// Deleting a stale stack must clear `media.stack_id` on its
+    /// members via the migration's `ON DELETE SET NULL` cascade so
+    /// surviving members rejoin the un-stacked timeline.
+    #[tokio::test]
+    async fn delete_stacks_with_stale_heartbeat_clears_member_stack_id() {
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let member = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(primary.clone(), "p.jpg", None))
+            .await
+            .unwrap();
+        repo.insert(&record_with_taken_at(member.clone(), "m.jpg", None))
+            .await
+            .unwrap();
+
+        repo.upsert_stack(&Stack {
+            id: "doomed".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.set_media_stack_id(&primary, "doomed").await.unwrap();
+        repo.set_media_stack_id(&member, "doomed").await.unwrap();
+        repo.bump_stack_last_seen_at("doomed", 50).await.unwrap();
+
+        let removed = repo.delete_stacks_with_stale_heartbeat(200).await.unwrap();
+        assert_eq!(removed, vec!["doomed".to_string()]);
+
+        // FK cascade must have nulled stack_id on both members.
+        let primary_stack: (Option<String>,) =
+            sqlx::query_as("SELECT stack_id FROM media WHERE id = ?")
+                .bind(primary.as_str())
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let member_stack: (Option<String>,) =
+            sqlx::query_as("SELECT stack_id FROM media WHERE id = ?")
+                .bind(member.as_str())
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(primary_stack.0.is_none());
+        assert!(member_stack.0.is_none());
+    }
+
+    /// The grid query collapses stacks to their primary — non-primary
+    /// members must not appear in the listing. Un-stacked rows are
+    /// unaffected.
+    #[tokio::test]
+    async fn list_hides_non_primary_stack_members() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling = MediaId::new("b".repeat(64));
+        let unstacked = MediaId::new("c".repeat(64));
+        repo.insert(&record_with_taken_at(primary.clone(), "p.jpg", Some(1000)))
+            .await
+            .unwrap();
+        repo.insert(&record_with_taken_at(sibling.clone(), "s.jpg", Some(2000)))
+            .await
+            .unwrap();
+        repo.insert(&record_with_taken_at(
+            unstacked.clone(),
+            "u.jpg",
+            Some(3000),
+        ))
+        .await
+        .unwrap();
+
+        repo.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.set_media_stack_id(&primary, "stk").await.unwrap();
+        repo.set_media_stack_id(&sibling, "stk").await.unwrap();
+
+        let items = repo.list(MediaFilter::All, None, 50).await.unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(items.len(), 2, "sibling must be hidden");
+        assert!(ids.contains(&unstacked.as_str()), "un-stacked visible");
+        assert!(ids.contains(&primary.as_str()), "primary visible");
+        assert!(
+            !ids.contains(&sibling.as_str()),
+            "non-primary stack member hidden"
+        );
+
+        // The `MediaItem.stack_id` field is populated for the primary
+        // (so the cell can render the stack badge) and absent on
+        // un-stacked rows.
+        let primary_item = items.iter().find(|i| i.id == primary).unwrap();
+        let unstacked_item = items.iter().find(|i| i.id == unstacked).unwrap();
+        assert_eq!(primary_item.stack_id.as_deref(), Some("stk"));
+        assert!(unstacked_item.stack_id.is_none());
+    }
+
+    /// Issue #224: `AssetV1` may arrive before its matching `StackV1`,
+    /// and `media.stack_id` REFERENCES `stacks(id)` is enforced. The
+    /// stub-then-bind path must succeed; the later `StackV1` upsert
+    /// overwrites the placeholder primary.
+    #[tokio::test]
+    async fn ensure_stack_stub_lets_asset_handler_bind_before_stack_arrives() {
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+
+        let asset = MediaId::new("a".repeat(64));
+        repo.insert(&record_with_taken_at(asset.clone(), "a.jpg", None))
+            .await
+            .unwrap();
+
+        // Stub-then-bind, mirroring `AssetHandler::apply_stack_membership`.
+        repo.ensure_stack_stub("late-stack", &asset).await.unwrap();
+        repo.set_media_stack_id(&asset, "late-stack").await.unwrap();
+
+        // Stub exists with the placeholder primary.
+        let row: (String, i64) =
+            sqlx::query_as("SELECT primary_asset_id, last_seen_at FROM stacks WHERE id = ?")
+                .bind("late-stack")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(row.0, asset.as_str(), "stub primary is the binding asset");
+        assert_eq!(row.1, 0, "stub heartbeat is 0 — overwritten by StackV1");
+
+        // Real StackV1 arrives later: upsert overwrites the primary.
+        let real_primary = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(real_primary.clone(), "b.jpg", None))
+            .await
+            .unwrap();
+        repo.upsert_stack(&Stack {
+            id: "late-stack".to_string(),
+            primary_asset_id: real_primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+
+        let primary_after: String =
+            sqlx::query_scalar("SELECT primary_asset_id FROM stacks WHERE id = ?")
+                .bind("late-stack")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(primary_after, real_primary.as_str());
+    }
+
+    /// Issue #224: when a stack primary is deleted, `siblings_freed_by_deletion`
+    /// must return the rows whose `stack_id` will be SET NULL by the
+    /// cascade — but never return ids that are themselves being deleted.
+    #[tokio::test]
+    async fn siblings_freed_by_deletion_returns_cascade_affected_only() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling_a = MediaId::new("b".repeat(64));
+        let sibling_b = MediaId::new("c".repeat(64));
+        let unrelated = MediaId::new("d".repeat(64));
+        for (id, name) in [
+            (&primary, "p.jpg"),
+            (&sibling_a, "a.jpg"),
+            (&sibling_b, "b.jpg"),
+            (&unrelated, "u.jpg"),
+        ] {
+            repo.insert(&record_with_taken_at(id.clone(), name, None))
+                .await
+                .unwrap();
+        }
+        repo.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        for id in [&primary, &sibling_a, &sibling_b] {
+            repo.set_media_stack_id(id, "stk").await.unwrap();
+        }
+
+        // Deleting just the primary frees both siblings.
+        let mut freed = repo
+            .siblings_freed_by_deletion(std::slice::from_ref(&primary))
+            .await
+            .unwrap();
+        freed.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(freed, vec![sibling_a.clone(), sibling_b.clone()]);
+
+        // Deleting the primary AND sibling_a frees only sibling_b —
+        // the other deleted id must be excluded from the freed list.
+        let to_delete = vec![primary.clone(), sibling_a.clone()];
+        let freed = repo.siblings_freed_by_deletion(&to_delete).await.unwrap();
+        assert_eq!(freed, vec![sibling_b.clone()]);
+
+        // Deleting an un-stacked row frees nobody.
+        let freed = repo
+            .siblings_freed_by_deletion(std::slice::from_ref(&unrelated))
+            .await
+            .unwrap();
+        assert!(freed.is_empty());
+
+        // Deleting a non-primary member frees nobody (its deletion
+        // doesn't trigger the stacks-cascade chain).
+        let freed = repo
+            .siblings_freed_by_deletion(std::slice::from_ref(&sibling_a))
+            .await
+            .unwrap();
+        assert!(freed.is_empty());
+    }
+
+    /// Migration 023 declares two cascades (`stacks.primary_asset_id
+    /// ON DELETE CASCADE` and `media.stack_id ON DELETE SET NULL`).
+    /// They're load-bearing for the AssetDelete-of-primary path:
+    /// when a stack primary is removed, the `stacks` row vanishes
+    /// and surviving siblings rejoin the un-stacked timeline.
+    /// This test exercises the cascade chain directly — without
+    /// going through `delete_stack`'s explicit-clear belt-and-braces
+    /// — to confirm sqlx 0.8's default `PRAGMA foreign_keys = ON` is
+    /// in effect.
+    #[tokio::test]
+    async fn fk_cascade_clears_stack_and_member_stack_id_on_primary_delete() {
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(primary.clone(), "p.jpg", None))
+            .await
+            .unwrap();
+        repo.insert(&record_with_taken_at(sibling.clone(), "s.jpg", None))
+            .await
+            .unwrap();
+        repo.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.set_media_stack_id(&primary, "stk").await.unwrap();
+        repo.set_media_stack_id(&sibling, "stk").await.unwrap();
+
+        // Delete the primary media row directly — bypassing
+        // `delete_stack`. We rely purely on the FK cascade chain.
+        sqlx::query("DELETE FROM media WHERE id = ?")
+            .bind(primary.as_str())
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        // stacks.primary_asset_id ON DELETE CASCADE should have removed
+        // the stack row.
+        let stack_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM stacks WHERE id = ?")
+            .bind("stk")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            stack_count.0, 0,
+            "stack row must cascade-delete when its primary media is removed"
+        );
+
+        // media.stack_id ON DELETE SET NULL should have cleared the
+        // sibling's stack pointer.
+        let sibling_stack: (Option<String>,) =
+            sqlx::query_as("SELECT stack_id FROM media WHERE id = ?")
+                .bind(sibling.as_str())
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert!(
+            sibling_stack.0.is_none(),
+            "surviving sibling's stack_id must cascade to NULL"
+        );
+    }
+
+    /// `clear_media_stack_id` is the path AssetHandler takes when
+    /// `AssetV1.stack` arrives as `null` — the asset was un-stacked
+    /// server-side.
+    #[tokio::test]
+    async fn clear_media_stack_id_unbinds() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let id = MediaId::new("a".repeat(64));
+        repo.insert(&test_record(id.clone())).await.unwrap();
+        repo.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: id.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        repo.set_media_stack_id(&id, "stk").await.unwrap();
+        repo.clear_media_stack_id(&id).await.unwrap();
+
+        let items = repo.list(MediaFilter::All, None, 10).await.unwrap();
+        assert!(items[0].stack_id.is_none());
     }
 }

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -347,36 +347,44 @@ impl MediaService {
     /// `StackV1` hasn't streamed yet. No event is emitted — the
     /// matching `set_media_stack_id` call that follows fires the
     /// `Updated` event for the asset that just bound.
+    ///
+    /// `now` seeds the stub's heartbeat so the same-cycle reset
+    /// sweep doesn't delete it before `StackV1` arrives.
     pub async fn ensure_stack_stub(
         &self,
         stack_id: &str,
         primary_fallback: &MediaId,
+        now: i64,
     ) -> Result<(), LibraryError> {
         self.repo
-            .ensure_stack_stub(stack_id, primary_fallback)
+            .ensure_stack_stub(stack_id, primary_fallback, now)
             .await
     }
 
     /// Sync-only: bind a media row to a stack. Emits
-    /// `MediaEvent::Updated` for the bound asset so the grid
-    /// reconciles (non-primary members get filtered out via
-    /// `get_many`'s primary-only clause).
+    /// `MediaEvent::Updated` only when the row actually changed —
+    /// re-syncing an unchanged membership skips the event. The grid
+    /// reconciles via `get_many`'s primary-only clause.
     pub async fn set_media_stack_id(
         &self,
         media_id: &MediaId,
         stack_id: &str,
     ) -> Result<(), LibraryError> {
-        self.repo.set_media_stack_id(media_id, stack_id).await?;
-        self.emit(MediaEvent::Updated(vec![media_id.clone()]));
+        if self.repo.set_media_stack_id(media_id, stack_id).await? {
+            self.emit(MediaEvent::Updated(vec![media_id.clone()]));
+        }
         Ok(())
     }
 
     /// Sync-only: clear a media row's stack pointer (the asset was
-    /// un-stacked server-side). Emits `MediaEvent::Updated` so the
-    /// asset reappears in the un-stacked grid.
+    /// un-stacked server-side). Emits `MediaEvent::Updated` only
+    /// when the row actually changed — re-syncing an
+    /// already-un-stacked asset (the common case for most `AssetV1`
+    /// payloads) skips the event.
     pub async fn clear_media_stack_id(&self, media_id: &MediaId) -> Result<(), LibraryError> {
-        self.repo.clear_media_stack_id(media_id).await?;
-        self.emit(MediaEvent::Updated(vec![media_id.clone()]));
+        if self.repo.clear_media_stack_id(media_id).await? {
+            self.emit(MediaEvent::Updated(vec![media_id.clone()]));
+        }
         Ok(())
     }
 
@@ -620,7 +628,6 @@ mod tests {
         svc.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -635,7 +642,6 @@ mod tests {
         svc.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: sibling.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -670,7 +676,6 @@ mod tests {
         svc.upsert_stack(&Stack {
             id: "doomed".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();
@@ -711,7 +716,6 @@ mod tests {
         svc.upsert_stack(&Stack {
             id: "stk".to_string(),
             primary_asset_id: primary.clone(),
-            last_seen_at: 0,
         })
         .await
         .unwrap();

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 use tracing::{instrument, warn};
 
 use super::event::MediaEvent;
-use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord};
+use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, Stack};
 use super::repository::MediaRepository;
 use crate::event_emitter::EventEmitter;
 use crate::library::config::LocalStorageMode;
@@ -253,8 +253,20 @@ impl MediaService {
     pub async fn delete_permanently(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
         // Capture external_ids before the DB delete removes the rows.
         let ext_map = self.repo.external_ids(ids).await.unwrap_or_default();
+        // Issue #224: capture siblings whose stack_id will be SET NULL
+        // by the FK cascade so we can emit `MediaEvent::Updated` for
+        // them after the delete — otherwise the live grid stays
+        // out of sync until restart.
+        let freed_siblings = self
+            .repo
+            .siblings_freed_by_deletion(ids)
+            .await
+            .unwrap_or_default();
         self.repo.delete_permanently(ids).await?;
         self.emit(MediaEvent::Removed(ids.to_vec()));
+        if !freed_siblings.is_empty() {
+            self.emit(MediaEvent::Updated(freed_siblings));
+        }
         let items: Vec<(MediaId, Option<String>)> = ids
             .iter()
             .map(|id| {
@@ -277,8 +289,16 @@ impl MediaService {
 
     /// Permanently delete without outbox recording (used by pull sync).
     pub async fn delete_permanently_no_record(&self, ids: &[MediaId]) -> Result<(), LibraryError> {
+        let freed_siblings = self
+            .repo
+            .siblings_freed_by_deletion(ids)
+            .await
+            .unwrap_or_default();
         self.repo.delete_permanently(ids).await?;
         self.emit(MediaEvent::Removed(ids.to_vec()));
+        if !freed_siblings.is_empty() {
+            self.emit(MediaEvent::Updated(freed_siblings));
+        }
         Ok(())
     }
 
@@ -304,6 +324,114 @@ impl MediaService {
         checkpoint: i64,
     ) -> Result<Vec<MediaId>, LibraryError> {
         self.repo.ids_with_stale_heartbeat(checkpoint).await
+    }
+
+    // ── Stacks (issue #224) ─────────────────────────────────────────
+
+    /// Sync-only: upsert a stack row from `StackV1`. Emits
+    /// `MediaEvent::Updated` for every current member of the stack
+    /// so any primary swap reflects in tracked grid models without
+    /// a restart.
+    pub async fn upsert_stack(&self, stack: &Stack) -> Result<(), LibraryError> {
+        self.repo.upsert_stack(stack).await?;
+        let members = self.repo.list_stack_members(&stack.id).await?;
+        if !members.is_empty() {
+            self.emit(MediaEvent::Updated(members));
+        }
+        Ok(())
+    }
+
+    /// Sync-only: ensure a stub `stacks` row exists for the given id,
+    /// pointing at the supplied media row as a placeholder primary.
+    /// Used by `AssetHandler` to satisfy the FK before binding when
+    /// `StackV1` hasn't streamed yet. No event is emitted — the
+    /// matching `set_media_stack_id` call that follows fires the
+    /// `Updated` event for the asset that just bound.
+    pub async fn ensure_stack_stub(
+        &self,
+        stack_id: &str,
+        primary_fallback: &MediaId,
+    ) -> Result<(), LibraryError> {
+        self.repo
+            .ensure_stack_stub(stack_id, primary_fallback)
+            .await
+    }
+
+    /// Sync-only: bind a media row to a stack. Emits
+    /// `MediaEvent::Updated` for the bound asset so the grid
+    /// reconciles (non-primary members get filtered out via
+    /// `get_many`'s primary-only clause).
+    pub async fn set_media_stack_id(
+        &self,
+        media_id: &MediaId,
+        stack_id: &str,
+    ) -> Result<(), LibraryError> {
+        self.repo.set_media_stack_id(media_id, stack_id).await?;
+        self.emit(MediaEvent::Updated(vec![media_id.clone()]));
+        Ok(())
+    }
+
+    /// Sync-only: clear a media row's stack pointer (the asset was
+    /// un-stacked server-side). Emits `MediaEvent::Updated` so the
+    /// asset reappears in the un-stacked grid.
+    pub async fn clear_media_stack_id(&self, media_id: &MediaId) -> Result<(), LibraryError> {
+        self.repo.clear_media_stack_id(media_id).await?;
+        self.emit(MediaEvent::Updated(vec![media_id.clone()]));
+        Ok(())
+    }
+
+    /// Sync-only: bump a stack's heartbeat. See issue #628.
+    pub async fn bump_stack_last_seen_at(
+        &self,
+        stack_id: &str,
+        now: i64,
+    ) -> Result<(), LibraryError> {
+        self.repo.bump_stack_last_seen_at(stack_id, now).await
+    }
+
+    /// Sync-only: delete a single stack by id (matches the
+    /// `SyncStackDeleteV1` ingress path). Emits `MediaEvent::Updated`
+    /// for every member that was bound at delete time so they
+    /// reappear in the un-stacked grid.
+    pub async fn delete_stack(&self, stack_id: &str) -> Result<(), LibraryError> {
+        let members = self.repo.list_stack_members(stack_id).await?;
+        self.repo.delete_stack(stack_id).await?;
+        if !members.is_empty() {
+            self.emit(MediaEvent::Updated(members));
+        }
+        Ok(())
+    }
+
+    /// Sync-only: stack ids whose heartbeat lags the checkpoint.
+    pub async fn ids_with_stale_stack_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<String>, LibraryError> {
+        self.repo.ids_with_stale_stack_heartbeat(checkpoint).await
+    }
+
+    /// Sync-only: delete stale stacks. Returns the removed stack ids
+    /// for logging. Members are rejoined to the un-stacked timeline
+    /// in the same transaction as the row delete. Emits
+    /// `MediaEvent::Updated` for every member that was bound at
+    /// sweep time so they reappear in the un-stacked grid.
+    pub async fn delete_stacks_with_stale_heartbeat(
+        &self,
+        checkpoint: i64,
+    ) -> Result<Vec<String>, LibraryError> {
+        let stale = self.repo.ids_with_stale_stack_heartbeat(checkpoint).await?;
+        let mut affected_members: Vec<MediaId> = Vec::new();
+        for stack_id in &stale {
+            affected_members.extend(self.repo.list_stack_members(stack_id).await?);
+        }
+        let removed = self
+            .repo
+            .delete_stacks_with_stale_heartbeat(checkpoint)
+            .await?;
+        if !affected_members.is_empty() {
+            self.emit(MediaEvent::Updated(affected_members));
+        }
+        Ok(removed)
     }
 }
 
@@ -471,6 +599,147 @@ mod tests {
             MediaEvent::Updated(ids) => assert_eq!(ids, &[local_id]),
             other => panic!("expected Updated; got {other:?}"),
         }
+    }
+
+    /// Issue #224: `upsert_stack` must emit `MediaEvent::Updated` for
+    /// every current member of the stack so a primary swap reflects
+    /// in tracked grid models without a restart.
+    #[tokio::test]
+    async fn upsert_stack_emits_updated_for_all_members() {
+        let (_dir, svc) = make_service().await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling = MediaId::new("b".repeat(64));
+        for (id, name) in [(&primary, "p.jpg"), (&sibling, "s.jpg")] {
+            svc.insert_media(&record_with_taken_at(id.clone(), name, None))
+                .await
+                .unwrap();
+        }
+        // Set up the stacks row first so the FK is satisfied when we
+        // bind members.
+        svc.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        svc.set_media_stack_id(&primary, "stk").await.unwrap();
+        svc.set_media_stack_id(&sibling, "stk").await.unwrap();
+
+        // Subscribe AFTER seeding so the Added/Updated noise from
+        // setup doesn't leak into the assertion.
+        let mut rx = svc.subscribe();
+        // Re-upsert with a new primary — the case we actually care
+        // about (primary swap should reflect in grid models).
+        svc.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: sibling.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+
+        let events = drain(&mut rx).await;
+        let updated_ids: Vec<MediaId> = events
+            .iter()
+            .flat_map(|e| match e {
+                MediaEvent::Updated(ids) => ids.clone(),
+                _ => Vec::new(),
+            })
+            .collect();
+        assert!(
+            updated_ids.contains(&primary) && updated_ids.contains(&sibling),
+            "upsert_stack must emit Updated for both members; got {updated_ids:?}"
+        );
+    }
+
+    /// Issue #224: `delete_stack` must emit `MediaEvent::Updated` for
+    /// every member so they reappear in the un-stacked grid.
+    #[tokio::test]
+    async fn delete_stack_emits_updated_for_freed_members() {
+        let (_dir, svc) = make_service().await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling = MediaId::new("b".repeat(64));
+        for (id, name) in [(&primary, "p.jpg"), (&sibling, "s.jpg")] {
+            svc.insert_media(&record_with_taken_at(id.clone(), name, None))
+                .await
+                .unwrap();
+        }
+        svc.upsert_stack(&Stack {
+            id: "doomed".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        svc.set_media_stack_id(&primary, "doomed").await.unwrap();
+        svc.set_media_stack_id(&sibling, "doomed").await.unwrap();
+
+        let mut rx = svc.subscribe();
+        svc.delete_stack("doomed").await.unwrap();
+
+        let events = drain(&mut rx).await;
+        let updated_ids: Vec<MediaId> = events
+            .iter()
+            .flat_map(|e| match e {
+                MediaEvent::Updated(ids) => ids.clone(),
+                _ => Vec::new(),
+            })
+            .collect();
+        assert!(
+            updated_ids.contains(&primary) && updated_ids.contains(&sibling),
+            "delete_stack must emit Updated for both members; got {updated_ids:?}"
+        );
+    }
+
+    /// Issue #224: deleting a stack primary must emit `Updated` for
+    /// the surviving siblings whose `stack_id` was cleared by the FK
+    /// cascade — otherwise the live grid stays out of sync.
+    #[tokio::test]
+    async fn delete_permanently_emits_updated_for_freed_siblings() {
+        let (_dir, svc) = make_service().await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling = MediaId::new("b".repeat(64));
+        for (id, name) in [(&primary, "p.jpg"), (&sibling, "s.jpg")] {
+            svc.insert_media(&record_with_taken_at(id.clone(), name, None))
+                .await
+                .unwrap();
+        }
+        svc.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: primary.clone(),
+            last_seen_at: 0,
+        })
+        .await
+        .unwrap();
+        svc.set_media_stack_id(&primary, "stk").await.unwrap();
+        svc.set_media_stack_id(&sibling, "stk").await.unwrap();
+
+        let mut rx = svc.subscribe();
+        svc.delete_permanently_no_record(std::slice::from_ref(&primary))
+            .await
+            .unwrap();
+
+        let events = drain(&mut rx).await;
+        let mut saw_removed = false;
+        let mut saw_updated_sibling = false;
+        for e in &events {
+            match e {
+                MediaEvent::Removed(ids) if ids.as_slice() == std::slice::from_ref(&primary) => {
+                    saw_removed = true
+                }
+                MediaEvent::Updated(ids) if ids.contains(&sibling) => saw_updated_sibling = true,
+                _ => {}
+            }
+        }
+        assert!(saw_removed, "expected Removed for primary; got {events:?}");
+        assert!(
+            saw_updated_sibling,
+            "expected Updated for sibling whose stack_id was cleared by cascade; got {events:?}"
+        );
     }
 
     /// Re-syncing an asset that already exists by id emits a single

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -127,8 +127,10 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
     // Issue #224: reflect server-side stack membership locally. The
     // matching `SyncStackV1` (carrying the primary asset id) arrives
     // on its own stream and is handled by `StackHandler` — here we
-    // just record the asset's `stackId` pointer.
-    apply_stack_membership(asset.stack_id.as_deref(), &media_id, ctx).await?;
+    // just record the asset's `stackId` pointer. `now` is shared
+    // with the stub heartbeat so a same-cycle reset sweep doesn't
+    // delete a stub that hasn't yet seen its real StackV1.
+    apply_stack_membership(asset.stack_id.as_deref(), &media_id, ctx, now).await?;
 
     if let Err(e) = download_thumbnail(
         &ctx.client,
@@ -161,10 +163,14 @@ async fn apply_stack_membership(
     stack_id: Option<&str>,
     media_id: &MediaId,
     ctx: &SyncContext,
+    now: i64,
 ) -> Result<(), LibraryError> {
     match stack_id {
         Some(id) => {
-            ctx.library.media().ensure_stack_stub(id, media_id).await?;
+            ctx.library
+                .media()
+                .ensure_stack_stub(id, media_id, now)
+                .await?;
             ctx.library.media().set_media_stack_id(media_id, id).await
         }
         None => ctx.library.media().clear_media_stack_id(media_id).await,

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -124,6 +124,12 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
         .bump_last_seen_at(&media_id, now)
         .await?;
 
+    // Issue #224: reflect server-side stack membership locally. The
+    // matching `SyncStackV1` (carrying the primary asset id) arrives
+    // on its own stream and is handled by `StackHandler` — here we
+    // just record the asset's `stackId` pointer.
+    apply_stack_membership(asset.stack_id.as_deref(), &media_id, ctx).await?;
+
     if let Err(e) = download_thumbnail(
         &ctx.client,
         &ctx.library,
@@ -137,6 +143,32 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
     }
 
     Ok(())
+}
+
+/// Bind or clear the asset's `media.stack_id` pointer based on
+/// `AssetV1.stackId`. The authoritative `stacks` row is upserted by
+/// `StackHandler` on the `StackV1` stream, not here — `AssetV1` and
+/// `StackV1` arrive independently and may interleave in any order.
+///
+/// FK on `media.stack_id REFERENCES stacks(id)` is enforced
+/// (`PRAGMA foreign_keys` is on by default in sqlx 0.8), so we
+/// can't bind to a non-existent stack. If the matching `StackV1`
+/// hasn't arrived, we create a stub `stacks` row pointing at the
+/// current asset as a placeholder primary; `StackV1` later
+/// overwrites the primary via `upsert_stack`'s ON CONFLICT clause.
+#[instrument(skip(ctx))]
+async fn apply_stack_membership(
+    stack_id: Option<&str>,
+    media_id: &MediaId,
+    ctx: &SyncContext,
+) -> Result<(), LibraryError> {
+    match stack_id {
+        Some(id) => {
+            ctx.library.media().ensure_stack_stub(id, media_id).await?;
+            ctx.library.media().set_media_stack_id(media_id, id).await
+        }
+        None => ctx.library.media().clear_media_stack_id(media_id).await,
+    }
 }
 
 pub struct AssetDeleteHandler;

--- a/src/sync/providers/immich/handlers/mod.rs
+++ b/src/sync/providers/immich/handlers/mod.rs
@@ -10,6 +10,7 @@ mod asset;
 mod asset_exif;
 mod asset_face;
 mod person;
+mod stack;
 mod sync_lifecycle;
 
 use std::path::PathBuf;
@@ -34,6 +35,8 @@ pub use asset_face::AssetFaceDeleteHandler;
 pub use asset_face::AssetFaceHandler;
 pub use person::PersonDeleteHandler;
 pub use person::PersonHandler;
+pub use stack::StackDeleteHandler;
+pub use stack::StackHandler;
 pub use sync_lifecycle::SyncCompleteHandler;
 pub use sync_lifecycle::SyncResetHandler;
 
@@ -98,5 +101,7 @@ pub fn all_handlers() -> Vec<Box<dyn SyncEntityHandler>> {
         Box::new(PersonDeleteHandler),
         Box::new(AssetFaceHandler),
         Box::new(AssetFaceDeleteHandler),
+        Box::new(StackHandler),
+        Box::new(StackDeleteHandler),
     ]
 }

--- a/src/sync/providers/immich/handlers/stack.rs
+++ b/src/sync/providers/immich/handlers/stack.rs
@@ -1,0 +1,93 @@
+use async_trait::async_trait;
+use tracing::{instrument, warn};
+
+use crate::library::error::LibraryError;
+use crate::library::media::Stack;
+
+use super::{CounterKind, HandlerResult, SyncContext, SyncEntityHandler};
+use crate::sync::providers::immich::types::*;
+
+pub struct StackHandler;
+
+#[async_trait]
+impl SyncEntityHandler for StackHandler {
+    fn entity_type(&self) -> &'static str {
+        "StackV1"
+    }
+
+    async fn handle(
+        &self,
+        data: &serde_json::Value,
+        line_number: usize,
+        ctx: &SyncContext,
+    ) -> Result<HandlerResult, LibraryError> {
+        let stack: SyncStackV1 = deserialize_entity(data, "StackV1", line_number)?;
+        handle_stack(stack, ctx).await?;
+        Ok(HandlerResult {
+            audit_action: "upsert",
+            counter: CounterKind::None,
+        })
+    }
+}
+
+/// Upsert the stack row carrying its primary asset id.
+///
+/// `AssetV1.stackId` (handled separately by `AssetHandler`) records
+/// only membership; the primary lives here. If the primary's local
+/// row hasn't streamed yet we warn-and-skip — the next pull cycle
+/// re-emits the `StackV1` once the primary is local. This is the
+/// only place we translate the Immich primary UUID into the local
+/// `MediaId`.
+#[instrument(skip(ctx, stack), fields(stack_id = %stack.id))]
+async fn handle_stack(stack: SyncStackV1, ctx: &SyncContext) -> Result<(), LibraryError> {
+    let Some(primary_local) = ctx
+        .library
+        .media()
+        .id_by_external_id(&stack.primary_asset_id)
+        .await?
+    else {
+        warn!(
+            primary_external_id = %stack.primary_asset_id,
+            "stack primary not yet local; skipping upsert (will retry next cycle)"
+        );
+        return Ok(());
+    };
+
+    let now = chrono::Utc::now().timestamp();
+    ctx.library
+        .media()
+        .upsert_stack(&Stack {
+            id: stack.id.clone(),
+            primary_asset_id: primary_local,
+            last_seen_at: now,
+        })
+        .await?;
+    ctx.library
+        .media()
+        .bump_stack_last_seen_at(&stack.id, now)
+        .await?;
+    Ok(())
+}
+
+pub struct StackDeleteHandler;
+
+#[async_trait]
+impl SyncEntityHandler for StackDeleteHandler {
+    fn entity_type(&self) -> &'static str {
+        "StackDeleteV1"
+    }
+
+    async fn handle(
+        &self,
+        data: &serde_json::Value,
+        line_number: usize,
+        ctx: &SyncContext,
+    ) -> Result<HandlerResult, LibraryError> {
+        let del: SyncStackDeleteV1 = deserialize_entity(data, "StackDeleteV1", line_number)?;
+        ctx.library.media().delete_stack(&del.stack_id).await?;
+        Ok(HandlerResult {
+            audit_action: "delete",
+            counter: CounterKind::Deletes,
+        })
+    }
+}

--- a/src/sync/providers/immich/handlers/stack.rs
+++ b/src/sync/providers/immich/handlers/stack.rs
@@ -59,7 +59,6 @@ async fn handle_stack(stack: SyncStackV1, ctx: &SyncContext) -> Result<(), Libra
         .upsert_stack(&Stack {
             id: stack.id.clone(),
             primary_asset_id: primary_local,
-            last_seen_at: now,
         })
         .await?;
     ctx.library

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -151,6 +151,10 @@ impl PullManager {
                 "AlbumToAssetsV1".to_string(),
                 "PeopleV1".to_string(),
                 "AssetFacesV1".to_string(),
+                // Issue #224: stacks arrive on their own stream as
+                // SyncStackV1 / SyncStackDeleteV1. AssetV1 carries
+                // only `stackId`; the primary lives on StackV1.
+                "StacksV1".to_string(),
             ],
         };
 
@@ -342,6 +346,22 @@ impl PullManager {
                 info!(
                     count = album_orphans.len(),
                     "removing orphaned albums after reset sync"
+                );
+            }
+
+            // Issue #224: stacks join the heartbeat sweep as the fifth
+            // participating table. Members rejoin the un-stacked
+            // timeline automatically via `media.stack_id`'s
+            // `ON DELETE SET NULL` FK (migration 023).
+            let stack_orphans = self
+                .library
+                .media()
+                .delete_stacks_with_stale_heartbeat(checkpoint)
+                .await?;
+            if !stack_orphans.is_empty() {
+                info!(
+                    count = stack_orphans.len(),
+                    "removing orphaned stacks after reset sync"
                 );
             }
 

--- a/src/sync/providers/immich/types.rs
+++ b/src/sync/providers/immich/types.rs
@@ -54,6 +54,45 @@ pub(crate) struct SyncAssetV1 {
     /// deserialisation; when absent, sync rows still work but won't
     /// participate in cross-origin dedup.
     pub checksum: Option<String>,
+    /// Identifier of the stack this asset belongs to, or `None` when
+    /// not stacked. The matching `SyncStackV1` event carries the
+    /// primary asset id and arrives independently in the stream — we
+    /// just record the pointer here. Immich re-emits the asset
+    /// whenever the stack relationship changes. Issue #224.
+    #[serde(rename = "stackId", default)]
+    pub stack_id: Option<String>,
+    /// Whether the asset has any geometric edits applied via
+    /// `PUT /assets/{id}/edits`. Pixel-adjustment edits surface as a
+    /// separate stacked rendered child rather than via this flag.
+    /// Issue #224. Optional for forward/backward compat with servers
+    /// that pre-date the edits API.
+    ///
+    /// Consumed in Phase D (recovery): on editor open we use this in
+    /// combination with the `moments-edit` tag to detect "stack with a
+    /// Moments-rendered child but no local edits row" and rebuild the
+    /// edit state from XMP.
+    #[allow(dead_code)] // wired into Phase A for the contract; consumed in Phase D
+    #[serde(rename = "isEdited", default)]
+    pub is_edited: Option<bool>,
+}
+
+/// Stack entity emitted on the `StacksV1` sync stream. Carries the
+/// primary asset id for stacks the local library has subscribed to.
+/// Issue #224.
+#[derive(Debug, Deserialize)]
+pub(crate) struct SyncStackV1 {
+    pub id: String,
+    #[serde(rename = "primaryAssetId")]
+    pub primary_asset_id: String,
+}
+
+/// Stack-deletion entity. Emitted when a stack is removed server-side
+/// (typically because the user un-stacked the assets, or the count
+/// dropped below 2 and Immich auto-collapsed it). Issue #224.
+#[derive(Debug, Deserialize)]
+pub(crate) struct SyncStackDeleteV1 {
+    #[serde(rename = "stackId")]
+    pub stack_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -329,6 +368,95 @@ mod tests {
         });
         let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
         assert!(asset.checksum.is_none());
+    }
+
+    /// Issue #224: `AssetV1` carries flat `stackId` (not a nested
+    /// object). The matching `SyncStackV1` event carries the primary.
+    #[test]
+    fn deserialize_sync_asset_v1_with_stack_id() {
+        let json = serde_json::json!({
+            "id": "asset-uuid",
+            "originalFileName": "burst.jpg",
+            "fileCreatedAt": "2024-06-15T10:30:00.000Z",
+            "localDateTime": null,
+            "type": "IMAGE",
+            "deletedAt": null,
+            "isFavorite": false,
+            "width": null,
+            "height": null,
+            "duration": null,
+            "stackId": "stack-uuid",
+            "isEdited": true
+        });
+        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        assert_eq!(asset.stack_id.as_deref(), Some("stack-uuid"));
+        assert_eq!(asset.is_edited, Some(true));
+    }
+
+    /// `stackId` is `null` when the asset is not in a stack.
+    #[test]
+    fn deserialize_sync_asset_v1_with_null_stack_id() {
+        let json = serde_json::json!({
+            "id": "asset-uuid",
+            "originalFileName": "lone.jpg",
+            "fileCreatedAt": "2024-06-15T10:30:00.000Z",
+            "localDateTime": null,
+            "type": "IMAGE",
+            "deletedAt": null,
+            "isFavorite": false,
+            "width": null,
+            "height": null,
+            "duration": null,
+            "stackId": null,
+            "isEdited": false
+        });
+        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        assert!(asset.stack_id.is_none());
+        assert_eq!(asset.is_edited, Some(false));
+    }
+
+    /// Older Immich versions don't emit `stackId`/`isEdited` at all —
+    /// deserialisation must succeed and leave both fields `None`.
+    #[test]
+    fn deserialize_sync_asset_v1_without_stack_fields_is_optional() {
+        let json = serde_json::json!({
+            "id": "asset-old",
+            "originalFileName": "old.jpg",
+            "fileCreatedAt": "2024-01-01T00:00:00.000Z",
+            "localDateTime": null,
+            "type": "IMAGE",
+            "deletedAt": null,
+            "isFavorite": false,
+            "width": null,
+            "height": null,
+            "duration": null
+        });
+        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        assert!(asset.stack_id.is_none());
+        assert!(asset.is_edited.is_none());
+    }
+
+    /// Issue #224: `StackV1` events carry the stack's primary asset id.
+    #[test]
+    fn deserialize_sync_stack_v1() {
+        let json = serde_json::json!({
+            "id": "stack-uuid",
+            "primaryAssetId": "primary-uuid",
+            "ownerId": "owner-uuid",
+            "createdAt": "2024-01-01T00:00:00.000Z",
+            "updatedAt": "2024-01-02T00:00:00.000Z"
+        });
+        let stack: SyncStackV1 = serde_json::from_value(json).unwrap();
+        assert_eq!(stack.id, "stack-uuid");
+        assert_eq!(stack.primary_asset_id, "primary-uuid");
+    }
+
+    /// `StackDeleteV1` carries only the stack id.
+    #[test]
+    fn deserialize_sync_stack_delete_v1() {
+        let json = serde_json::json!({ "stackId": "stack-uuid" });
+        let del: SyncStackDeleteV1 = serde_json::from_value(json).unwrap();
+        assert_eq!(del.stack_id, "stack-uuid");
     }
 
     #[test]

--- a/src/ui/photo_grid/cell.blp
+++ b/src/ui/photo_grid/cell.blp
@@ -71,7 +71,7 @@ template $MomentsPhotoGridCell : Gtk.Widget {
       margin-end: 6;
       margin-top: 6;
       visible: false;
-      styles ["osd", "circular"]
+      styles ["osd"]
     }
   }
 }

--- a/src/ui/photo_grid/cell.blp
+++ b/src/ui/photo_grid/cell.blp
@@ -61,5 +61,17 @@ template $MomentsPhotoGridCell : Gtk.Widget {
       visible: false;
       styles ["osd", "caption", "pill"]
     }
+
+    [overlay]
+    Gtk.Image stack_badge {
+      icon-name: "edit-copy-symbolic";
+      pixel-size: 16;
+      halign: end;
+      valign: start;
+      margin-end: 6;
+      margin-top: 6;
+      visible: false;
+      styles ["osd", "circular"]
+    }
   }
 }

--- a/src/ui/photo_grid/cell.rs
+++ b/src/ui/photo_grid/cell.rs
@@ -14,6 +14,10 @@ pub struct CellBindings {
     item: glib::WeakRef<MediaItemObject>,
     texture_handler: glib::SignalHandlerId,
     favorite_handler: glib::SignalHandlerId,
+    /// Issue #224: stack-membership changes mid-bind (e.g. an un-stacked
+    /// primary acquiring siblings during sync) need to refresh the
+    /// stack badge live.
+    is_stacked_handler: glib::SignalHandlerId,
 }
 
 mod imp {
@@ -35,6 +39,8 @@ mod imp {
         pub days_label: TemplateChild<gtk::Label>,
         #[template_child]
         pub duration_label: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub stack_badge: TemplateChild<gtk::Image>,
 
         pub bindings: RefCell<Option<CellBindings>>,
         /// Whether to show the star button (false in Trash view).
@@ -43,6 +49,10 @@ mod imp {
         pub has_texture: Cell<bool>,
         /// Whether the item is currently favourited.
         pub is_favorited: Cell<bool>,
+        /// Whether the bound item is part of an asset stack. Set in
+        /// `update_stack_badge`, gating the badge's visibility from
+        /// `update_from_item` once a texture is ready.
+        pub is_stacked: Cell<bool>,
         /// Whether the grid is in selection mode (checkbox always visible).
         pub in_selection_mode: Cell<bool>,
         /// Click handler for the star button — connected in factory `bind`,
@@ -137,6 +147,7 @@ impl PhotoGridCell {
         self.update_star(item);
         self.update_days_remaining(item);
         self.update_duration(item);
+        self.update_stack_badge(item);
 
         let cell = self.clone();
         let texture_handler = item.connect_texture_notify(move |item| {
@@ -148,10 +159,16 @@ impl PhotoGridCell {
             cell.update_star(item);
         });
 
+        let cell = self.clone();
+        let is_stacked_handler = item.connect_is_stacked_notify(move |item| {
+            cell.update_stack_badge(item);
+        });
+
         *self.imp().bindings.borrow_mut() = Some(CellBindings {
             item: item.downgrade(),
             texture_handler,
             favorite_handler,
+            is_stacked_handler,
         });
     }
 
@@ -167,6 +184,7 @@ impl PhotoGridCell {
             if let Some(item) = b.item.upgrade() {
                 item.disconnect(b.texture_handler);
                 item.disconnect(b.favorite_handler);
+                item.disconnect(b.is_stacked_handler);
             }
         }
         imp.picture.set_paintable(None::<&gtk::gdk::Texture>);
@@ -177,8 +195,22 @@ impl PhotoGridCell {
         imp.checkbox.set_active(false);
         imp.days_label.set_visible(false);
         imp.duration_label.set_visible(false);
+        imp.stack_badge.set_visible(false);
         imp.has_texture.set(false);
         imp.is_favorited.set(false);
+        imp.is_stacked.set(false);
+    }
+
+    /// Toggle the "stacked" badge based on the item's `is_stacked`
+    /// property. Only shown once a texture is loaded — otherwise the
+    /// badge would float over the placeholder, which looks wrong.
+    /// Issue #224.
+    fn update_stack_badge(&self, item: &MediaItemObject) {
+        let imp = self.imp();
+        let stacked = item.is_stacked();
+        imp.is_stacked.set(stacked);
+        imp.stack_badge
+            .set_visible(stacked && imp.has_texture.get());
     }
 
     fn update_duration(&self, item: &MediaItemObject) {
@@ -290,12 +322,16 @@ impl PhotoGridCell {
             if imp.show_star.get() && imp.is_favorited.get() {
                 imp.star_btn.set_visible(true);
             }
+            if imp.is_stacked.get() {
+                imp.stack_badge.set_visible(true);
+            }
         } else {
             imp.picture.set_paintable(None::<&gtk::gdk::Texture>);
             imp.picture.set_visible(false);
             imp.placeholder.set_visible(true);
             imp.has_texture.set(false);
             imp.star_btn.set_visible(false);
+            imp.stack_badge.set_visible(false);
         }
     }
 }

--- a/tests/baseline_event_wiring.rs
+++ b/tests/baseline_event_wiring.rs
@@ -32,6 +32,7 @@ fn test_item(id: &str) -> MediaItem {
         is_trashed: false,
         trashed_at: None,
         duration_ms: None,
+        stack_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary
- Phase A of the Immich edit-sync build spec (`docs/design-immich-edit-sync.md`). Models Immich asset stacks locally and collapses them to their primary in every grid view.
- Pull-side stack ingestion via two coordinated streams (`AssetV1.stackId` for membership, `StackV1`/`StackDeleteV1` for the stack row); heartbeat sweep; primary-only grid filter; live-update event plumbing; stack badge on the photo grid cell.
- Phases B (geometric edits via `PUT /assets/{id}/edits`), C (pixel-adjustment edits via render+stack+tag+XMP), and D (recovery) follow in separate PRs.

## What's in scope
- **Schema**: migrations 023 (stacks table + `media.stack_id` FK) and 024 (`edits.server_rendered_asset_id`, `xmp_edit_version`).
- **Domain**: `Stack` model, `MediaRepository` stack methods (`upsert_stack`, `set/clear_media_stack_id`, `bump_stack_last_seen_at`, `ids_with_stale_stack_heartbeat`, `delete_stacks_with_stale_heartbeat`, `delete_stack`, `ensure_stack_stub`, `siblings_freed_by_deletion`, `list_stack_members`), and matching `MediaService` accessors.
- **Sync**: `SyncAssetV1` deserialises flat `stackId` and `isEdited` (latter consumed in Phase D). New `SyncStackV1`/`SyncStackDeleteV1` types. New `StackHandler`/`StackDeleteHandler` registered. Subscribed to `"StacksV1"` in the sync request types. Stale-stack sweep slotted into `pull.rs::finish_sync` between albums and people.
- **FK ordering**: AssetV1 may arrive before its StackV1; `apply_stack_membership` calls `ensure_stack_stub` to satisfy the FK with the bound asset as a placeholder primary. Real `StackV1` later overwrites via `upsert_stack`'s ON CONFLICT.
- **Grid filter**: primary-only `LEFT JOIN stacks` clause on `MediaRepository::list`, `get_many`, `AlbumRepository::list_media`, `FacesRepository::list_media_for_person`.
- **UI**: `MediaItem.stack_id`, `MediaItemObject::is_stacked` GObject property, stack badge overlay (`edit-copy-symbolic`, top-right) on photo grid cells, live `notify::is-stacked` listener.
- **Live updates**: `MediaService` stack mutators emit `MediaEvent::Updated`; `upsert_stack` and `delete_stack` fan out to all members; `delete_permanently[_no_record]` captures freed siblings before delete so AssetDelete-of-primary live-updates the grid via the FK cascade.

## Out of scope (deliberate)
- Click-to-expand siblings UI — separate issue.
- Phase B/C/D push paths.
- Replacing `design-photo-editing.md` §5 — pencilled in for the final Phase D PR.

## Implementation notes
- **FK enforcement is ON** (sqlx 0.8 default per connection). Cascade declarations in migration 023 fire automatically; the explicit `UPDATE … SET stack_id = NULL` in `delete_stack` and `delete_stacks_with_stale_heartbeat` is defensive belt-and-braces.
- **Spec doc corrections**: the original spec described the wrong wire shape for `AssetV1` (claimed nested `stack` — actually flat `stackId`) and the wrong shape for `SyncAssetEditV1` (claimed batched `edits[]` — actually one event per action with `sequence`). Corrected in §4.1, §4.2, §3.1, §3.3 with explicit "earlier draft was wrong" callouts.
- **Order independence**: `AssetV1` and `StackV1` arrive in arbitrary order across the sync stream. Stub-then-bind handles AssetV1-first; if StackV1 arrives first, it just upserts and the AssetV1 sets `media.stack_id` later normally. Documented in spec doc §4.1.

## Test plan
- [x] `make lint` clean.
- [x] `make test` — 535/535 pass, including 11 new tests covering: stack upsert idempotency, stale sweep with member rejoin, primary-only filter, stub-then-bind ordering, member clearing, isolated FK cascade behaviour, `siblings_freed_by_deletion` correctness, `upsert_stack` event fan-out, `delete_stack` event fan-out, AssetDelete-of-primary live-update, and `SyncAssetV1`/`SyncStackV1`/`SyncStackDeleteV1` deserialisation.
- [x] Manual against a live Immich v2.7.5: create a stack with 3 assets, swap primary, un-stack, delete a stack primary — all reflect in the Moments grid live within one sync cycle, no restart needed.

## Follow-up issues to file
- StackHandler module-level smoke tests (deserialise + warn-and-skip path).
- Stub primary-overwrite ordering covered end-to-end across the handler chain.
- Tighten the query+delete+emit pattern in `delete_stack` / `delete_stacks_with_stale_heartbeat` into a single transaction (theoretical race window; sync stream is currently serialised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)