### PR TITLE
feat(sync): pixel-adjustment edit sync via render+stack+tag+XMP (#224 Phase C)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,7 +1,0 @@
-[default.extend-words]
-# JPEG marker convention: APPn means APP0/APP1/.../APP15.
-# typos splits `APPn` into `AP` + `Pn` and flags `Pn` as a typo of `On`.
-pn = "pn"
-
-[default.extend-identifiers]
-APPn = "APPn"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,7 @@
+[default.extend-words]
+# JPEG marker convention: APPn means APP0/APP1/.../APP15.
+# typos splits `APPn` into `AP` + `Pn` and flags `Pn` as a typo of `On`.
+pn = "pn"
+
 [default.extend-identifiers]
 APPn = "APPn"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,2 +1,2 @@
-[default.extend-words]
-appn = "appn"
+[default.extend-identifiers]
+APPn = "APPn"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+appn = "appn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
  "libheif-rs",
  "libsecret",
  "lru",
+ "quick-xml",
  "rawler",
  "reqwest",
  "serde",
@@ -2557,6 +2558,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Serialisation
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
+# XMP read-back robustness — embedded edits in rendered JPEGs need to
+# survive Immich's media pipeline rewriting attributes/whitespace.
+# Encode is still hand-rolled for deterministic output.
+quick-xml = "0.39"
 
 # Image processing
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "tiff"] }

--- a/docs/design-immich-edit-sync.md
+++ b/docs/design-immich-edit-sync.md
@@ -24,7 +24,7 @@ The original is never replaced. Immich's "originals are sacred" architectural ru
 
 ## 2. Design summary
 
-> **Status of this document**: Phase A merged via #651. Phase B is implemented in `feat/224-immich-edits-phase-b` and **deviates from the §4 sketches in three deliberate ways** to simplify layering — see the "as-built" callouts in §4.2 / §4.3 / §4.4 and §7.1. Phases C and D remain as drafted. The "actual wire shape vs. earlier draft" callouts in §4.1 and §4.2 record corrections discovered while testing against a live Immich v2.7.5 instance and cross-checking against the upstream OpenAPI spec.
+> **Status of this document**: Phase A merged via #651. Phase B merged via #652 — deviates from the §4 sketches in three deliberate ways (see Phase B as-built callouts in §4.2 / §4.3 / §4.4 / §7.1). Phase C is implemented in `feat/224-immich-edits-phase-c` and lands the full pixel-adjustment path: render → upload → stack → tag → embed XMP, with the §8.2 grid override flipped on so the timeline surfaces the original. See Phase C as-built callouts in §4.3 / §4.4 / §7.2 / §7.3 / §8.2 for as-built notes (orchestration lives on `Library::save_pixel_edit` / `Library::revert_edit`; the UI client branches on `EditState::has_pixel_adjustments()`). Phase D (XMP-based recovery) remains as drafted. The "actual wire shape vs. earlier draft" callouts in §4.1 / §4.2 record corrections discovered while testing against a live Immich v2.7.5 instance and cross-checking against the upstream OpenAPI spec.
 >
 > **Phase B layering summary**: `Mutation::AssetEdits{Applied,Cleared}` are payload-free. `ImmichEditAction` lives in `src/sync/providers/immich/edit_action.rs` and never leaks into the library. The push handler reads the latest `EditState` from `EditingRepository::get_edit_state()` at drain time, projects to actions, and decides PUT vs. DELETE vs. skip — this is **latest-state read** (every wire call sends the final state, so no intermediate edit can leak past a later save), not coalescing (N saves still drive N round-trips; insert-side dedup would be a future enhancement). There is no `EditState::is_geometric_only()` predicate; `project()` returns `Option<Vec<ImmichEditAction>>` and `None` is the "Phase C territory" signal.
 
@@ -326,6 +326,8 @@ OutboxMutation::AssetUntaggedMomentsEdit { id } => {
 
 `ensure_moments_edit_tag` calls `PUT /tags { tags: ["moments-edit"] }` (idempotent), caches the tag id in memory for the push session, and re-derives on cache miss.
 
+> **As-built (#224 Phase C)** — implemented largely as drafted; `ensure_moments_edit_tag` lives on `PushManager` with a `Mutex<Option<String>>` cache. Two notable wire-shape findings from the §10.3 probe pass: `POST /tags { name }` returns **400** on existing tags (rejected), so we use `PUT /tags { tags: [...] }` exclusively. `delete_stack_member` returns **204** and leaves the stack record with a single member; the surviving sibling's `stackId` is cleared on the asset row, and local cleanup completes via the next pull cycle's heartbeat reconciliation. The stack-create response is `{ id, primaryAssetId, assets: [...] }`; we use `id` for `persist_stack_locally` and defensively check `primary_asset_id` matches what we expected (Immich convention: first id in `assetIds` becomes primary). `require_media_external_id` is a strict variant of `lookup_media_external_id` that errors when `external_id` is null — Phase C push arms use it so `StackCreated` / `AssetTaggedMomentsEdit` automatically retry via outbox backoff until `AssetImported` drains.
+
 ---
 
 ## 5. XMP specification
@@ -474,6 +476,8 @@ Triggered when `EditState::has_pixel_adjustments()` returns true.
 
 The "delete old render, upload new render" sequence ensures at most one rendered sibling per photo. Step 6 is skipped on the first edit.
 
+> **As-built (#224 Phase C)** — implemented as `Library::save_pixel_edit(original_id, state, rendered_bytes)`. The UI layer (`MediaClientV2::save_edit_state`) branches on `EditState::has_pixel_adjustments()` and runs the render + JPEG encode on a Tokio blocking thread before calling into Library. Library owns XMP encode + inject (so the original's `external_id` / `content_hash` never have to leak into the UI), generates the rendered `MediaId`, writes the bytes to the standard sharded originals layout, and inserts the rendered `media` row (which records `AssetImported` via the existing media-service path). All four mutations (`AssetImported`, `StackCreated`, `AssetTaggedMomentsEdit`, plus the prior-render cleanup tuple) are enqueued at save time — the push manager's existing outbox retry handles the `AssetImported → external_id → StackCreated` dependency (the strict `require_media_external_id` errors and the backoff cycles the entry until the upload completes; ordering by outbox row id keeps the steps in sequence on the happy path). **Erroring case**: if the original isn't yet on the server (no `external_id`), `save_pixel_edit` returns an error — Phase D recovery depends on a stable `originalAssetId` in the XMP, so silently saving without it would break recoverability.
+
 ### 7.3 Revert
 
 ```
@@ -485,6 +489,8 @@ The "delete old render, upload new render" sequence ensures at most one rendered
 3. Delete local edits row.
 4. UI: navigate back to original (it surfaces in the timeline as the stack auto-collapses).
 ```
+
+> **As-built (#224 Phase C)** — implemented as `Library::revert_edit(original_id)`. The flow is: look up the rendered sibling via `editing.server_rendered_asset_id`; if non-null, enqueue `StackMemberRemoved` (skipped when `media.stack_id` is null — `StackCreated` hadn't drained yet) + `AssetUntaggedMomentsEdit`, then call `Library::delete_permanently` for the rendered asset (which records `AssetDeleted` and cleans up the local file). Finally records `AssetEditsCleared` for the original as belt-and-braces against any geometric-only state that was previously pushed via the Phase B path (idempotent: Immich `DELETE /assets/{id}/edits` returns 204 even when no edits exist). UI navigation (step 4) is handled by the existing client signal flow when the original surfaces in the grid as the stack collapses.
 
 ### 7.4 Recovery (Phase D)
 
@@ -542,33 +548,31 @@ The Phase A primary-only rule is correct for Immich-native stacks (panoramas, bu
 
 The local `edits` table remains the source of truth for what edit was applied. The server-side render is a sync artifact, not a first-class user-visible asset.
 
-**Resolution (to land in Phase C):**
+**Resolution (Phase C, as-built #224):**
 
-The grid filter swaps "primary" for "non-Moments-render member" when a Moments-edit-tagged member is present in the stack. Concretely, on top of the §8.1 clause:
+Migration `026_add_media_is_moments_render.sql` adds an `is_moments_render INTEGER NOT NULL DEFAULT 0` column on `media`. Phase C save sets it to `1` when inserting the rendered media row; a future pull-side change will toggle it based on the asset's `tags[]` (when tag sync lands as part of Phase D).
 
-1. Sync the `tags[]` field from `AssetV1` (Phase C work — Phase A doesn't touch tags).
-2. Hydrate `is_moments_render: bool` on `MediaItem` (true iff the asset carries the `moments-edit` tag — see §6).
-3. Extend the grid filter so a stack containing a Moments-render member surfaces the **other** sibling (the original), not the server's primary. Sketch:
+The grid filter in `MediaRepository::list`, `get_many`, and the per-album / per-person queries got the §8.2 extension:
 
-   ```sql
-   LEFT JOIN stacks s ON m.stack_id = s.id
-   LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
-   WHERE (
-     s.id IS NULL                                    -- not stacked → show
-     OR (render.id IS NULL                            -- ordinary stack → use server primary
-         AND s.primary_asset_id = m.id)
-     OR (render.id IS NOT NULL                        -- Moments-edit stack → surface
-         AND m.id != render.id                        --   the non-render sibling, regardless
-         AND m.stack_id = s.id)                       --   of which one is server-primary
-   )
-   ```
+```sql
+LEFT JOIN stacks s ON m.stack_id = s.id
+LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
+WHERE (
+  s.id IS NULL                                    -- not stacked → show
+  OR (render.id IS NULL                            -- ordinary stack → use server primary
+      AND s.primary_asset_id = m.id)
+  OR (render.id IS NOT NULL                        -- Moments-edit stack → surface the
+      AND m.is_moments_render = 0)                 --   non-render sibling
+)
+```
 
-4. Thumbnail and viewer paths render the original through `RenderPipeline` with the local `edits` row applied — the same on-the-fly edit pipeline already used for local-only edits today. The rendered JPEG asset is never user-visible inside Moments; it's strictly a sync artifact.
-5. Re-opening the editor loads the local `edits` row, not the rendered bytes. (Phase D recovery is the only path that ever parses the rendered JPEG's XMP — to rebuild a missing local `edits` row.)
+The final form is slightly tighter than the draft sketch: instead of `m.id != render.id AND m.stack_id = s.id`, we use `m.is_moments_render = 0`. Because the `render` join only matches rows with `is_moments_render = 1`, the WHERE clause's third branch implicitly excludes the rendered child via the column on `m` itself, with no second equality check needed.
 
-**Why option (a) over option (b)**: keeping the rule "filter on a property of `MediaItem` (the tag flag)" aligns with how every other filter in the project works — in-memory `MediaFilter::matches` style. The alternative (don't bind originals to Moments-edit stacks at all locally) requires the grid query to know about a sync-internal concept, which leaks abstraction. The tag-driven override is more localised.
+Thumbnail and viewer paths render the original through `RenderPipeline` with the local `edits` row applied — the same on-the-fly edit pipeline already used for local-only edits today. The rendered JPEG asset is never user-visible inside Moments; it's strictly a sync artifact.
 
-**Does Phase A need to change to make Phase C work?** No. Phase A is generic stack plumbing; the Phase C override is additive — a tag-based filter exception layered on the existing primary-only clause.
+Re-opening the editor loads the local `edits` row, not the rendered bytes. (Phase D recovery is the only path that ever parses the rendered JPEG's XMP — to rebuild a missing local `edits` row.)
+
+**Does Phase A need to change to make Phase C work?** No. Phase A's primary-only rule is preserved as the second WHERE branch; Phase C just adds the third branch on top.
 
 ---
 
@@ -616,19 +620,25 @@ Acceptance: cropping a photo in the Moments editor + save → photo appears crop
 
 ### Phase C — pixel-adjustment edits via render+stack+tag+XMP
 
-Depends on Phase A (stacks model).
+Depends on Phase A (stacks model). Independent of Phase B.
 
-- [ ] `src/renderer/xmp.rs` encoder/decoder
-- [ ] JPEG APP1 segment injection in render pipeline output
-- [ ] `Mutation::StackCreated`, `StackMemberRemoved`, `AssetTaggedMomentsEdit`, `AssetUntaggedMomentsEdit` variants
-- [ ] `OutboxMutation::from_row` decoders
-- [ ] `PushManager::push_one` arms (§4.4) and `ensure_moments_edit_tag` helper
-- [ ] `EditState::has_pixel_adjustments()` predicate
-- [ ] Editor save flow §7.2 (two-step delete-then-upload)
-- [ ] Editor revert flow §7.3
-- [ ] Tests: XMP roundtrip, save → render → upload → stack → tag end-to-end (mocked HTTP), revert
+- [x] §10.3 probes resolved — `PUT /tags { tags: [...] }` idempotent, `POST /tags { name }` 400s on existing tags (use PUT exclusively); `POST /stacks { assetIds }` returns `{id, primaryAssetId, assets}`; `DELETE /stacks/{id}/assets/{aid}` returns 204; **§11.2 XMP-strip question resolved: XMP block survives upload+download bit-exactly on v2.7.5** — Phase D recovery is viable.
+- [x] `src/renderer/xmp.rs` encoder/decoder + JPEG APP1 walker (skips past existing EXIF segment); 13 tests including bit-exact roundtrip
+- [x] `Mutation::StackCreated`, `StackMemberRemoved`, `AssetTaggedMomentsEdit`, `AssetUntaggedMomentsEdit` variants + outbox round-trips
+- [x] `OutboxMutation::from_row` decoders + tests
+- [x] `ImmichClient` typed wrappers: `post_stack`, `delete_stack_member`, `ensure_tags`, `add_assets_to_tag`, `remove_assets_from_tag`
+- [x] `PushManager::push_one` arms (§4.4) + `ensure_moments_edit_tag` helper with `Mutex<Option<String>>` session cache + `persist_stack_locally` + strict `require_media_external_id`
+- [x] `EditState::has_pixel_adjustments()` predicate (domain method; routes UI between Phase B and Phase C save paths) + tests
+- [x] `migrations/026_add_media_is_moments_render.sql` + column on `media` row / `MediaItem` / `MediaRecord`
+- [x] `Library::save_pixel_edit` orchestrator (§7.2) — UI client renders + JPEG-encodes; Library handles XMP encode/inject + sharded write + media-row insert + mutation sequence
+- [x] `Library::revert_edit` orchestrator (§7.3) — stack/tag/delete cleanup + AssetEditsCleared as belt-and-braces
+- [x] `MediaClientV2::save_edit_state` / `revert_edits` branch on `has_pixel_adjustments`
+- [x] §8.2 grid filter override (`is_moments_render` exception) applied to `MediaRepository::list`, `get_many`, the album per-album queries, and the faces `list_media_for_person`
+- [x] Unit tests: XMP roundtrip + APP1 walker, push helpers (`require_media_external_id`, `persist_stack_locally`), library orchestrators (`save_pixel_edit_*`, `revert_edit_*`), grid filter (Moments-edit and ordinary stack cases)
 
-Acceptance: applying a vignette in the Moments editor + save → original photo gets stacked with a new rendered asset on Immich; the rendered asset is primary, has `moments-edit` tag, and contains the XMP block; revert removes the rendered asset and the stack auto-collapses.
+**Items deferred to Phase D**: pull-side toggling of `is_moments_render` based on `AssetV1.tags[]` (requires tag sync, currently a no-op on insert from sync), eager tag-based discovery (`GET /search/metadata?tagIds=…`).
+
+Acceptance: applying a vignette in the Moments editor + save → original photo gets stacked with a new rendered asset on Immich; the rendered asset is the stack primary on the server, has the `moments-edit` tag, and contains the XMP block; locally the grid surfaces the original (§8.2 override). Revert removes the rendered asset and the stack auto-collapses.
 
 ### Phase D — recovery
 
@@ -694,7 +704,7 @@ If still 500: open an issue upstream and reduce Phase B scope to "best-effort, f
 
 ### 11.2 Does Immich strip XMP from uploaded JPEGs?
 
-The probe established that originals aren't transcoded. The render is uploaded *as a new asset* via `POST /assets`. Verify: upload a JPEG with embedded custom XMP, fetch it back via `GET /assets/{id}/original`, confirm bytes are identical. If Immich rewrites EXIF/XMP at ingestion time, the embedded `editJson` would be lost.
+**Resolved (2026-05-10, Phase C kickoff)**. Probed against the local v2.7.5 instance: built a minimal JPEG with a custom XMP APP1 segment carrying a `MOMENTS_PROBE_2026_05_10` marker, uploaded via `POST /assets`, fetched the bytes back via `GET /assets/{id}/original`. `cmp` reports the downloaded bytes are identical to the uploaded bytes. The MOMENTS marker survives unchanged. Phase D recovery via the embedded XMP is viable on v2.7.5; worth re-checking if a future Immich version changes ingestion behaviour.
 
 ### 11.3 SHA-1 dedup interaction
 

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -323,6 +323,13 @@ impl MediaClientV2 {
     }
 
     /// Persist the non-destructive edit state for a media item.
+    ///
+    /// Phase C: when `state.has_pixel_adjustments()` returns true the
+    /// edit can't be expressed as an Immich `/edits` action list, so
+    /// we render a full-resolution JPEG locally and forward to
+    /// [`Library::save_pixel_edit`] which embeds an XMP block,
+    /// inserts a rendered media row, and enqueues the upload/stack/tag
+    /// mutations. Geometric-only edits stay on the simpler Phase B path.
     pub fn save_edit_state(
         &self,
         id: &MediaId,
@@ -335,23 +342,29 @@ impl MediaClientV2 {
 
         glib::MainContext::default().spawn_local(async move {
             let result = crate::client::spawn_on(&tokio, async move {
-                library.editing().save_edit_state(&id, &state).await
+                if state.has_pixel_adjustments() {
+                    render_and_save_pixel_edit(&library, &id, &state).await
+                } else {
+                    library.editing().save_edit_state(&id, &state).await
+                }
             })
             .await;
             cb(result);
         });
     }
 
-    /// Revert edits for a media item (delete edit state from DB).
+    /// Revert edits for a media item: delete the local edit state,
+    /// clean up the rendered sibling on Immich if any (Phase C §7.3),
+    /// and clear any server-side `/edits` action list (Phase B path,
+    /// idempotent).
     pub fn revert_edits(&self, id: &MediaId, cb: impl FnOnce(Result<(), LibraryError>) + 'static) {
         let (library, tokio) = self.deps();
         let id = id.clone();
 
         glib::MainContext::default().spawn_local(async move {
-            let result = crate::client::spawn_on(&tokio, async move {
-                library.editing().revert_edits(&id).await
-            })
-            .await;
+            let result =
+                crate::client::spawn_on(&tokio, async move { library.revert_edit(&id).await })
+                    .await;
             cb(result);
         });
     }
@@ -1034,6 +1047,47 @@ fn remove_item_from_tracked(tracked: &TrackedMediaModel, store: &gio::ListStore,
         tracked.id_index.borrow_mut().remove(id);
         store.remove(pos);
     }
+}
+
+/// Phase C save path: render the original at full resolution with
+/// `state` applied, JPEG-encode the result, and hand it to
+/// [`crate::library::Library::save_pixel_edit`] which embeds the XMP
+/// block, inserts the rendered media row, and enqueues the upload +
+/// stack + tag mutations.
+///
+/// Runs the decode + edit pipeline on a Tokio blocking thread.
+async fn render_and_save_pixel_edit(
+    library: &std::sync::Arc<crate::library::Library>,
+    id: &MediaId,
+    state: &EditState,
+) -> Result<(), LibraryError> {
+    let original_path = library
+        .media()
+        .original_path(id)
+        .await?
+        .ok_or_else(|| LibraryError::Runtime(format!("original file for {id} not found")))?;
+
+    let pipeline = crate::application::MomentsApplication::default()
+        .render_pipeline()
+        .ok_or_else(|| LibraryError::Runtime("render pipeline not initialised".into()))?;
+
+    let state_for_render = state.clone();
+    let jpeg = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, LibraryError> {
+        let options = crate::renderer::pipeline::RenderOptions {
+            size: crate::renderer::pipeline::RenderSize::FullRes,
+            edits: Some(&state_for_render),
+            target: crate::renderer::target::RenderTarget::Final,
+        };
+        let img = pipeline
+            .render(&original_path, &options)
+            .map_err(|e| LibraryError::Runtime(format!("render failed: {e}")))?;
+        crate::renderer::output::to_jpeg(&img, 90)
+            .map_err(|e| LibraryError::Runtime(format!("JPEG encode failed: {e}")))
+    })
+    .await
+    .map_err(|e| LibraryError::Runtime(format!("render task join: {e}")))??;
+
+    library.save_pixel_edit(id, state, jpeg).await
 }
 
 /// Load a thumbnail from disk and decode it into a `gdk::Texture`.

--- a/src/importer/persistence.rs
+++ b/src/importer/persistence.rs
@@ -111,6 +111,7 @@ pub async fn persist(params: PersistParams<'_>) -> Result<PersistResult, ImportE
             is_favorite: false,
             is_trashed: false,
             trashed_at: None,
+            is_moments_render: false,
         })
         .await?;
 

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -325,12 +325,15 @@ impl AlbumRepository {
             None => sqlx::query_as::<_, MediaRow>(
                 "SELECT m.id, m.taken_at, m.imported_at, m.original_filename,
                             m.width, m.height, m.orientation, m.media_type, m.is_favorite,
-                            m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id
+                            m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id, m.is_moments_render
                      FROM media m
                      JOIN album_media am ON m.id = am.media_id
                      LEFT JOIN stacks s ON m.stack_id = s.id
+                     LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
                      WHERE am.album_id = ? AND m.is_trashed = 0
-                       AND (s.id IS NULL OR s.primary_asset_id = m.id)
+                       AND (s.id IS NULL AND m.is_moments_render = 0
+                            OR (render.id IS NULL AND s.primary_asset_id = m.id)
+                            OR (render.id IS NOT NULL AND m.is_moments_render = 0))
                      ORDER BY COALESCE(m.taken_at, 0) DESC, m.id DESC
                      LIMIT ?",
             )
@@ -342,15 +345,18 @@ impl AlbumRepository {
             Some(cur) => sqlx::query_as::<_, MediaRow>(
                 "SELECT m.id, m.taken_at, m.imported_at, m.original_filename,
                             m.width, m.height, m.orientation, m.media_type, m.is_favorite,
-                            m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id
+                            m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id, m.is_moments_render
                      FROM media m
                      JOIN album_media am ON m.id = am.media_id
                      LEFT JOIN stacks s ON m.stack_id = s.id
+                     LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
                      WHERE am.album_id = ?
                        AND (COALESCE(m.taken_at, 0) < ?
                             OR (COALESCE(m.taken_at, 0) = ? AND m.id < ?))
                        AND m.is_trashed = 0
-                       AND (s.id IS NULL OR s.primary_asset_id = m.id)
+                       AND (s.id IS NULL AND m.is_moments_render = 0
+                            OR (render.id IS NULL AND s.primary_asset_id = m.id)
+                            OR (render.id IS NOT NULL AND m.is_moments_render = 0))
                      ORDER BY COALESCE(m.taken_at, 0) DESC, m.id DESC
                      LIMIT ?",
             )

--- a/src/library/db/migrations/026_add_media_is_moments_render.sql
+++ b/src/library/db/migrations/026_add_media_is_moments_render.sql
@@ -1,0 +1,18 @@
+-- Issue #224 Phase C: mark assets that are Moments-rendered children
+-- of a stack. Used by:
+--   * the §8.2 grid filter — when a stack contains a Moments-render
+--     member, surface the *other* sibling (the original) instead of
+--     the server's stack primary, so the user sees the artifact they
+--     can still edit (the rendered child is a flat JPEG).
+--   * Phase D recovery — eager tag-based discovery on first sync can
+--     enumerate Moments-rendered assets and rebuild local edits rows
+--     from XMP.
+--
+-- Defaults to 0 for all existing rows. The save flow sets the column
+-- to 1 when inserting the new media row for a rendered output; the
+-- pull side toggles it based on the asset's `tags[]` containing the
+-- well-known `moments-edit` tag (see Phase C tag handling).
+
+ALTER TABLE media ADD COLUMN is_moments_render INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_media_is_moments_render ON media(is_moments_render) WHERE is_moments_render = 1;

--- a/src/library/db/mod.rs
+++ b/src/library/db/mod.rs
@@ -155,6 +155,7 @@ pub(crate) mod test_helpers {
             is_favorite: false,
             is_trashed: false,
             trashed_at: None,
+            is_moments_render: false,
         }
     }
 
@@ -180,6 +181,7 @@ pub(crate) mod test_helpers {
             is_favorite: false,
             is_trashed: false,
             trashed_at: None,
+            is_moments_render: false,
         }
     }
 }

--- a/src/library/editing/model.rs
+++ b/src/library/editing/model.rs
@@ -110,6 +110,22 @@ impl EditState {
             && self.filter.is_none()
     }
 
+    /// Returns `true` if this edit state contains anything that can't be
+    /// expressed as a discrete geometric action — exposure, colour,
+    /// detail, a filter preset, or freeform straighten. Used by the save
+    /// flow to choose between "push as a `/edits` action list" (Phase B)
+    /// and "render → upload → stack → tag" (Phase C).
+    ///
+    /// 90°-step rotates and crop/flip do *not* count as pixel
+    /// adjustments — those are expressible without rendering.
+    pub fn has_pixel_adjustments(&self) -> bool {
+        self.exposure != ExposureState::default()
+            || self.color != ColorState::default()
+            || self.detail != DetailState::default()
+            || self.filter.is_some()
+            || self.transforms.straighten_degrees.abs() >= f64::EPSILON
+    }
+
     /// Apply a filter preset's exposure/color/detail values scaled by strength.
     ///
     /// Sets this state's exposure, color, and detail fields to the preset
@@ -214,6 +230,65 @@ mod tests {
         let mut state = EditState::default();
         state.apply_filter_at_strength(&preset, 0.5);
         assert!((state.detail.vignette - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn identity_state_has_no_pixel_adjustments() {
+        assert!(!EditState::default().has_pixel_adjustments());
+    }
+
+    #[test]
+    fn rotate_and_crop_are_not_pixel_adjustments() {
+        // 90°-step rotate + crop + flip are geometric — push goes
+        // through the /edits API, no render needed.
+        let state = EditState {
+            transforms: TransformState {
+                crop: Some(CropRect {
+                    x: 0.1,
+                    y: 0.1,
+                    width: 0.8,
+                    height: 0.8,
+                }),
+                rotate_degrees: 90,
+                straighten_degrees: 0.0,
+                flip_horizontal: true,
+                flip_vertical: false,
+            },
+            ..Default::default()
+        };
+        assert!(!state.has_pixel_adjustments());
+    }
+
+    #[test]
+    fn exposure_is_pixel_adjustment() {
+        let mut state = EditState::default();
+        state.exposure.brightness = 0.3;
+        assert!(state.has_pixel_adjustments());
+    }
+
+    #[test]
+    fn filter_is_pixel_adjustment() {
+        let state = EditState {
+            filter: Some("vintage".into()),
+            ..Default::default()
+        };
+        assert!(state.has_pixel_adjustments());
+    }
+
+    #[test]
+    fn straighten_is_pixel_adjustment() {
+        // Freeform straighten requires rendering — Immich's `/edits`
+        // API only knows 90° increments.
+        let mut state = EditState::default();
+        state.transforms.straighten_degrees = 2.5;
+        assert!(state.has_pixel_adjustments());
+    }
+
+    #[test]
+    fn detail_vignette_is_pixel_adjustment() {
+        let mut state = EditState::default();
+        state.detail.vignette = 0.4;
+        assert!(state.has_pixel_adjustments());
     }
 
     #[test]

--- a/src/library/editing/repository.rs
+++ b/src/library/editing/repository.rs
@@ -37,6 +37,44 @@ impl EditingRepository {
         }
     }
 
+    /// Get the local id of the rendered sibling for an edit, if any.
+    ///
+    /// Phase C records this when a pixel-adjustment edit is saved: the
+    /// rendered JPEG goes into a new media row and that row's MediaId
+    /// is stamped here. `None` means either no edit row, no render
+    /// (geometric-only edit), or a previously-rendered row that was
+    /// reverted.
+    pub async fn server_rendered_asset_id(
+        &self,
+        id: &MediaId,
+    ) -> Result<Option<MediaId>, LibraryError> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT server_rendered_asset_id FROM edits WHERE media_id = ?")
+                .bind(id.as_str())
+                .fetch_optional(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
+
+        Ok(row.and_then(|(s,)| s.map(MediaId::new)))
+    }
+
+    /// Stamp (or clear, with `None`) the rendered sibling pointer on
+    /// an existing edit row. Called by the Phase C save flow once the
+    /// rendered media row has been inserted, and by revert to clear.
+    pub async fn set_server_rendered_asset_id(
+        &self,
+        id: &MediaId,
+        rendered: Option<&MediaId>,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("UPDATE edits SET server_rendered_asset_id = ? WHERE media_id = ?")
+            .bind(rendered.map(|r| r.as_str()))
+            .bind(id.as_str())
+            .execute(self.db.pool())
+            .await
+            .map_err(LibraryError::Db)?;
+        Ok(())
+    }
+
     /// Save or update the edit state for a media item.
     pub async fn upsert_edit_state(
         &self,

--- a/src/library/editing/service.rs
+++ b/src/library/editing/service.rs
@@ -65,6 +65,41 @@ impl EditingService {
     pub async fn has_pending_edits(&self, id: &MediaId) -> Result<bool, LibraryError> {
         self.repo.has_pending_edits(id).await
     }
+
+    // ── Phase C orchestration helpers ─────────────────────────────────
+    //
+    // These bypass the recorder because the caller — `Library::save_pixel_edit` /
+    // `Library::revert_edit` — emits its own mutation sequence
+    // (StackCreated + AssetTaggedMomentsEdit, or AssetEditsCleared +
+    // the rendered-asset cleanup). Recording AssetEditsApplied here as
+    // well would race those.
+
+    pub async fn server_rendered_asset_id(
+        &self,
+        id: &MediaId,
+    ) -> Result<Option<MediaId>, LibraryError> {
+        self.repo.server_rendered_asset_id(id).await
+    }
+
+    pub async fn set_server_rendered_asset_id(
+        &self,
+        id: &MediaId,
+        rendered: Option<&MediaId>,
+    ) -> Result<(), LibraryError> {
+        self.repo.set_server_rendered_asset_id(id, rendered).await
+    }
+
+    pub async fn upsert_edit_state_no_record(
+        &self,
+        id: &MediaId,
+        state: &EditState,
+    ) -> Result<(), LibraryError> {
+        self.repo.upsert_edit_state(id, state).await
+    }
+
+    pub async fn delete_edit_state_no_record(&self, id: &MediaId) -> Result<(), LibraryError> {
+        self.repo.delete_edit_state(id).await
+    }
 }
 
 #[cfg(test)]

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -91,8 +91,11 @@ impl FacesRepository {
             "SELECT DISTINCT af.asset_id FROM asset_faces af
              INNER JOIN media m ON m.id = af.asset_id
              LEFT JOIN stacks s ON m.stack_id = s.id
+             LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
              WHERE af.person_id = ? AND m.is_trashed = 0
-               AND (s.id IS NULL OR s.primary_asset_id = m.id)
+               AND (s.id IS NULL AND m.is_moments_render = 0
+                    OR (render.id IS NULL AND s.primary_asset_id = m.id)
+                    OR (render.id IS NOT NULL AND m.is_moments_render = 0))
              ORDER BY COALESCE(m.taken_at, m.imported_at) DESC",
         )
         .bind(person_id)

--- a/src/library/media/model.rs
+++ b/src/library/media/model.rs
@@ -69,6 +69,11 @@ pub struct MediaItem {
     /// out via a `LEFT JOIN stacks` clause; clients can use this to
     /// surface a "stacked" badge on the primary.
     pub stack_id: Option<String>,
+    /// True if this asset is a Moments-produced render (the rendered
+    /// JPEG sibling of an edited original). Phase C (#224): the grid
+    /// filter swaps these out for the original sibling so the user
+    /// sees the editable artifact rather than the flat render.
+    pub is_moments_render: bool,
 }
 
 /// A stack of related assets on the Immich server (e.g. a panorama
@@ -193,6 +198,11 @@ pub struct MediaRecord {
     pub is_trashed: bool,
     /// Unix timestamp when the item was trashed. `None` if not trashed.
     pub trashed_at: Option<i64>,
+    /// True if this row was inserted by Phase C save flow as the
+    /// rendered sibling of an edited asset. Toggled on by the editor
+    /// at save time and on the pull side when an asset arrives with
+    /// the `moments-edit` tag.
+    pub is_moments_render: bool,
 }
 
 #[cfg(test)]

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -21,6 +21,7 @@ pub(crate) struct MediaRow {
     trashed_at: Option<i64>,
     duration_ms: Option<i64>,
     stack_id: Option<String>,
+    is_moments_render: i64,
 }
 
 impl MediaRow {
@@ -43,6 +44,7 @@ impl MediaRow {
             trashed_at: self.trashed_at,
             duration_ms: self.duration_ms.map(|v| v as u64),
             stack_id: self.stack_id,
+            is_moments_render: self.is_moments_render != 0,
         }
     }
 }
@@ -83,12 +85,75 @@ impl MediaRepository {
         Ok(row.is_some())
     }
 
+    /// Fetch the full media row by ID, including columns omitted from
+    /// [`MediaItem`] (content_hash, external_id, relative_path,
+    /// file_size). Used by Phase C save to populate the embedded XMP
+    /// block and by other paths that need the full row.
+    pub async fn get_record(&self, id: &MediaId) -> Result<Option<MediaRecord>, LibraryError> {
+        #[derive(sqlx::FromRow)]
+        struct Row {
+            id: String,
+            content_hash: Option<String>,
+            external_id: Option<String>,
+            relative_path: String,
+            original_filename: String,
+            file_size: i64,
+            imported_at: i64,
+            media_type: i64,
+            taken_at: Option<i64>,
+            width: Option<i64>,
+            height: Option<i64>,
+            orientation: i64,
+            duration_ms: Option<i64>,
+            is_favorite: i64,
+            is_trashed: i64,
+            trashed_at: Option<i64>,
+            is_moments_render: i64,
+        }
+
+        let row: Option<Row> = sqlx::query_as(
+            "SELECT id, content_hash, external_id, relative_path, original_filename,
+                    file_size, imported_at, media_type, taken_at, width, height,
+                    orientation, duration_ms, is_favorite, is_trashed, trashed_at,
+                    is_moments_render
+             FROM media WHERE id = ?",
+        )
+        .bind(id.as_str())
+        .fetch_optional(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+
+        Ok(row.map(|r| MediaRecord {
+            id: MediaId::new(r.id),
+            content_hash: r.content_hash,
+            external_id: r.external_id,
+            relative_path: r.relative_path,
+            original_filename: r.original_filename,
+            file_size: r.file_size,
+            imported_at: r.imported_at,
+            media_type: if r.media_type == 1 {
+                MediaType::Video
+            } else {
+                MediaType::Image
+            },
+            taken_at: r.taken_at,
+            width: r.width,
+            height: r.height,
+            orientation: r.orientation as u8,
+            duration_ms: r.duration_ms.map(|v| v as u64),
+            is_favorite: r.is_favorite != 0,
+            is_trashed: r.is_trashed != 0,
+            trashed_at: r.trashed_at,
+            is_moments_render: r.is_moments_render != 0,
+        }))
+    }
+
     /// Fetch a single media item by ID.
     pub async fn get(&self, id: &MediaId) -> Result<Option<MediaItem>, LibraryError> {
         let row: Option<MediaRow> = sqlx::query_as(
             "SELECT id, taken_at, imported_at, original_filename,
                     width, height, orientation, media_type, is_favorite,
-                    is_trashed, trashed_at, duration_ms, stack_id
+                    is_trashed, trashed_at, duration_ms, stack_id, is_moments_render
              FROM media WHERE id = ?",
         )
         .bind(id.as_str())
@@ -118,11 +183,14 @@ impl MediaRepository {
         let sql = format!(
             "SELECT m.id, m.taken_at, m.imported_at, m.original_filename,
                     m.width, m.height, m.orientation, m.media_type, m.is_favorite,
-                    m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id
+                    m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id, m.is_moments_render
              FROM media m
              LEFT JOIN stacks s ON m.stack_id = s.id
+             LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
              WHERE m.id IN ({placeholders})
-               AND (s.id IS NULL OR s.primary_asset_id = m.id)"
+               AND (s.id IS NULL AND m.is_moments_render = 0
+                    OR (render.id IS NULL AND s.primary_asset_id = m.id)
+                    OR (render.id IS NOT NULL AND m.is_moments_render = 0))"
         );
         let mut query = sqlx::query_as::<_, MediaRow>(&sql);
         for id in ids {
@@ -234,11 +302,20 @@ impl MediaRepository {
         limit: u32,
     ) -> Result<Vec<MediaItem>, LibraryError> {
         // Issue #224: stacked-but-not-primary members are hidden from
-        // every grid view. The `LEFT JOIN stacks` + `(s.id IS NULL OR
-        // s.primary_asset_id = m.id)` clause keeps un-stacked rows
-        // visible while collapsing each stack to its primary. Bare
-        // column references are now qualified with `m.` to disambiguate
-        // from `stacks.id` / `stacks.primary_asset_id`.
+        // every grid view. The `LEFT JOIN stacks` keeps un-stacked rows
+        // visible while collapsing each stack to its visible representative.
+        //
+        // Phase A's filter was a plain primary-only check. Phase C §8.2
+        // adds the override for Moments-edit stacks: when the stack
+        // contains a Moments-render member (the rendered JPEG sibling
+        // we uploaded for a pixel-adjustment edit), surface the
+        // *other* sibling — the original — so the timeline shows the
+        // artifact the user can still edit. The extra `LEFT JOIN media
+        // render … is_moments_render = 1` is the existence test for
+        // that override branch.
+        //
+        // Bare column references are qualified with `m.` to disambiguate
+        // from `stacks.id` / `stacks.primary_asset_id` (and now `render.*`).
         let (filter_clause, sort_expr) = match &filter {
             MediaFilter::All => (" AND m.is_trashed = 0", "COALESCE(m.taken_at, 0)"),
             MediaFilter::Favorites => (
@@ -269,7 +346,7 @@ impl MediaRepository {
 
         let columns = "m.id, m.taken_at, m.imported_at, m.original_filename,
                         m.width, m.height, m.orientation, m.media_type, m.is_favorite,
-                        m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id";
+                        m.is_trashed, m.trashed_at, m.duration_ms, m.stack_id, m.is_moments_render";
 
         let rows = match cursor {
             None => {
@@ -277,7 +354,10 @@ impl MediaRepository {
                     "SELECT {columns}
                      FROM media m
                      LEFT JOIN stacks s ON m.stack_id = s.id
-                     WHERE (s.id IS NULL OR s.primary_asset_id = m.id){filter_clause}
+                     LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
+                     WHERE (s.id IS NULL AND m.is_moments_render = 0
+                            OR (render.id IS NULL AND s.primary_asset_id = m.id)
+                            OR (render.id IS NOT NULL AND m.is_moments_render = 0)){filter_clause}
                      ORDER BY {sort_expr} DESC, m.id DESC
                      LIMIT ?"
                 );
@@ -295,7 +375,10 @@ impl MediaRepository {
                     "SELECT {columns}
                      FROM media m
                      LEFT JOIN stacks s ON m.stack_id = s.id
-                     WHERE (s.id IS NULL OR s.primary_asset_id = m.id)
+                     LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
+                     WHERE (s.id IS NULL AND m.is_moments_render = 0
+                            OR (render.id IS NULL AND s.primary_asset_id = m.id)
+                            OR (render.id IS NOT NULL AND m.is_moments_render = 0))
                        AND ({sort_expr} < ?
                             OR ({sort_expr} = ? AND m.id < ?)){filter_clause}
                      ORDER BY {sort_expr} DESC, m.id DESC
@@ -375,8 +458,8 @@ impl MediaRepository {
             "INSERT INTO media (id, content_hash, external_id, relative_path,
                                 original_filename, file_size, imported_at, media_type,
                                 taken_at, width, height, orientation, duration_ms,
-                                is_favorite, is_trashed, trashed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                                is_favorite, is_trashed, trashed_at, is_moments_render)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(record.id.as_str())
         .bind(&record.content_hash)
@@ -394,6 +477,7 @@ impl MediaRepository {
         .bind(record.is_favorite as i64)
         .bind(record.is_trashed as i64)
         .bind(record.trashed_at)
+        .bind(record.is_moments_render as i64)
         .execute(self.db.pool())
         .await
         .map_err(LibraryError::Db)?;
@@ -422,19 +506,34 @@ impl MediaRepository {
     /// the server's `file_created_at` (the photo's capture time), which
     /// would silently move assets out of the Recent Imports view (issue #614).
     pub async fn upsert(&self, record: &MediaRecord) -> Result<Option<MediaId>, LibraryError> {
-        // Capture the existing row's imported_at so we can preserve it —
-        // see #614. Post-#626 the upserting handler always passes the
-        // locally-owned `MediaId` (resolved via `id_by_external_id` /
+        // Capture the existing row's locally-only fields so we can
+        // preserve them across the INSERT OR REPLACE:
+        //
+        // * `imported_at` — see #614. The server's `file_created_at`
+        //   is the photo's capture time, not when it entered this
+        //   library; overwriting moves assets out of Recent Imports.
+        // * `is_moments_render` — Phase C (#224). The Phase C save
+        //   sets this to 1 on the rendered child it produces; sync's
+        //   `AssetHandler` always passes `false` (pull-side tag-based
+        //   derivation is Phase D scope). Without preserving the
+        //   column, the §8.2 grid filter would flip the wrong
+        //   sibling visible after the next pull.
+        //
+        // Post-#626 the upserting handler always passes the locally-owned
+        // `MediaId` (resolved via `id_by_external_id` /
         // `id_by_content_hash_pending_push`), so a plain `id = ?` lookup
         // is sufficient; the older `OR external_id = ?` arm was for the
         // local→server UUID swap that no longer happens.
-        let existing_imported_at: Option<i64> =
-            sqlx::query_scalar("SELECT imported_at FROM media WHERE id = ?")
+        let existing: Option<(i64, i64)> =
+            sqlx::query_as("SELECT imported_at, is_moments_render FROM media WHERE id = ?")
                 .bind(record.id.as_str())
                 .fetch_optional(self.db.pool())
                 .await
                 .map_err(LibraryError::Db)?;
-        let imported_at = existing_imported_at.unwrap_or(record.imported_at);
+        let imported_at = existing.map(|(t, _)| t).unwrap_or(record.imported_at);
+        let is_moments_render = existing
+            .map(|(_, r)| r != 0)
+            .unwrap_or(record.is_moments_render);
 
         // Atomic delete-and-return so the replaced-id observation can
         // never disagree with the row that was actually removed. SQLite
@@ -452,8 +551,8 @@ impl MediaRepository {
                                            original_filename, file_size, imported_at,
                                            media_type, taken_at, width, height,
                                            orientation, duration_ms, is_favorite,
-                                           is_trashed, trashed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                                           is_trashed, trashed_at, is_moments_render)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(record.id.as_str())
         .bind(&record.content_hash)
@@ -471,6 +570,7 @@ impl MediaRepository {
         .bind(record.is_favorite as i64)
         .bind(record.is_trashed as i64)
         .bind(record.trashed_at)
+        .bind(is_moments_render as i64)
         .execute(self.db.pool())
         .await
         .map_err(LibraryError::Db)?;
@@ -925,6 +1025,65 @@ mod tests {
         let item = repo.get(&id).await.unwrap().unwrap();
         assert_eq!(item.id, id);
         assert_eq!(item.taken_at, Some(5000));
+    }
+
+    /// Phase C: `is_moments_render` must round-trip through INSERT
+    /// and SELECT correctly. Silent column drift here would surface as
+    /// the §8.2 grid filter flipping the wrong sibling visible.
+    #[tokio::test]
+    async fn is_moments_render_round_trips_insert_and_get() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        // is_moments_render = false (the default for ordinary imports)
+        let unset_id = MediaId::new("a".repeat(64));
+        let mut unset_rec = test_record(unset_id.clone());
+        unset_rec.relative_path = "unset.jpg".into();
+        repo.insert(&unset_rec).await.unwrap();
+        let item = repo.get(&unset_id).await.unwrap().unwrap();
+        assert!(!item.is_moments_render);
+
+        // is_moments_render = true (Phase C save sets this)
+        let render_id = MediaId::new("b".repeat(64));
+        let mut rec = test_record(render_id.clone());
+        rec.relative_path = "render.jpg".into();
+        rec.is_moments_render = true;
+        repo.insert(&rec).await.unwrap();
+        let item = repo.get(&render_id).await.unwrap().unwrap();
+        assert!(item.is_moments_render);
+
+        // get_record reflects the same value.
+        let full = repo.get_record(&render_id).await.unwrap().unwrap();
+        assert!(full.is_moments_render);
+    }
+
+    /// Phase C blocker #2: `upsert` is used by the pull-side
+    /// `AssetHandler`, which constructs the record with
+    /// `is_moments_render: false` (Phase D will derive it from tags).
+    /// Without preservation, every pull would clobber the Phase-C-set
+    /// `true` and break §8.2.
+    #[tokio::test]
+    async fn upsert_preserves_existing_is_moments_render() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+        let id = MediaId::new("c".repeat(64));
+
+        // Insert with the Phase C save flag set.
+        let mut rec = test_record(id.clone());
+        rec.is_moments_render = true;
+        repo.insert(&rec).await.unwrap();
+
+        // Upsert with the column false (simulating pull from Immich).
+        let mut sync_rec = test_record(id.clone());
+        sync_rec.is_moments_render = false;
+        repo.upsert(&sync_rec).await.unwrap();
+
+        // The locally-set flag survives the pull.
+        let item = repo.get(&id).await.unwrap().unwrap();
+        assert!(
+            item.is_moments_render,
+            "upsert must preserve the local is_moments_render flag"
+        );
     }
 
     #[tokio::test]
@@ -1405,6 +1564,119 @@ mod tests {
         let unstacked_item = items.iter().find(|i| i.id == unstacked).unwrap();
         assert_eq!(primary_item.stack_id.as_deref(), Some("stk"));
         assert!(unstacked_item.stack_id.is_none());
+    }
+
+    /// Phase C §8.2: when a stack contains a Moments-render member
+    /// (the rendered sibling we upload for a pixel-adjustment edit),
+    /// the grid filter surfaces the *other* sibling — the original.
+    /// The rendered child is still the stack primary on Immich, but
+    /// users edit the original.
+    #[tokio::test]
+    async fn list_surfaces_original_for_moments_edit_stack() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let original = MediaId::new("a".repeat(64));
+        let rendered = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(original.clone(), "o.jpg", Some(1000)))
+            .await
+            .unwrap();
+        let mut rendered_rec = record_with_taken_at(rendered.clone(), "r.jpg", Some(1000));
+        rendered_rec.is_moments_render = true;
+        repo.insert(&rendered_rec).await.unwrap();
+
+        // The rendered child is the stack primary on Immich.
+        repo.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: rendered.clone(),
+        })
+        .await
+        .unwrap();
+        repo.set_media_stack_id(&rendered, "stk").await.unwrap();
+        repo.set_media_stack_id(&original, "stk").await.unwrap();
+
+        let items = repo.list(MediaFilter::All, None, 50).await.unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        // Expect the original visible, the rendered child hidden.
+        assert!(
+            ids.contains(&original.as_str()),
+            "original must be visible: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&rendered.as_str()),
+            "rendered sibling must be hidden: {ids:?}"
+        );
+    }
+
+    /// Phase C review fix #3: an unstacked row with
+    /// `is_moments_render = 1` must not appear in the grid — this is
+    /// the transient state between `save_pixel_edit` inserting the
+    /// rendered media row and the push manager's `StackCreated`
+    /// draining. Without the extra clause, the rendered child would
+    /// briefly appear as a duplicate of the original.
+    #[tokio::test]
+    async fn list_hides_unstacked_moments_render_rows() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let original = MediaId::new("a".repeat(64));
+        let rendered = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(original.clone(), "o.jpg", Some(1000)))
+            .await
+            .unwrap();
+        let mut rendered_rec = record_with_taken_at(rendered.clone(), "r.jpg", Some(1000));
+        rendered_rec.is_moments_render = true;
+        repo.insert(&rendered_rec).await.unwrap();
+
+        // Note: no stack created yet — simulating the window between
+        // save_pixel_edit's media insert and the push manager's
+        // StackCreated draining.
+
+        let items = repo.list(MediaFilter::All, None, 50).await.unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert!(
+            ids.contains(&original.as_str()),
+            "original visible: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&rendered.as_str()),
+            "unstacked rendered child must be hidden: {ids:?}"
+        );
+    }
+
+    /// Sanity: the §8.2 override only kicks in for Moments-edit
+    /// stacks. Ordinary stacks (e.g. a panorama burst with no
+    /// `is_moments_render` member) still collapse to the server's
+    /// primary.
+    #[tokio::test]
+    async fn list_keeps_primary_when_no_moments_render_member() {
+        let dir = tempdir().unwrap();
+        let (repo, _db) = test_repo(dir.path()).await;
+
+        let primary = MediaId::new("a".repeat(64));
+        let sibling = MediaId::new("b".repeat(64));
+        repo.insert(&record_with_taken_at(primary.clone(), "p.jpg", Some(1000)))
+            .await
+            .unwrap();
+        repo.insert(&record_with_taken_at(sibling.clone(), "s.jpg", Some(1000)))
+            .await
+            .unwrap();
+        repo.upsert_stack(&Stack {
+            id: "stk".to_string(),
+            primary_asset_id: primary.clone(),
+        })
+        .await
+        .unwrap();
+        repo.set_media_stack_id(&primary, "stk").await.unwrap();
+        repo.set_media_stack_id(&sibling, "stk").await.unwrap();
+
+        let items = repo.list(MediaFilter::All, None, 50).await.unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert!(ids.contains(&primary.as_str()), "primary visible: {ids:?}");
+        assert!(
+            !ids.contains(&sibling.as_str()),
+            "non-primary sibling hidden"
+        );
     }
 
     /// Issue #224: `AssetV1` may arrive before its matching `StackV1`,

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -64,6 +64,13 @@ impl MediaService {
         self.events.emit(event);
     }
 
+    /// Filesystem directory holding originals for the local library
+    /// (under `Managed` mode). Phase C uses this to write newly-rendered
+    /// edits at their sharded UUID path before inserting the media row.
+    pub fn originals_dir(&self) -> &PathBuf {
+        &self.originals_dir
+    }
+
     // ── Path resolution ─────────────────────────────────────────────
 
     /// Resolve the original file path for `id`.
@@ -163,6 +170,18 @@ impl MediaService {
     /// Check if an asset with this content hash already exists (dedup).
     pub async fn exists_by_content_hash(&self, hash: &str) -> Result<bool, LibraryError> {
         self.repo.exists_by_content_hash(hash).await
+    }
+
+    /// Fetch the full DB row (including `content_hash` and
+    /// `external_id`) for an asset. Phase C uses this in
+    /// [`crate::library::Library::save_pixel_edit`] to populate the
+    /// embedded XMP block; the column subset returned by
+    /// [`Self::get_media_item`] omits those fields.
+    pub async fn get_media_record(
+        &self,
+        id: &MediaId,
+    ) -> Result<Option<MediaRecord>, LibraryError> {
+        self.repo.get_record(id).await
     }
 
     pub async fn get_media_item(&self, id: &MediaId) -> Result<Option<MediaItem>, LibraryError> {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -41,6 +41,12 @@ pub struct Library {
     media: MediaService,
     metadata: MetadataService,
     thumbnails: ThumbnailService,
+    /// Same recorder Arc that the per-service constructors received —
+    /// kept on `Library` so cross-service operations like
+    /// [`Library::save_pixel_edit`] can record their own mutations
+    /// (Stack*, *MomentsEdit) without going through a per-service
+    /// shim.
+    recorder: Arc<dyn MutationRecorder>,
 }
 
 impl Library {
@@ -69,7 +75,7 @@ impl Library {
             db.clone(),
             bundle.originals.clone(),
             mode,
-            recorder,
+            Arc::clone(&recorder),
             resolver,
         );
         let metadata = MetadataService::new(db.clone());
@@ -83,6 +89,7 @@ impl Library {
             media,
             metadata,
             thumbnails,
+            recorder,
         })
     }
 
@@ -119,6 +126,218 @@ impl Library {
     }
 
     // ── Cross-service operations ─────────────────────────────────────
+
+    /// Save a pixel-adjustment edit: persist the edit state, write the
+    /// rendered JPEG (with the Moments XMP block embedded) to the
+    /// originals shard, record the upload+stack+tag mutation sequence,
+    /// and clean up any previously-rendered sibling. Phase C §7.2.
+    ///
+    /// The caller produces `rendered_bytes` by running the original
+    /// through [`crate::renderer::pipeline::RenderPipeline`] at
+    /// `FullRes` with the user's `EditState`, then encoding via
+    /// [`crate::renderer::output::to_jpeg`]. XMP injection is handled
+    /// here so the original's `external_id` and `content_hash` (needed
+    /// for Phase D recovery) don't have to leak into the UI.
+    ///
+    /// Errors if the original asset hasn't been synced to Immich yet
+    /// (no `external_id`) — Phase D recovery depends on that id being
+    /// stable, and saving an edit before the original is on the
+    /// server would lose recoverability.
+    pub async fn save_pixel_edit(
+        &self,
+        original_id: &MediaId,
+        state: &editing::EditState,
+        rendered_bytes: Vec<u8>,
+    ) -> Result<(), LibraryError> {
+        use crate::library::media::{MediaRecord, MediaType};
+        use crate::library::mutation::Mutation;
+        use crate::renderer::xmp;
+
+        // Look up the original — we need its external_id and content
+        // hash for the XMP, and its filename for the rendered output.
+        let original = self
+            .media
+            .get_media_record(original_id)
+            .await?
+            .ok_or_else(|| {
+                LibraryError::Runtime(format!("save_pixel_edit: original {original_id} not found"))
+            })?;
+        let Some(original_external_id) = original.external_id.as_deref() else {
+            return Err(LibraryError::Runtime(format!(
+                "save_pixel_edit: original {original_id} has not been uploaded yet"
+            )));
+        };
+        // Phase D fallback recovery (§7.4) uses `originalContentHash`
+        // to find the parent when `originalAssetId` no longer resolves.
+        // Defaulting to an empty string would resolve to any zero-hash
+        // row — fail fast instead.
+        let Some(content_hash) = original.content_hash.clone() else {
+            return Err(LibraryError::Runtime(format!(
+                "save_pixel_edit: original {original_id} has no content_hash — can't embed Phase D recovery fallback"
+            )));
+        };
+
+        // Build the embedded edit block. `editJson` is the same JSON
+        // the local `edits.edit_json` column stores.
+        let edit_json = serde_json::to_string(state)
+            .map_err(|e| LibraryError::Runtime(format!("serialize EditState: {e}")))?;
+        let embedded = xmp::EmbeddedEdit {
+            original_asset_id: original_external_id.to_string(),
+            original_content_hash: content_hash,
+            edit_version: 1,
+            rendered_at: chrono::Utc::now(),
+            edit_json,
+        };
+        let xmp_xml = xmp::encode(&embedded);
+        let rendered_with_xmp = xmp::inject_xmp(&rendered_bytes, &xmp_xml)
+            .map_err(|e| LibraryError::Runtime(format!("inject XMP: {e}")))?;
+
+        // Allocate the rendered MediaId and write the file under the
+        // standard sharded originals layout. The `make sharded_dir` step
+        // creates the two-level parent directories.
+        let rendered_id = MediaId::generate();
+        let relative_path = crate::library::thumbnail::sharded_original_relative(&rendered_id);
+        let abs_path = self.media.originals_dir().join(&relative_path);
+        if let Some(parent) = abs_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(LibraryError::Io)?;
+        }
+        tokio::fs::write(&abs_path, &rendered_with_xmp)
+            .await
+            .map_err(LibraryError::Io)?;
+
+        // If we're replacing an existing rendered sibling, enqueue its
+        // revert sequence BEFORE the new upload so the order in the
+        // outbox is sensible: untag → remove from stack → delete →
+        // (then the new) import → stack → tag.
+        //
+        // `delete_permanently` records `AssetDeleted` (matching design
+        // §7.2 step 6c). The `_from_sync` variant skips the recorder,
+        // which would orphan the prior rendered asset on Immich
+        // forever — see Phase C code review item #1.
+        if let Some(prev_rendered) = self.editing.server_rendered_asset_id(original_id).await? {
+            self.enqueue_rendered_cleanup(&prev_rendered).await?;
+            self.delete_permanently(&[prev_rendered]).await?;
+        }
+
+        // Insert the rendered media row. `insert_media` records the
+        // AssetImported mutation; the push manager picks it up next
+        // drain cycle, uploads the file, and stamps external_id.
+        let rendered_filename = format!(
+            "{}-edit.jpg",
+            std::path::Path::new(&original.original_filename)
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("photo")
+        );
+        let now = chrono::Utc::now().timestamp();
+        let rendered_record = MediaRecord {
+            id: rendered_id.clone(),
+            content_hash: None, // computed lazily on import; not load-bearing for rendered children
+            external_id: None,
+            relative_path,
+            original_filename: rendered_filename,
+            file_size: rendered_with_xmp.len() as i64,
+            imported_at: now,
+            media_type: MediaType::Image,
+            taken_at: original.taken_at,
+            width: original.width,
+            height: original.height,
+            orientation: 1, // EditState already accounts for orientation
+            duration_ms: None,
+            is_favorite: false,
+            is_trashed: false,
+            trashed_at: None,
+            is_moments_render: true,
+        };
+        self.media.insert_media(&rendered_record).await?;
+
+        // Persist the edit state and the rendered pointer.
+        self.editing
+            .upsert_edit_state_no_record(original_id, state)
+            .await?;
+        self.editing
+            .set_server_rendered_asset_id(original_id, Some(&rendered_id))
+            .await?;
+
+        // Stack + tag mutations — these depend on the rendered asset
+        // having a server-side external_id. The push handler retries
+        // via the outbox backoff until AssetImported drains.
+        self.recorder
+            .record(&Mutation::StackCreated {
+                rendered_asset_id: rendered_id.clone(),
+                original_asset_id: original_id.clone(),
+            })
+            .await?;
+        self.recorder
+            .record(&Mutation::AssetTaggedMomentsEdit { id: rendered_id })
+            .await?;
+
+        Ok(())
+    }
+
+    /// Revert any edit on `original_id`: clear local edit state, and
+    /// — if a rendered sibling was previously uploaded — enqueue the
+    /// stack/tag/delete sequence to clean it up server-side. Phase C §7.3.
+    ///
+    /// Records `AssetEditsCleared` last so the geometric-only `/edits`
+    /// state is also wiped (no-op if no such state was ever pushed).
+    pub async fn revert_edit(&self, original_id: &MediaId) -> Result<(), LibraryError> {
+        use crate::library::mutation::Mutation;
+        let prev_rendered = self.editing.server_rendered_asset_id(original_id).await?;
+
+        if let Some(rendered) = prev_rendered.as_ref() {
+            self.enqueue_rendered_cleanup(rendered).await?;
+        }
+
+        // Delete the local edits row and clear the render pointer
+        // (the row is gone, but be explicit for completeness).
+        self.editing
+            .delete_edit_state_no_record(original_id)
+            .await?;
+
+        if let Some(rendered) = prev_rendered {
+            // The local rendered media row + file go away too. This
+            // records AssetDeleted via `delete_permanently`'s normal
+            // path — the push handler removes it from Immich.
+            self.delete_permanently(&[rendered]).await?;
+        }
+
+        // Belt-and-braces: also clear any server-side /edits action
+        // list (Phase B path). DELETE is idempotent on v2.7.5.
+        self.recorder
+            .record(&Mutation::AssetEditsCleared {
+                id: original_id.clone(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Helper: enqueue the StackMemberRemoved + AssetUntaggedMomentsEdit
+    /// mutations for a rendered child. Stack id is looked up from the
+    /// child's `media.stack_id`; if null (StackCreated hasn't drained
+    /// yet) the stack-remove step is skipped — the rendered's deletion
+    /// alone is enough since Immich auto-deletes the stack at < 2
+    /// members.
+    async fn enqueue_rendered_cleanup(&self, rendered_id: &MediaId) -> Result<(), LibraryError> {
+        use crate::library::mutation::Mutation;
+        let item = self.media.get_media_item(rendered_id).await?;
+        if let Some(stack_id) = item.as_ref().and_then(|m| m.stack_id.clone()) {
+            self.recorder
+                .record(&Mutation::StackMemberRemoved {
+                    stack_id,
+                    asset_id: rendered_id.clone(),
+                })
+                .await?;
+        }
+        self.recorder
+            .record(&Mutation::AssetUntaggedMomentsEdit {
+                id: rendered_id.clone(),
+            })
+            .await?;
+        Ok(())
+    }
 
     /// Permanently delete assets: DB first, then best-effort file cleanup.
     ///
@@ -169,18 +388,219 @@ mod tests {
     use crate::library::config::LibraryConfig;
 
     async fn open_test_library(bundle: Bundle) -> Library {
+        let originals = bundle.originals.clone();
         Library::open(
             bundle,
             LocalStorageMode::Managed,
             Database::new(),
             Arc::new(crate::sync::outbox::NoOpRecorder),
             Arc::new(resolver::LocalResolver::new(
-                std::path::PathBuf::new(),
+                originals,
                 LocalStorageMode::Managed,
             )),
         )
         .await
         .unwrap()
+    }
+
+    /// Open a library with a CapturingRecorder so tests can assert
+    /// the outbox-bound mutation sequence emitted by Phase C save and
+    /// revert orchestration.
+    async fn open_test_library_with_recorder(
+        bundle: Bundle,
+    ) -> (
+        Library,
+        Arc<crate::library::recorder::tests::CapturingRecorder>,
+    ) {
+        let recorder = Arc::new(crate::library::recorder::tests::CapturingRecorder::default());
+        let originals = bundle.originals.clone();
+        let library = Library::open(
+            bundle,
+            LocalStorageMode::Managed,
+            Database::new(),
+            Arc::clone(&recorder) as Arc<dyn MutationRecorder>,
+            Arc::new(resolver::LocalResolver::new(
+                originals,
+                LocalStorageMode::Managed,
+            )),
+        )
+        .await
+        .unwrap();
+        (library, recorder)
+    }
+
+    fn fresh_bundle(dir: &std::path::Path) -> Bundle {
+        let path = dir.join("Test.library");
+        Bundle::create(
+            &path,
+            &LibraryConfig::Local {
+                mode: LocalStorageMode::Managed,
+            },
+        )
+        .unwrap()
+    }
+
+    fn rendered_jpeg() -> Vec<u8> {
+        // Hand-roll a 1x1 JPEG via the `image` crate.
+        use image::{ImageFormat, RgbImage};
+        let img = RgbImage::from_pixel(1, 1, image::Rgb([255, 0, 0]));
+        let mut buf = Vec::new();
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut std::io::Cursor::new(&mut buf), ImageFormat::Jpeg)
+            .unwrap();
+        buf
+    }
+
+    #[tokio::test]
+    async fn save_pixel_edit_requires_original_to_be_synced() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = fresh_bundle(dir.path());
+        let library = open_test_library(bundle).await;
+
+        // Insert an original media row WITHOUT external_id.
+        let original_id = MediaId::new("orig".into());
+        let mut rec = crate::library::db::test_helpers::test_record(original_id.clone());
+        rec.relative_path = "orig.jpg".into();
+        library.media().insert_media(&rec).await.unwrap();
+
+        let err = library
+            .save_pixel_edit(
+                &original_id,
+                &editing::EditState::default(),
+                rendered_jpeg(),
+            )
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("has not been uploaded yet"));
+    }
+
+    #[tokio::test]
+    async fn save_pixel_edit_writes_render_inserts_row_and_records_mutations() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = fresh_bundle(dir.path());
+        let originals_dir = bundle.originals.clone();
+        let (library, recorder) = open_test_library_with_recorder(bundle).await;
+
+        // Insert a synced original (external_id + content_hash set).
+        let original_id = MediaId::new("orig".into());
+        let mut rec = crate::library::db::test_helpers::test_record(original_id.clone());
+        rec.relative_path = "orig.jpg".into();
+        rec.external_id = Some("immich-orig".into());
+        rec.content_hash = Some("hash-orig".into());
+        rec.original_filename = "IMG_42.jpg".into();
+        library.media().insert_media(&rec).await.unwrap();
+        recorder.clear();
+
+        let mut state = editing::EditState::default();
+        state.exposure.brightness = 0.5;
+        library
+            .save_pixel_edit(&original_id, &state, rendered_jpeg())
+            .await
+            .unwrap();
+
+        // Server-rendered pointer is stamped on the edit row.
+        let rendered_id = library
+            .editing()
+            .server_rendered_asset_id(&original_id)
+            .await
+            .unwrap()
+            .expect("rendered id must be stamped");
+
+        // The rendered file exists under the sharded originals layout.
+        let rendered_relative = crate::library::thumbnail::sharded_original_relative(&rendered_id);
+        let rendered_abs = originals_dir.join(&rendered_relative);
+        assert!(
+            rendered_abs.exists(),
+            "rendered file should be on disk at {rendered_abs:?}"
+        );
+        let bytes = std::fs::read(&rendered_abs).unwrap();
+        // XMP marker must be embedded for Phase D recovery.
+        assert!(
+            crate::renderer::xmp::extract_xmp(&bytes).unwrap().is_some(),
+            "rendered JPEG must carry the Moments XMP block"
+        );
+
+        // Mutation sequence: AssetImported (from insert_media),
+        // StackCreated, AssetTaggedMomentsEdit — recorded in this order.
+        let recorded = recorder.snapshot();
+        let mut iter = recorded.iter();
+        assert!(matches!(
+            iter.next(),
+            Some(mutation::Mutation::AssetImported { id, .. }) if id == &rendered_id
+        ));
+        assert!(matches!(
+            iter.next(),
+            Some(mutation::Mutation::StackCreated { rendered_asset_id, original_asset_id })
+                if rendered_asset_id == &rendered_id && original_asset_id == &original_id
+        ));
+        assert!(matches!(
+            iter.next(),
+            Some(mutation::Mutation::AssetTaggedMomentsEdit { id }) if id == &rendered_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn revert_edit_clears_state_and_enqueues_rendered_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = fresh_bundle(dir.path());
+        let (library, recorder) = open_test_library_with_recorder(bundle).await;
+
+        // Set up: synced original + first pixel edit save → rendered exists.
+        let original_id = MediaId::new("orig".into());
+        let mut rec = crate::library::db::test_helpers::test_record(original_id.clone());
+        rec.relative_path = "orig.jpg".into();
+        rec.external_id = Some("immich-orig".into());
+        rec.content_hash = Some("hash".into());
+        library.media().insert_media(&rec).await.unwrap();
+        let mut state = editing::EditState::default();
+        state.exposure.brightness = 0.5;
+        library
+            .save_pixel_edit(&original_id, &state, rendered_jpeg())
+            .await
+            .unwrap();
+        let rendered_id = library
+            .editing()
+            .server_rendered_asset_id(&original_id)
+            .await
+            .unwrap()
+            .unwrap();
+        recorder.clear();
+
+        library.revert_edit(&original_id).await.unwrap();
+
+        // Edit row is gone.
+        assert!(library
+            .editing()
+            .get_edit_state(&original_id)
+            .await
+            .unwrap()
+            .is_none());
+
+        // Rendered media row is gone.
+        assert!(library
+            .media()
+            .get_media_item(&rendered_id)
+            .await
+            .unwrap()
+            .is_none());
+
+        // Mutation sequence: AssetUntaggedMomentsEdit (stack-remove
+        // is skipped — no stack_id yet because StackCreated hasn't
+        // drained in this unit test), AssetDeleted for the rendered,
+        // then AssetEditsCleared for the original. The Phase B
+        // `AssetEditsCleared` shows up *after* the cleanup, matching
+        // the §7.3 order documented in the design doc.
+        let recorded = recorder.snapshot();
+        assert!(recorded
+            .iter()
+            .any(|m| matches!(m, mutation::Mutation::AssetUntaggedMomentsEdit { id } if id == &rendered_id)));
+        assert!(recorded
+            .iter()
+            .any(|m| matches!(m, mutation::Mutation::AssetDeleted { items } if items.iter().any(|(i, _)| i == &rendered_id))));
+        assert!(matches!(
+            recorded.last(),
+            Some(mutation::Mutation::AssetEditsCleared { id }) if id == &original_id
+        ));
     }
 
     #[tokio::test]

--- a/src/library/mutation.rs
+++ b/src/library/mutation.rs
@@ -76,6 +76,35 @@ pub enum Mutation {
     /// The local edit state for an asset was cleared (revert).
     AssetEditsCleared { id: MediaId },
 
+    // ── Stacks (Phase C, #224) ───────────────────────────────────────
+    /// A pixel-adjustment edit was saved: a new rendered asset was
+    /// imported and should be stacked with the original on the server.
+    /// The push handler waits for both members' `external_id`s to be
+    /// stamped before calling `POST /stacks`.
+    StackCreated {
+        /// Local id of the rendered asset (becomes the stack primary
+        /// on Immich; §8.2 swaps this back to the original in the
+        /// timeline grid).
+        rendered_asset_id: MediaId,
+        /// Local id of the original asset.
+        original_asset_id: MediaId,
+    },
+
+    /// A stack member should be removed on the server (revert flow).
+    /// Immich auto-deletes the stack when fewer than 2 members remain;
+    /// the surviving sibling's `stackId` clears on the next pull
+    /// cycle, so no explicit local cleanup is recorded here.
+    StackMemberRemoved { stack_id: String, asset_id: MediaId },
+
+    // ── Tags ──────────────────────────────────────────────────────────
+    /// Apply the well-known `moments-edit` tag to a rendered asset.
+    /// The push handler creates the tag lazily via PUT /tags on first
+    /// use and caches the resolved tag id in memory for the session.
+    AssetTaggedMomentsEdit { id: MediaId },
+
+    /// Detach the `moments-edit` tag from an asset (revert flow).
+    AssetUntaggedMomentsEdit { id: MediaId },
+
     // ── People ───────────────────────────────────────────────────────
     /// A person was renamed.
     PersonRenamed { id: PersonId, name: String },
@@ -242,6 +271,45 @@ impl Mutation {
                 payload: None,
             }],
 
+            Mutation::StackCreated {
+                rendered_asset_id,
+                original_asset_id,
+            } => {
+                let payload =
+                    serde_json::json!({ "original_asset_id": original_asset_id.as_str() })
+                        .to_string();
+                vec![OutboxRow {
+                    entity_type: "stack".into(),
+                    entity_id: rendered_asset_id.as_str().into(),
+                    action: "create".into(),
+                    payload: Some(payload),
+                }]
+            }
+
+            Mutation::StackMemberRemoved { stack_id, asset_id } => {
+                let payload = serde_json::json!({ "asset_id": asset_id.as_str() }).to_string();
+                vec![OutboxRow {
+                    entity_type: "stack".into(),
+                    entity_id: stack_id.clone(),
+                    action: "remove_member".into(),
+                    payload: Some(payload),
+                }]
+            }
+
+            Mutation::AssetTaggedMomentsEdit { id } => vec![OutboxRow {
+                entity_type: "asset".into(),
+                entity_id: id.as_str().into(),
+                action: "tag_moments_edit".into(),
+                payload: None,
+            }],
+
+            Mutation::AssetUntaggedMomentsEdit { id } => vec![OutboxRow {
+                entity_type: "asset".into(),
+                entity_id: id.as_str().into(),
+                action: "untag_moments_edit".into(),
+                payload: None,
+            }],
+
             Mutation::PersonRenamed { id, name } => {
                 let payload = serde_json::json!({ "name": name }).to_string();
                 vec![OutboxRow {
@@ -352,9 +420,23 @@ mod tests {
             Mutation::AssetEditsCleared {
                 id: MediaId::new("id7".to_string()),
             },
+            Mutation::StackCreated {
+                rendered_asset_id: MediaId::new("rendered-1".to_string()),
+                original_asset_id: MediaId::new("orig-1".to_string()),
+            },
+            Mutation::StackMemberRemoved {
+                stack_id: "stk-1".to_string(),
+                asset_id: MediaId::new("rendered-1".to_string()),
+            },
+            Mutation::AssetTaggedMomentsEdit {
+                id: MediaId::new("rendered-2".to_string()),
+            },
+            Mutation::AssetUntaggedMomentsEdit {
+                id: MediaId::new("rendered-3".to_string()),
+            },
         ];
 
-        assert_eq!(mutations.len(), 14);
+        assert_eq!(mutations.len(), 18);
         for m in &mutations {
             // Ensure Debug doesn't panic.
             let _ = format!("{m:?}");
@@ -383,6 +465,49 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].action, "clear_edits");
         assert!(rows[0].payload.is_none());
+    }
+
+    #[test]
+    fn stack_created_carries_original_id_in_payload() {
+        let m = Mutation::StackCreated {
+            rendered_asset_id: MediaId::new("rendered".into()),
+            original_asset_id: MediaId::new("orig".into()),
+        };
+        let rows = m.to_outbox_rows();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].entity_type, "stack");
+        assert_eq!(rows[0].entity_id, "rendered");
+        assert_eq!(rows[0].action, "create");
+        assert!(rows[0].payload.as_deref().unwrap().contains("orig"));
+    }
+
+    #[test]
+    fn stack_member_removed_keys_by_stack_id() {
+        let m = Mutation::StackMemberRemoved {
+            stack_id: "stk-uuid".into(),
+            asset_id: MediaId::new("rendered".into()),
+        };
+        let rows = m.to_outbox_rows();
+        assert_eq!(rows[0].entity_type, "stack");
+        assert_eq!(rows[0].entity_id, "stk-uuid");
+        assert_eq!(rows[0].action, "remove_member");
+        assert!(rows[0].payload.as_deref().unwrap().contains("\"rendered\""));
+    }
+
+    #[test]
+    fn tag_actions_are_payload_free() {
+        let tag = Mutation::AssetTaggedMomentsEdit {
+            id: MediaId::new("rendered".into()),
+        };
+        let untag = Mutation::AssetUntaggedMomentsEdit {
+            id: MediaId::new("rendered".into()),
+        };
+        let tag_rows = tag.to_outbox_rows();
+        let untag_rows = untag.to_outbox_rows();
+        assert_eq!(tag_rows[0].action, "tag_moments_edit");
+        assert!(tag_rows[0].payload.is_none());
+        assert_eq!(untag_rows[0].action, "untag_moments_edit");
+        assert!(untag_rows[0].payload.is_none());
     }
 
     #[test]

--- a/src/library/recorder.rs
+++ b/src/library/recorder.rs
@@ -18,11 +18,38 @@ pub trait MutationRecorder: Send + Sync {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::library::media::MediaId;
     use crate::sync::outbox::NoOpRecorder;
-    use std::sync::Arc;
+    use async_trait::async_trait;
+    use std::sync::{Arc, Mutex};
+
+    /// Test fixture: records every mutation passed to `record` so
+    /// assertions can inspect the outbox-bound sequence emitted by
+    /// services and cross-service orchestrators.
+    #[derive(Default)]
+    pub(crate) struct CapturingRecorder {
+        recorded: Mutex<Vec<Mutation>>,
+    }
+
+    impl CapturingRecorder {
+        pub(crate) fn snapshot(&self) -> Vec<Mutation> {
+            self.recorded.lock().unwrap().clone()
+        }
+
+        pub(crate) fn clear(&self) {
+            self.recorded.lock().unwrap().clear();
+        }
+    }
+
+    #[async_trait]
+    impl MutationRecorder for CapturingRecorder {
+        async fn record(&self, mutation: &Mutation) -> Result<(), LibraryError> {
+            self.recorded.lock().unwrap().push(mutation.clone());
+            Ok(())
+        }
+    }
 
     #[tokio::test]
     async fn trait_is_object_safe() {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -18,3 +18,4 @@ pub mod output;
 pub mod pipeline;
 pub mod resize;
 pub mod target;
+pub mod xmp;

--- a/src/renderer/output.rs
+++ b/src/renderer/output.rs
@@ -27,6 +27,27 @@ pub fn to_webp(img: &DynamicImage) -> Result<Vec<u8>, RenderError> {
     Ok(buf.into_inner())
 }
 
+/// Encode as JPEG bytes at the given quality (1–100).
+///
+/// Phase C uses this to produce the rendered output that gets stacked
+/// alongside the original on Immich. The caller is expected to inject
+/// the Moments XMP APP1 segment afterwards via
+/// [`super::xmp::inject_xmp`].
+///
+/// Blocking — call from `spawn_blocking`. JPEG compression can take
+/// 50–500 ms for a large photo.
+pub fn to_jpeg(img: &DynamicImage, quality: u8) -> Result<Vec<u8>, RenderError> {
+    use image::codecs::jpeg::JpegEncoder;
+    let rgb = img.to_rgb8();
+    let (w, h) = rgb.dimensions();
+    let mut buf = Vec::with_capacity((w * h) as usize);
+    let mut encoder = JpegEncoder::new_with_quality(&mut buf, quality);
+    encoder
+        .encode(&rgb, w, h, image::ExtendedColorType::Rgb8)
+        .map_err(|e| RenderError::EncodeFailed(e.to_string()))?;
+    Ok(buf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -58,6 +79,17 @@ mod tests {
         assert_eq!(bytes[1], 100);
         assert_eq!(bytes[2], 50);
         assert_eq!(bytes[3], 255);
+    }
+
+    #[test]
+    fn to_jpeg_produces_valid_jpeg() {
+        let img = test_image();
+        let bytes = to_jpeg(&img, 85).unwrap();
+        // JPEG magic: FF D8 FF.
+        assert!(bytes.len() > 4);
+        assert_eq!(&bytes[..3], &[0xFF, 0xD8, 0xFF]);
+        // Ends with EOI marker FF D9.
+        assert_eq!(&bytes[bytes.len() - 2..], &[0xFF, 0xD9]);
     }
 
     #[test]

--- a/src/renderer/xmp.rs
+++ b/src/renderer/xmp.rs
@@ -26,7 +26,7 @@
 //! Adobe XMP lives in an APP1 (`FF E1`) marker segment whose payload
 //! starts with the marker `http://ns.adobe.com/xap/1.0/\0`. Cameras
 //! commonly already use APP1 for EXIF; we walk past EXIF (and any
-//! other APPn segments) and insert ours right before the first non-app
+//! other APP segments) and insert ours right before the first non-app
 //! segment, so EXIF stays intact.
 //!
 //! See [XMP Specification Part 3 §1.1.3](https://www.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf).
@@ -282,7 +282,7 @@ pub fn decode(xml: &str) -> Result<EmbeddedEdit, XmpError> {
 
 /// Append an Adobe XMP APP1 segment to an in-memory JPEG.
 ///
-/// The segment is inserted **after** any existing APPn segments (so an
+/// The segment is inserted **after** any existing APP segments (so an
 /// EXIF APP1 stays intact) and before the first non-app segment.
 /// Returns `XmpError::Jpeg` if the input doesn't start with SOI or
 /// runs out of segments before SOS.
@@ -313,7 +313,7 @@ pub fn inject_xmp(jpeg: &[u8], xmp: &str) -> Result<Vec<u8>, XmpError> {
 
 /// Walk the JPEG header marker chain and return the byte offset of
 /// the first non-app segment (DQT, SOF, etc.) — i.e. the right
-/// insertion point for a new APPn marker.
+/// insertion point for a new APP marker.
 ///
 /// JPEG layout:
 ///   * `FF D8`       — SOI (no length)
@@ -342,14 +342,14 @@ fn find_post_app_offset(jpeg: &[u8]) -> Result<usize, XmpError> {
         }
         let marker = jpeg[i];
         i += 1;
-        // APPn = 0xE0..=0xEF — keep walking past these
+        // APP markers (0xE0..=0xEF) — keep walking past these
         if (0xE0..=0xEF).contains(&marker) {
             if i + 2 > jpeg.len() {
-                return Err(XmpError::Jpeg("truncated APPn length"));
+                return Err(XmpError::Jpeg("truncated APP segment length"));
             }
             let seg_len = u16::from_be_bytes([jpeg[i], jpeg[i + 1]]) as usize;
             if seg_len < 2 || i + seg_len > jpeg.len() {
-                return Err(XmpError::Jpeg("APPn segment length out of bounds"));
+                return Err(XmpError::Jpeg("APP segment length out of bounds"));
             }
             i += seg_len;
             continue;

--- a/src/renderer/xmp.rs
+++ b/src/renderer/xmp.rs
@@ -1,0 +1,600 @@
+//! XMP encode/decode + JPEG APP1 segment injection.
+//!
+//! Phase C (#224) embeds a Moments-specific XMP block in every
+//! rendered JPEG so a fresh-install Moments can reconstruct the local
+//! `edits` row by reading the rendered sibling's bytes (Phase D).
+//!
+//! ## Wire shape
+//!
+//! ```xml
+//! <x:xmpmeta xmlns:x="adobe:ns:meta/">
+//!   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+//!     <rdf:Description rdf:about=""
+//!         xmlns:moments="urn:moments:edits:1.0">
+//!       <moments:originalAssetId>…</moments:originalAssetId>
+//!       <moments:originalContentHash>…</moments:originalContentHash>
+//!       <moments:editVersion>1</moments:editVersion>
+//!       <moments:renderedAt>2026-05-10T12:34:56Z</moments:renderedAt>
+//!       <moments:editJson>…</moments:editJson>
+//!     </rdf:Description>
+//!   </rdf:RDF>
+//! </x:xmpmeta>
+//! ```
+//!
+//! ## JPEG APP1 layout
+//!
+//! Adobe XMP lives in an APP1 (`FF E1`) marker segment whose payload
+//! starts with the marker `http://ns.adobe.com/xap/1.0/\0`. Cameras
+//! commonly already use APP1 for EXIF; we walk past EXIF (and any
+//! other APPn segments) and insert ours right before the first non-app
+//! segment, so EXIF stays intact.
+//!
+//! See [XMP Specification Part 3 §1.1.3](https://www.adobe.com/content/dam/acom/en/devnet/xmp/pdfs/XMP%20SDK%20Release%20cc-2016-08/XMPSpecificationPart3.pdf).
+
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+/// Adobe's standard XMP APP1 marker, including the trailing NUL.
+pub(crate) const ADOBE_XMP_MARKER: &[u8] = b"http://ns.adobe.com/xap/1.0/\0";
+
+/// Cap a single APP1 segment's payload at this size. JPEG segment
+/// length is a 16-bit field that includes the 2 length bytes, so the
+/// payload max is 65533 bytes. We refuse to inject beyond this — XMP
+/// extension segments (`ExtendedXMP`) exist but Moments-edit JSON is
+/// far smaller than that ceiling in practice.
+const MAX_APP1_PAYLOAD: usize = 65533;
+
+/// Phase D recovery payload — what a fresh install reads back from a
+/// rendered JPEG to rebuild the local `edits` row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EmbeddedEdit {
+    /// Immich asset id of the *original* (un-edited) asset. Phase D
+    /// uses this to find the parent during recovery.
+    pub original_asset_id: String,
+    /// SHA-1 base64 of the original asset's bytes — fallback when the
+    /// `original_asset_id` doesn't resolve (rare: original was
+    /// re-uploaded). Matches Immich's `checksum` wire format.
+    pub original_content_hash: String,
+    /// Schema version of `edit_json`. Bumped only on incompatible
+    /// changes; consumers parse forward-compatibly.
+    pub edit_version: u32,
+    /// When the render was produced locally. Tiebreaker if multiple
+    /// Moments installs raced.
+    pub rendered_at: DateTime<Utc>,
+    /// Serialised `EditState` (the whole struct's JSON form).
+    pub edit_json: String,
+}
+
+#[derive(Debug, Error)]
+pub enum XmpError {
+    #[error("XML parse error: {0}")]
+    Xml(String),
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("invalid field {field}: {reason}")]
+    InvalidField { field: &'static str, reason: String },
+    #[error("JPEG parse error: {0}")]
+    Jpeg(&'static str),
+    #[error("XMP block too large for one APP1 segment ({size} > {max})")]
+    TooLarge { size: usize, max: usize },
+}
+
+// ── XMP encode (hand-rolled, deterministic output) ────────────────────
+
+/// Serialise an [`EmbeddedEdit`] into the canonical XMP block.
+pub fn encode(edit: &EmbeddedEdit) -> String {
+    let mut s = String::with_capacity(512 + edit.edit_json.len());
+    s.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    s.push_str("<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">");
+    s.push_str("<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">");
+    s.push_str("<rdf:Description rdf:about=\"\" xmlns:moments=\"urn:moments:edits:1.0\">");
+    push_element(&mut s, "moments:originalAssetId", &edit.original_asset_id);
+    push_element(
+        &mut s,
+        "moments:originalContentHash",
+        &edit.original_content_hash,
+    );
+    push_element(
+        &mut s,
+        "moments:editVersion",
+        &edit.edit_version.to_string(),
+    );
+    push_element(&mut s, "moments:renderedAt", &edit.rendered_at.to_rfc3339());
+    push_element(&mut s, "moments:editJson", &edit.edit_json);
+    s.push_str("</rdf:Description>");
+    s.push_str("</rdf:RDF>");
+    s.push_str("</x:xmpmeta>");
+    s
+}
+
+fn push_element(buf: &mut String, tag: &str, content: &str) {
+    buf.push('<');
+    buf.push_str(tag);
+    buf.push('>');
+    push_xml_escaped(buf, content);
+    buf.push_str("</");
+    buf.push_str(tag);
+    buf.push('>');
+}
+
+/// Resolve the five XML named entities + numeric character references.
+/// Returns `None` for unknown entity names so the caller can decide
+/// whether to keep the raw text or fail.
+fn resolve_xml_entity(name: &str) -> Option<String> {
+    match name {
+        "amp" => Some("&".into()),
+        "lt" => Some("<".into()),
+        "gt" => Some(">".into()),
+        "quot" => Some("\"".into()),
+        "apos" => Some("'".into()),
+        n if n.starts_with('#') => {
+            let digits = &n[1..];
+            let code = if let Some(hex) = digits
+                .strip_prefix('x')
+                .or_else(|| digits.strip_prefix('X'))
+            {
+                u32::from_str_radix(hex, 16).ok()?
+            } else {
+                digits.parse::<u32>().ok()?
+            };
+            char::from_u32(code).map(|c| c.to_string())
+        }
+        _ => None,
+    }
+}
+
+fn push_xml_escaped(buf: &mut String, s: &str) {
+    for c in s.chars() {
+        match c {
+            '&' => buf.push_str("&amp;"),
+            '<' => buf.push_str("&lt;"),
+            '>' => buf.push_str("&gt;"),
+            '"' => buf.push_str("&quot;"),
+            '\'' => buf.push_str("&apos;"),
+            _ => buf.push(c),
+        }
+    }
+}
+
+// ── XMP decode (quick-xml — survives whitespace/attribute drift) ──────
+
+/// Parse an XMP block back into an [`EmbeddedEdit`].
+pub fn decode(xml: &str) -> Result<EmbeddedEdit, XmpError> {
+    use quick_xml::events::Event;
+    use quick_xml::Reader;
+
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(false);
+
+    let mut original_asset_id: Option<String> = None;
+    let mut original_content_hash: Option<String> = None;
+    let mut edit_version: Option<u32> = None;
+    let mut rendered_at: Option<DateTime<Utc>> = None;
+    let mut edit_json: Option<String> = None;
+
+    // Accumulate all text+CDATA inside a `moments:` element and only
+    // commit on End — quick-xml splits text runs around entity refs,
+    // and a JSON payload with escaped quotes would be lost otherwise.
+    let mut buf = Vec::new();
+    let mut current_field: Option<&'static str> = None;
+    let mut accumulator = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Err(e) => {
+                return Err(XmpError::Xml(format!(
+                    "at {}: {e}",
+                    reader.error_position()
+                )))
+            }
+            Ok(Event::Eof) => break,
+            Ok(Event::Start(e)) => {
+                let name = e.name();
+                let local = std::str::from_utf8(name.local_name().as_ref())
+                    .unwrap_or("")
+                    .to_string();
+                let new_field = match local.as_str() {
+                    "originalAssetId" => Some("originalAssetId"),
+                    "originalContentHash" => Some("originalContentHash"),
+                    "editVersion" => Some("editVersion"),
+                    "renderedAt" => Some("renderedAt"),
+                    "editJson" => Some("editJson"),
+                    _ => None,
+                };
+                if new_field.is_some() {
+                    accumulator.clear();
+                    current_field = new_field;
+                }
+            }
+            Ok(Event::End(_)) => {
+                if let Some(field) = current_field.take() {
+                    let value = std::mem::take(&mut accumulator);
+                    match field {
+                        "originalAssetId" => original_asset_id = Some(value),
+                        "originalContentHash" => original_content_hash = Some(value),
+                        "editVersion" => {
+                            edit_version = Some(value.trim().parse().map_err(
+                                |e: std::num::ParseIntError| XmpError::InvalidField {
+                                    field: "editVersion",
+                                    reason: e.to_string(),
+                                },
+                            )?);
+                        }
+                        "renderedAt" => {
+                            rendered_at = Some(
+                                DateTime::parse_from_rfc3339(value.trim())
+                                    .map_err(|e| XmpError::InvalidField {
+                                        field: "renderedAt",
+                                        reason: e.to_string(),
+                                    })?
+                                    .with_timezone(&Utc),
+                            );
+                        }
+                        "editJson" => edit_json = Some(value),
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::Text(t)) if current_field.is_some() => {
+                let decoded = t.decode().map_err(|e| XmpError::Xml(e.to_string()))?;
+                let unescaped = quick_xml::escape::unescape(&decoded)
+                    .map_err(|e| XmpError::Xml(e.to_string()))?;
+                accumulator.push_str(&unescaped);
+            }
+            Ok(Event::CData(t)) if current_field.is_some() => {
+                // CDATA is literal — no entity unescaping.
+                let s = std::str::from_utf8(&t)
+                    .map_err(|e| XmpError::Xml(format!("CDATA not UTF-8: {e}")))?;
+                accumulator.push_str(s);
+            }
+            // quick-xml emits entity references (`&quot;`, `&#34;`, etc.)
+            // as their own events, separate from surrounding Text. We
+            // resolve standard XML entities and numeric refs in-line so
+            // the accumulator sees the original text. Anything we don't
+            // recognise is kept as `&name;` rather than being dropped —
+            // that round-trips through the encode-side escaping.
+            Ok(Event::GeneralRef(r)) if current_field.is_some() => {
+                let name = r.decode().map_err(|e| XmpError::Xml(e.to_string()))?;
+                if let Some(resolved) = resolve_xml_entity(&name) {
+                    accumulator.push_str(&resolved);
+                } else {
+                    accumulator.push('&');
+                    accumulator.push_str(&name);
+                    accumulator.push(';');
+                }
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(EmbeddedEdit {
+        original_asset_id: original_asset_id.ok_or(XmpError::MissingField("originalAssetId"))?,
+        original_content_hash: original_content_hash
+            .ok_or(XmpError::MissingField("originalContentHash"))?,
+        edit_version: edit_version.ok_or(XmpError::MissingField("editVersion"))?,
+        rendered_at: rendered_at.ok_or(XmpError::MissingField("renderedAt"))?,
+        edit_json: edit_json.ok_or(XmpError::MissingField("editJson"))?,
+    })
+}
+
+// ── JPEG APP1 segment injection ───────────────────────────────────────
+
+/// Append an Adobe XMP APP1 segment to an in-memory JPEG.
+///
+/// The segment is inserted **after** any existing APPn segments (so an
+/// EXIF APP1 stays intact) and before the first non-app segment.
+/// Returns `XmpError::Jpeg` if the input doesn't start with SOI or
+/// runs out of segments before SOS.
+pub fn inject_xmp(jpeg: &[u8], xmp: &str) -> Result<Vec<u8>, XmpError> {
+    let xmp_bytes = xmp.as_bytes();
+    let segment_payload_len = ADOBE_XMP_MARKER.len() + xmp_bytes.len();
+    if segment_payload_len > MAX_APP1_PAYLOAD {
+        return Err(XmpError::TooLarge {
+            size: segment_payload_len,
+            max: MAX_APP1_PAYLOAD,
+        });
+    }
+
+    let insert_at = find_post_app_offset(jpeg)?;
+
+    // segment len = 2 (length field itself) + marker + xmp
+    let seg_len = 2 + segment_payload_len;
+    let mut out = Vec::with_capacity(jpeg.len() + 4 + segment_payload_len);
+    out.extend_from_slice(&jpeg[..insert_at]);
+    out.push(0xFF);
+    out.push(0xE1);
+    out.extend_from_slice(&(seg_len as u16).to_be_bytes());
+    out.extend_from_slice(ADOBE_XMP_MARKER);
+    out.extend_from_slice(xmp_bytes);
+    out.extend_from_slice(&jpeg[insert_at..]);
+    Ok(out)
+}
+
+/// Walk the JPEG header marker chain and return the byte offset of
+/// the first non-app segment (DQT, SOF, etc.) — i.e. the right
+/// insertion point for a new APPn marker.
+///
+/// JPEG layout:
+///   * `FF D8`       — SOI (no length)
+///   * `FF E0..EF`   — APP0..APP15: `FF Ex LL LL [data...]`, length is BE u16 *including* the 2 length bytes
+///   * `FF DB / C0 / DA / …` — DQT / SOF / SOS / etc.
+fn find_post_app_offset(jpeg: &[u8]) -> Result<usize, XmpError> {
+    if jpeg.len() < 4 || jpeg[0] != 0xFF || jpeg[1] != 0xD8 {
+        return Err(XmpError::Jpeg("missing SOI marker"));
+    }
+    let mut i = 2;
+    loop {
+        if i + 1 >= jpeg.len() {
+            return Err(XmpError::Jpeg("truncated before any non-SOI segment"));
+        }
+        if jpeg[i] != 0xFF {
+            return Err(XmpError::Jpeg(
+                "unexpected byte where marker prefix expected",
+            ));
+        }
+        // Skip over consecutive 0xFF fill bytes (rare but legal).
+        while i < jpeg.len() && jpeg[i] == 0xFF {
+            i += 1;
+        }
+        if i >= jpeg.len() {
+            return Err(XmpError::Jpeg("truncated after FF padding"));
+        }
+        let marker = jpeg[i];
+        i += 1;
+        // APPn = 0xE0..=0xEF — keep walking past these
+        if (0xE0..=0xEF).contains(&marker) {
+            if i + 2 > jpeg.len() {
+                return Err(XmpError::Jpeg("truncated APPn length"));
+            }
+            let seg_len = u16::from_be_bytes([jpeg[i], jpeg[i + 1]]) as usize;
+            if seg_len < 2 || i + seg_len > jpeg.len() {
+                return Err(XmpError::Jpeg("APPn segment length out of bounds"));
+            }
+            i += seg_len;
+            continue;
+        }
+        // Any other marker: insertion point is just before the FF prefix,
+        // i.e. before the marker byte we already advanced past — back up
+        // to the FF (skipping any fill 0xFFs we walked through).
+        let mut back = i - 1; // the marker byte
+        while back > 0 && jpeg[back - 1] == 0xFF {
+            back -= 1;
+        }
+        return Ok(back);
+    }
+}
+
+/// Find and return the XMP block embedded in a JPEG, if any.
+///
+/// Walks the APP1 segments and returns the first whose payload starts
+/// with the Adobe XMP marker. Returns `None` if no such segment exists.
+pub fn extract_xmp(jpeg: &[u8]) -> Result<Option<String>, XmpError> {
+    if jpeg.len() < 4 || jpeg[0] != 0xFF || jpeg[1] != 0xD8 {
+        return Err(XmpError::Jpeg("missing SOI marker"));
+    }
+    let mut i = 2;
+    loop {
+        if i + 1 >= jpeg.len() {
+            return Ok(None);
+        }
+        while i < jpeg.len() && jpeg[i] == 0xFF {
+            i += 1;
+        }
+        if i >= jpeg.len() {
+            return Ok(None);
+        }
+        let marker = jpeg[i];
+        i += 1;
+        if (0xE0..=0xEF).contains(&marker) {
+            if i + 2 > jpeg.len() {
+                return Ok(None);
+            }
+            let seg_len = u16::from_be_bytes([jpeg[i], jpeg[i + 1]]) as usize;
+            if seg_len < 2 || i + seg_len > jpeg.len() {
+                return Ok(None);
+            }
+            let body_start = i + 2;
+            let body_end = i + seg_len;
+            i = body_end;
+            if marker == 0xE1
+                && body_end - body_start >= ADOBE_XMP_MARKER.len()
+                && &jpeg[body_start..body_start + ADOBE_XMP_MARKER.len()] == ADOBE_XMP_MARKER
+            {
+                let xmp_bytes = &jpeg[body_start + ADOBE_XMP_MARKER.len()..body_end];
+                let xmp = std::str::from_utf8(xmp_bytes)
+                    .map_err(|e| XmpError::Xml(format!("XMP not UTF-8: {e}")))?;
+                return Ok(Some(xmp.to_string()));
+            }
+            continue;
+        }
+        // Reached a non-app marker — XMP not present.
+        return Ok(None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_edit() -> EmbeddedEdit {
+        EmbeddedEdit {
+            original_asset_id: "e4f66d10-b88f-44e7-89ce-79259805a3b3".into(),
+            original_content_hash: "uf1I8QpFndkfh4yAQn+SwZWvLZg=".into(),
+            edit_version: 1,
+            rendered_at: DateTime::parse_from_rfc3339("2026-05-10T12:34:56+00:00")
+                .unwrap()
+                .with_timezone(&Utc),
+            edit_json: r#"{"version":1,"exposure":{"brightness":0.5}}"#.into(),
+        }
+    }
+
+    #[test]
+    fn encode_then_decode_round_trips() {
+        let original = sample_edit();
+        let xml = encode(&original);
+        let decoded = decode(&xml).unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn encode_escapes_xml_special_chars_in_edit_json() {
+        // editJson is JSON which is largely XML-safe, but `<` could
+        // appear in a string field. Verify it's escaped, and that the
+        // decoded payload is bytewise-equal to the input.
+        let original = EmbeddedEdit {
+            edit_json: r#"{"label":"a < b & c > d"}"#.into(),
+            ..sample_edit()
+        };
+        let xml = encode(&original);
+        assert!(xml.contains("&lt;"));
+        assert!(xml.contains("&gt;"));
+        assert!(xml.contains("&amp;"));
+        let decoded = decode(&xml).unwrap();
+        assert_eq!(decoded.edit_json, original.edit_json);
+    }
+
+    #[test]
+    fn decode_tolerates_attribute_reordering() {
+        // Immich's media pipeline could rewrite RDF attributes. Our
+        // decoder should match by local name + namespace, not exact
+        // attribute order. Construct a "rewritten" form and verify.
+        let xml = r#"<?xml version="1.0"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:moments="urn:moments:edits:1.0" rdf:about=""><moments:originalAssetId>asset-1</moments:originalAssetId><moments:originalContentHash>hash-1</moments:originalContentHash><moments:editVersion>1</moments:editVersion><moments:renderedAt>2026-05-10T12:34:56+00:00</moments:renderedAt><moments:editJson>{}</moments:editJson></rdf:Description></rdf:RDF></x:xmpmeta>"#;
+        let edit = decode(xml).unwrap();
+        assert_eq!(edit.original_asset_id, "asset-1");
+        assert_eq!(edit.edit_version, 1);
+    }
+
+    #[test]
+    fn decode_missing_field_returns_error() {
+        let xml = r#"<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:moments="urn:moments:edits:1.0"><moments:originalAssetId>asset-1</moments:originalAssetId></rdf:Description></rdf:RDF></x:xmpmeta>"#;
+        let err = decode(xml).unwrap_err();
+        assert!(matches!(err, XmpError::MissingField(_)));
+    }
+
+    #[test]
+    fn decode_invalid_version_returns_error() {
+        let xml = r#"<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description xmlns:moments="urn:moments:edits:1.0"><moments:originalAssetId>a</moments:originalAssetId><moments:originalContentHash>h</moments:originalContentHash><moments:editVersion>not-a-number</moments:editVersion><moments:renderedAt>2026-05-10T12:34:56+00:00</moments:renderedAt><moments:editJson>{}</moments:editJson></rdf:Description></rdf:RDF></x:xmpmeta>"#;
+        let err = decode(xml).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                XmpError::InvalidField {
+                    field: "editVersion",
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+    }
+
+    // ── JPEG segment walker tests ────────────────────────────────────
+
+    /// Build a minimal JPEG: SOI + APP0 (JFIF) + DQT + EOI.
+    /// Not decodable as an image, but valid for segment-walking tests.
+    fn minimal_jpeg() -> Vec<u8> {
+        let mut j = Vec::new();
+        j.extend_from_slice(&[0xFF, 0xD8]); // SOI
+                                            // APP0 JFIF: marker + length(16) + "JFIF\0" + 1.01 + ...
+        j.extend_from_slice(&[0xFF, 0xE0]);
+        let app0_payload = b"JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00";
+        j.extend_from_slice(&((app0_payload.len() + 2) as u16).to_be_bytes());
+        j.extend_from_slice(app0_payload);
+        // DQT (we won't supply real data, just a stub segment)
+        j.extend_from_slice(&[0xFF, 0xDB]);
+        let dqt_payload = [0u8; 64];
+        j.extend_from_slice(&((dqt_payload.len() + 2) as u16).to_be_bytes());
+        j.extend_from_slice(&dqt_payload);
+        j.extend_from_slice(&[0xFF, 0xD9]); // EOI
+        j
+    }
+
+    #[test]
+    fn jpeg_with_xmp_contains_marker_and_payload() {
+        let jpeg = minimal_jpeg();
+        let xmp = encode(&sample_edit());
+        let out = inject_xmp(&jpeg, &xmp).unwrap();
+        // APP0 should still be present and unchanged.
+        assert_eq!(&out[2..4], &[0xFF, 0xE0]);
+        // Marker bytes appear in the output.
+        assert!(out
+            .windows(ADOBE_XMP_MARKER.len())
+            .any(|w| w == ADOBE_XMP_MARKER));
+        // Original payload bytes appear too.
+        assert!(out.windows(20).any(|w| w.starts_with(b"<x:xmpmeta")));
+    }
+
+    #[test]
+    fn inject_then_extract_round_trips_xmp_text() {
+        let jpeg = minimal_jpeg();
+        let xmp = encode(&sample_edit());
+        let out = inject_xmp(&jpeg, &xmp).unwrap();
+        let extracted = extract_xmp(&out).unwrap().unwrap();
+        assert_eq!(extracted, xmp);
+    }
+
+    #[test]
+    fn inject_inserts_after_existing_app_segments() {
+        // Verify the new APP1 lands AFTER APP0, not before.
+        let jpeg = minimal_jpeg();
+        let xmp = encode(&sample_edit());
+        let out = inject_xmp(&jpeg, &xmp).unwrap();
+        // Walk: SOI APP0 [our APP1] DQT EOI
+        // SOI = bytes 0..2; first segment after SOI should be APP0.
+        assert_eq!(&out[0..2], &[0xFF, 0xD8]);
+        assert_eq!(&out[2..4], &[0xFF, 0xE0]);
+        // skip APP0 length + payload
+        let app0_len = u16::from_be_bytes([out[4], out[5]]) as usize;
+        let after_app0 = 4 + app0_len;
+        assert_eq!(&out[after_app0..after_app0 + 2], &[0xFF, 0xE1]);
+    }
+
+    #[test]
+    fn extract_returns_none_when_no_xmp_segment() {
+        let jpeg = minimal_jpeg();
+        assert!(extract_xmp(&jpeg).unwrap().is_none());
+    }
+
+    #[test]
+    fn extract_skips_non_xmp_app1_segments() {
+        // Build a JPEG with an APP1 EXIF segment but no XMP — extract
+        // should skip the EXIF block and not return its bytes.
+        let mut jpeg = Vec::new();
+        jpeg.extend_from_slice(&[0xFF, 0xD8]); // SOI
+        jpeg.extend_from_slice(&[0xFF, 0xE1]); // APP1
+        let exif_payload = b"Exif\x00\x00MM\x00\x2A\x00\x00\x00\x08";
+        jpeg.extend_from_slice(&((exif_payload.len() + 2) as u16).to_be_bytes());
+        jpeg.extend_from_slice(exif_payload);
+        jpeg.extend_from_slice(&[0xFF, 0xD9]); // EOI
+
+        assert!(extract_xmp(&jpeg).unwrap().is_none());
+    }
+
+    #[test]
+    fn inject_rejects_truncated_jpeg() {
+        // No SOI = invalid JPEG.
+        let err = inject_xmp(b"\x00\x00", "x").unwrap_err();
+        assert!(matches!(err, XmpError::Jpeg(_)));
+    }
+
+    #[test]
+    fn inject_rejects_oversize_xmp() {
+        let jpeg = minimal_jpeg();
+        let oversize = "x".repeat(MAX_APP1_PAYLOAD + 1);
+        let err = inject_xmp(&jpeg, &oversize).unwrap_err();
+        assert!(matches!(err, XmpError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn round_trip_through_jpeg_preserves_embedded_edit() {
+        // The full intended use: encode → inject → extract → decode →
+        // recover the original struct.
+        let original = sample_edit();
+        let jpeg = minimal_jpeg();
+        let with_xmp = inject_xmp(&jpeg, &encode(&original)).unwrap();
+        let extracted_xml = extract_xmp(&with_xmp).unwrap().unwrap();
+        let recovered = decode(&extracted_xml).unwrap();
+        assert_eq!(recovered, original);
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -77,6 +77,7 @@ impl SyncHandle {
             sync_events,
             shutdown_rx,
             interval_rx: tokio::sync::Mutex::new(interval_rx),
+            moments_edit_tag: tokio::sync::Mutex::new(None),
         };
         tokio.spawn(async move {
             if let Err(e) = push_mgr.run().await {

--- a/src/sync/outbox/mutation.rs
+++ b/src/sync/outbox/mutation.rs
@@ -74,6 +74,21 @@ pub enum OutboxMutation {
         id: MediaId,
     },
 
+    StackCreated {
+        rendered_asset_id: MediaId,
+        original_asset_id: MediaId,
+    },
+    StackMemberRemoved {
+        stack_id: String,
+        asset_id: MediaId,
+    },
+    AssetTaggedMomentsEdit {
+        id: MediaId,
+    },
+    AssetUntaggedMomentsEdit {
+        id: MediaId,
+    },
+
     PersonRenamed {
         id: PersonId,
         name: String,
@@ -184,6 +199,28 @@ impl OutboxMutation {
                 id: MediaId::new(row.entity_id.clone()),
             }),
             ("asset", "clear_edits") => Some(Self::AssetEditsCleared {
+                id: MediaId::new(row.entity_id.clone()),
+            }),
+            ("stack", "create") => {
+                let p = json();
+                let original_asset_id = p["original_asset_id"].as_str()?.to_string();
+                Some(Self::StackCreated {
+                    rendered_asset_id: MediaId::new(row.entity_id.clone()),
+                    original_asset_id: MediaId::new(original_asset_id),
+                })
+            }
+            ("stack", "remove_member") => {
+                let p = json();
+                let asset_id = p["asset_id"].as_str()?.to_string();
+                Some(Self::StackMemberRemoved {
+                    stack_id: row.entity_id.clone(),
+                    asset_id: MediaId::new(asset_id),
+                })
+            }
+            ("asset", "tag_moments_edit") => Some(Self::AssetTaggedMomentsEdit {
+                id: MediaId::new(row.entity_id.clone()),
+            }),
+            ("asset", "untag_moments_edit") => Some(Self::AssetUntaggedMomentsEdit {
                 id: MediaId::new(row.entity_id.clone()),
             }),
             ("person", "rename") => {
@@ -363,6 +400,20 @@ mod tests {
             Mutation::AssetEditsCleared {
                 id: MediaId::new("id7".into()),
             },
+            Mutation::StackCreated {
+                rendered_asset_id: MediaId::new("rendered".into()),
+                original_asset_id: MediaId::new("orig".into()),
+            },
+            Mutation::StackMemberRemoved {
+                stack_id: "stk-1".into(),
+                asset_id: MediaId::new("rendered".into()),
+            },
+            Mutation::AssetTaggedMomentsEdit {
+                id: MediaId::new("rendered".into()),
+            },
+            Mutation::AssetUntaggedMomentsEdit {
+                id: MediaId::new("rendered".into()),
+            },
         ];
 
         for mutation in &cases {
@@ -398,6 +449,69 @@ mod tests {
         assert!(matches!(
             OutboxMutation::from_row(&clear),
             Some(OutboxMutation::AssetEditsCleared { id }) if id.as_str() == "photo-2"
+        ));
+    }
+
+    #[test]
+    fn stack_created_decodes_with_original_id() {
+        let row = OutboxRow {
+            entity_type: "stack".into(),
+            entity_id: "rendered-uuid".into(),
+            action: "create".into(),
+            payload: Some(r#"{"original_asset_id":"orig-uuid"}"#.into()),
+        };
+        let m = OutboxMutation::from_row(&row).unwrap();
+        match m {
+            OutboxMutation::StackCreated {
+                rendered_asset_id,
+                original_asset_id,
+            } => {
+                assert_eq!(rendered_asset_id.as_str(), "rendered-uuid");
+                assert_eq!(original_asset_id.as_str(), "orig-uuid");
+            }
+            _ => panic!("expected StackCreated"),
+        }
+    }
+
+    #[test]
+    fn stack_member_removed_decodes_stack_and_asset() {
+        let row = OutboxRow {
+            entity_type: "stack".into(),
+            entity_id: "stk-uuid".into(),
+            action: "remove_member".into(),
+            payload: Some(r#"{"asset_id":"rendered-uuid"}"#.into()),
+        };
+        let m = OutboxMutation::from_row(&row).unwrap();
+        match m {
+            OutboxMutation::StackMemberRemoved { stack_id, asset_id } => {
+                assert_eq!(stack_id, "stk-uuid");
+                assert_eq!(asset_id.as_str(), "rendered-uuid");
+            }
+            _ => panic!("expected StackMemberRemoved"),
+        }
+    }
+
+    #[test]
+    fn tag_actions_decode_payload_free() {
+        let tag_row = OutboxRow {
+            entity_type: "asset".into(),
+            entity_id: "rendered".into(),
+            action: "tag_moments_edit".into(),
+            payload: None,
+        };
+        let untag_row = OutboxRow {
+            entity_type: "asset".into(),
+            entity_id: "rendered".into(),
+            action: "untag_moments_edit".into(),
+            payload: None,
+        };
+        assert!(matches!(
+            OutboxMutation::from_row(&tag_row),
+            Some(OutboxMutation::AssetTaggedMomentsEdit { id }) if id.as_str() == "rendered"
+        ));
+        assert!(matches!(
+            OutboxMutation::from_row(&untag_row),
+            Some(OutboxMutation::AssetUntaggedMomentsEdit { id }) if id.as_str() == "rendered"
         ));
     }
 

--- a/src/sync/providers/immich/client.rs
+++ b/src/sync/providers/immich/client.rs
@@ -413,6 +413,90 @@ impl ImmichClient {
             .await
     }
 
+    // ── Stacks (Phase C, #224) ───────────────────────────────────────
+
+    /// Create a stack containing the given assets. The first id in
+    /// the slice becomes the server-side primary; Phase C uploads the
+    /// rendered child first so it's the primary, and the §8.2 grid
+    /// filter swaps the original back in for display.
+    ///
+    /// Returns the new stack's server id.
+    pub(crate) async fn post_stack(
+        &self,
+        asset_ids: &[&str],
+    ) -> Result<StackResponse, LibraryError> {
+        self.post("/stacks", &serde_json::json!({ "assetIds": asset_ids }))
+            .await
+    }
+
+    /// Remove one asset from a stack. On Immich v2.7.5 the stack
+    /// record persists with a single member while the surviving
+    /// asset's `stackId` is cleared on its row — local cleanup
+    /// completes via the next pull's heartbeat reconciliation. Verified
+    /// idempotent: 204 even if the asset is no longer in the stack.
+    pub(crate) async fn delete_stack_member(
+        &self,
+        stack_id: &str,
+        asset_id: &str,
+    ) -> Result<(), LibraryError> {
+        self.delete_no_content(&format!("/stacks/{stack_id}/assets/{asset_id}"))
+            .await
+    }
+
+    // ── Tags (Phase C, #224) ─────────────────────────────────────────
+
+    /// Idempotently ensure that the tags with the given names exist
+    /// on the server, returning their resolved ids in input order.
+    ///
+    /// Uses `PUT /tags { tags: [...] }` — verified idempotent on
+    /// v2.7.5 (returns existing rows untouched, creates missing ones).
+    /// `POST /tags { name }` was rejected because it 400s on existing
+    /// tags.
+    pub(crate) async fn ensure_tags(
+        &self,
+        names: &[&str],
+    ) -> Result<Vec<TagResponse>, LibraryError> {
+        self.put_json("/tags", &serde_json::json!({ "tags": names }))
+            .await
+    }
+
+    /// Attach `tag_id` to each of the given asset ids. The response
+    /// is per-id; duplicates (already tagged) come back as
+    /// `success: false, error: "duplicate"` and are not an error.
+    pub(crate) async fn add_assets_to_tag(
+        &self,
+        tag_id: &str,
+        asset_ids: &[&str],
+    ) -> Result<(), LibraryError> {
+        self.put_no_content(
+            &format!("/tags/{tag_id}/assets"),
+            &serde_json::json!({ "ids": asset_ids }),
+        )
+        .await
+    }
+
+    /// Detach `tag_id` from each of the given asset ids.
+    pub(crate) async fn remove_assets_from_tag(
+        &self,
+        tag_id: &str,
+        asset_ids: &[&str],
+    ) -> Result<(), LibraryError> {
+        self.delete_with_body(
+            &format!("/tags/{tag_id}/assets"),
+            &serde_json::json!({ "ids": asset_ids }),
+        )
+        .await
+    }
+
+    async fn put_json<B: serde::Serialize, T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, LibraryError> {
+        self.send_json(self.client.put(self.url(path)).json(body), "PUT", path)
+            .await
+    }
+
     /// Send a POST request and return the raw response for streaming.
     pub(crate) async fn post_stream<B: serde::Serialize>(
         &self,
@@ -448,6 +532,23 @@ pub struct UploadResponse {
     pub id: String,
     /// "created" or "duplicate".
     pub status: String,
+}
+
+/// Response from `POST /stacks` — only the `id` and `primaryAssetId`
+/// fields are needed. Immich's full response includes the assets array
+/// but we get that via the next sync stream.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct StackResponse {
+    pub id: String,
+    #[serde(rename = "primaryAssetId")]
+    pub primary_asset_id: String,
+}
+
+/// One element of the response from `PUT /tags { tags: [...] }`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TagResponse {
+    pub id: String,
+    pub name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -567,6 +668,32 @@ mod tests {
         let truncated = truncate_error_body(&emoji_str, 10);
         // 10 emoji characters
         assert_eq!(truncated.chars().count(), 10);
+    }
+
+    #[test]
+    fn stack_response_deserialises() {
+        // Shape captured from the live v2.7.5 probe — we only consume
+        // `id` and `primaryAssetId`; the `assets` array is ignored.
+        let json = serde_json::json!({
+            "id": "stk-uuid",
+            "primaryAssetId": "rendered-uuid",
+            "assets": [{"id":"rendered-uuid"},{"id":"orig-uuid"}]
+        });
+        let resp: StackResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.id, "stk-uuid");
+        assert_eq!(resp.primary_asset_id, "rendered-uuid");
+    }
+
+    #[test]
+    fn tag_response_deserialises() {
+        let json = serde_json::json!([
+            {"id":"tag-1","name":"moments-edit","value":"moments-edit","createdAt":"…","updatedAt":"…"},
+            {"id":"tag-2","name":"other","value":"other","createdAt":"…","updatedAt":"…"}
+        ]);
+        let resp: Vec<TagResponse> = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.len(), 2);
+        assert_eq!(resp[0].id, "tag-1");
+        assert_eq!(resp[0].name, "moments-edit");
     }
 
     #[test]

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -109,6 +109,10 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
         is_favorite: asset.is_favorite,
         is_trashed,
         trashed_at,
+        // Phase C (#224): set on the pull side from `tags[]` once tag
+        // sync lands. Default-false here covers the bootstrap before
+        // the tag stream is wired (Phase D scope).
+        is_moments_render: false,
     };
 
     let server_id = record.external_id.clone().expect("external_id set above");

--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -71,6 +71,10 @@ pub(crate) struct PushManager {
     pub sync_events: tokio::sync::mpsc::UnboundedSender<SyncEvent>,
     pub shutdown_rx: tokio::sync::watch::Receiver<bool>,
     pub interval_rx: tokio::sync::Mutex<tokio::sync::watch::Receiver<u64>>,
+    /// In-memory cache of resolved tag ids by name for the push session.
+    /// Avoids a `PUT /tags` round-trip per Phase C save/revert. Reset
+    /// to `None` on cache miss; `ensure_moments_edit_tag` re-derives.
+    pub moments_edit_tag: tokio::sync::Mutex<Option<String>>,
 }
 
 impl PushManager {
@@ -344,6 +348,75 @@ impl PushManager {
                     )
                     .await?;
                 self.bump_person_heartbeat(id.as_str()).await
+            }
+
+            // ── Stacks (Phase C) ────────────────────────────────────
+            OutboxMutation::StackCreated {
+                rendered_asset_id,
+                original_asset_id,
+            } => {
+                // Both members must already be uploaded (their
+                // `external_id` is stamped by the AssetImported push
+                // arm). If either is still null, error out — the outbox
+                // backoff retries until upload completes.
+                let rendered_ext = self
+                    .require_media_external_id(rendered_asset_id.as_str())
+                    .await?;
+                let original_ext = self
+                    .require_media_external_id(original_asset_id.as_str())
+                    .await?;
+                let resp = self
+                    .client
+                    .post_stack(&[&rendered_ext, &original_ext])
+                    .await?;
+                // Defensive check — Immich convention is "first id in
+                // assetIds becomes primary". If a future version
+                // changes that we want to know.
+                if resp.primary_asset_id != rendered_ext {
+                    warn!(
+                        expected = %rendered_ext,
+                        got = %resp.primary_asset_id,
+                        "stack primary was not the rendered asset; §8.2 grid filter may surface the wrong sibling"
+                    );
+                }
+                self.persist_stack_locally(
+                    &resp.id,
+                    &rendered_asset_id,
+                    &[&rendered_asset_id, &original_asset_id],
+                )
+                .await?;
+                self.bump_media_heartbeat(rendered_asset_id.as_str()).await
+            }
+
+            OutboxMutation::StackMemberRemoved { stack_id, asset_id } => {
+                let asset_ext = self.require_media_external_id(asset_id.as_str()).await?;
+                self.client
+                    .delete_stack_member(&stack_id, &asset_ext)
+                    .await?;
+                // Local cleanup (clearing the asset's `stack_id`)
+                // happens via the next pull cycle's heartbeat
+                // reconciliation; verified on v2.7.5 the surviving
+                // sibling's `stackId` is already null on the server.
+                Ok(())
+            }
+
+            // ── Tags (Phase C) ──────────────────────────────────────
+            OutboxMutation::AssetTaggedMomentsEdit { id } => {
+                let tag_id = self.ensure_moments_edit_tag().await?;
+                let external_id = self.require_media_external_id(id.as_str()).await?;
+                self.client
+                    .add_assets_to_tag(&tag_id, &[&external_id])
+                    .await?;
+                self.bump_media_heartbeat(id.as_str()).await
+            }
+
+            OutboxMutation::AssetUntaggedMomentsEdit { id } => {
+                let tag_id = self.ensure_moments_edit_tag().await?;
+                let external_id = self.require_media_external_id(id.as_str()).await?;
+                self.client
+                    .remove_assets_from_tag(&tag_id, &[&external_id])
+                    .await?;
+                self.bump_media_heartbeat(id.as_str()).await
             }
 
             // ── Edits ───────────────────────────────────────────────
@@ -629,6 +702,93 @@ impl PushManager {
         }
     }
 
+    /// Strict variant of [`Self::lookup_media_external_id`] that
+    /// errors if `external_id` is null (rather than falling back to
+    /// the local id). Used by Phase C push arms where targeting the
+    /// local UUID would 404 on Immich and waste a retry.
+    ///
+    /// The natural caller is the `StackCreated` / tag push paths,
+    /// which run after `AssetImported` — if upload hasn't drained
+    /// yet, this errors and the outbox backoff retries until the
+    /// upload completes.
+    async fn require_media_external_id(&self, local_id: &str) -> Result<String, LibraryError> {
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT external_id FROM media WHERE id = ?")
+                .bind(local_id)
+                .fetch_optional(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
+
+        match row {
+            Some((Some(eid),)) => Ok(eid),
+            Some((None,)) => Err(LibraryError::Immich(format!(
+                "media {local_id} has no external_id yet — upload still pending"
+            ))),
+            None => Err(LibraryError::Immich(format!("media not found: {local_id}"))),
+        }
+    }
+
+    /// Ensure the `moments-edit` tag exists on the server and return
+    /// its id. Cached in memory for the push session; on cache miss
+    /// we round-trip through `PUT /tags { tags: [...] }` (verified
+    /// idempotent on v2.7.5 in the §10.3 probe).
+    async fn ensure_moments_edit_tag(&self) -> Result<String, LibraryError> {
+        let mut cache = self.moments_edit_tag.lock().await;
+        if let Some(id) = cache.as_ref() {
+            return Ok(id.clone());
+        }
+        let resp = self.client.ensure_tags(&["moments-edit"]).await?;
+        let tag = resp
+            .into_iter()
+            .find(|t| t.name == "moments-edit")
+            .ok_or_else(|| {
+                LibraryError::Immich("PUT /tags response missing the moments-edit entry".into())
+            })?;
+        *cache = Some(tag.id.clone());
+        Ok(tag.id)
+    }
+
+    /// After `POST /stacks` succeeds, mirror the stack into the local
+    /// `stacks` and `media` tables so the timeline's primary-only
+    /// filter (Phase A §8.1) and the §8.2 Moments-edit override see
+    /// the relationship before the next pull cycle re-streams it.
+    ///
+    /// `members` lists the local MediaIds to set `stack_id` on. The
+    /// `primary` arg is the rendered asset's local id (becomes the
+    /// stack primary on the server side; Immich uses the first id in
+    /// the `assetIds` array, and Phase C save passes rendered first).
+    async fn persist_stack_locally(
+        &self,
+        stack_id: &str,
+        primary: &crate::library::media::MediaId,
+        members: &[&crate::library::media::MediaId],
+    ) -> Result<(), LibraryError> {
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query(
+            "INSERT INTO stacks (id, primary_asset_id, last_seen_at)
+             VALUES (?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                 primary_asset_id = excluded.primary_asset_id,
+                 last_seen_at = excluded.last_seen_at",
+        )
+        .bind(stack_id)
+        .bind(primary.as_str())
+        .bind(now)
+        .execute(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
+
+        for member in members {
+            sqlx::query("UPDATE media SET stack_id = ? WHERE id = ?")
+                .bind(stack_id)
+                .bind(member.as_str())
+                .execute(self.db.pool())
+                .await
+                .map_err(LibraryError::Db)?;
+        }
+        Ok(())
+    }
+
     /// Read the stored pixel dimensions for an asset.
     ///
     /// Required for crop coordinate translation: EditState carries
@@ -857,6 +1017,7 @@ mod tests {
             sync_events,
             shutdown_rx,
             interval_rx: tokio::sync::Mutex::new(interval_rx),
+            moments_edit_tag: tokio::sync::Mutex::new(None),
         }
     }
 
@@ -1571,6 +1732,85 @@ mod tests {
         let push = make_push_manager(db).await;
         let err = push.lookup_media_dims("local-2").await.unwrap_err();
         assert!(err.to_string().contains("missing width/height"));
+    }
+
+    #[tokio::test]
+    async fn require_media_external_id_returns_set_value() {
+        let (_dir, db) = setup_push_db().await;
+        let mut record = test_record(MediaId::new("local-1".to_string()));
+        record.external_id = Some("ext-1".to_string());
+        MediaRepository::new(db.clone())
+            .upsert(&record)
+            .await
+            .unwrap();
+
+        let push = make_push_manager(db).await;
+        let ext = push.require_media_external_id("local-1").await.unwrap();
+        assert_eq!(ext, "ext-1");
+    }
+
+    #[tokio::test]
+    async fn require_media_external_id_errors_when_null() {
+        // Phase C scenario: rendered asset row exists locally but
+        // upload hasn't drained yet, so external_id is null. The
+        // strict variant errors so the outbox backoff retries the
+        // dependent stack/tag mutations.
+        let (_dir, db) = setup_push_db().await;
+        let record = test_record(MediaId::new("local-2".to_string())); // external_id = None
+        MediaRepository::new(db.clone())
+            .upsert(&record)
+            .await
+            .unwrap();
+
+        let push = make_push_manager(db).await;
+        let err = push.require_media_external_id("local-2").await.unwrap_err();
+        assert!(err.to_string().contains("upload still pending"));
+    }
+
+    #[tokio::test]
+    async fn require_media_external_id_errors_when_row_missing() {
+        let (_dir, db) = setup_push_db().await;
+        let push = make_push_manager(db).await;
+        let err = push
+            .require_media_external_id("nonexistent")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("media not found"));
+    }
+
+    #[tokio::test]
+    async fn persist_stack_locally_upserts_stack_and_member_pointers() {
+        let (_dir, db) = setup_push_db().await;
+        let media_repo = MediaRepository::new(db.clone());
+        let rendered = MediaId::new("rendered".into());
+        let original = MediaId::new("original".into());
+        let mut r = test_record(rendered.clone());
+        r.relative_path = "renders/r.jpg".into();
+        media_repo.insert(&r).await.unwrap();
+        let mut o = test_record(original.clone());
+        o.relative_path = "originals/o.jpg".into();
+        media_repo.insert(&o).await.unwrap();
+
+        let push = make_push_manager(db.clone()).await;
+        push.persist_stack_locally("stk-1", &rendered, &[&rendered, &original])
+            .await
+            .unwrap();
+
+        // Both members got the stack pointer.
+        let r = media_repo.get(&rendered).await.unwrap().unwrap();
+        let o = media_repo.get(&original).await.unwrap().unwrap();
+        assert_eq!(r.stack_id.as_deref(), Some("stk-1"));
+        assert_eq!(o.stack_id.as_deref(), Some("stk-1"));
+
+        // Stack row exists with rendered as primary.
+        let row: (String, String) =
+            sqlx::query_as("SELECT id, primary_asset_id FROM stacks WHERE id = ?")
+                .bind("stk-1")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(row.0, "stk-1");
+        assert_eq!(row.1, "rendered");
     }
 
     #[tokio::test]

--- a/tests/baseline_event_wiring.rs
+++ b/tests/baseline_event_wiring.rs
@@ -33,6 +33,7 @@ fn test_item(id: &str) -> MediaItem {
         trashed_at: None,
         duration_ms: None,
         stack_id: None,
+        is_moments_render: false,
     }
 }
 


### PR DESCRIPTION
## Summary

- Phase C of #224 — the third edit-sync path, for edits that can't be expressed as Immich `/edits` actions (brightness, saturation, vignette, filter presets, freeform straighten). Independent of #652 (Phase B); depends on Phase A's stack model.
- **Save flow**: UI client renders a full-resolution JPEG through `RenderPipeline` with the `EditState` applied, then calls `Library::save_pixel_edit` which embeds a Moments XMP block, writes the bytes under the standard sharded originals layout, inserts a media row (`is_moments_render = 1`), and enqueues `AssetImported` + `StackCreated` + `AssetTaggedMomentsEdit` mutations. On a re-save, the prior rendered child is cleaned up first (untag → stack-remove → `AssetDeleted`).
- **Revert flow**: `Library::revert_edit` tears down the rendered sibling on Immich and clears any prior `/edits` action list (Phase B path) as belt-and-braces. Idempotent on v2.7.5.
- **§8.2 grid filter override** applied across `MediaRepository::list` / `get_many` and the per-album / per-person queries — Moments-edit stacks surface the *original* in the timeline; the rendered JPEG is a sync artifact, never user-visible inside Moments.
- **XMP module** (`src/renderer/xmp.rs`, ~620 LoC) — hand-rolled encoder for deterministic output, quick-xml decoder that tolerates whitespace and attribute reordering and handles entity-reference splitting, hand-rolled JPEG APP1 walker that inserts after any existing EXIF segment so camera metadata stays intact.
- **Probe findings** (logged in design doc §11.2): XMP block survives upload + download bit-exactly on Immich v2.7.5 — Phase D recovery is viable. `POST /tags` 400s on existing tags (use `PUT /tags { tags: [...] }`); `DELETE /stacks/{id}/assets/{aid}` returns 204 and leaves a 1-member stack record with the asset's `stackId` cleared.

Deviates from the original §7.2 draft in three places (all documented as as-built callouts):
1. Orchestration lives on `Library::save_pixel_edit` / `Library::revert_edit`, not inside `EditingService` — keeps render dependencies and the renderer in the UI/client layer where they belong.
2. The UI client passes raw JPEG bytes (no XMP); Library handles XMP encode + APP1 inject so the original's `external_id` / `content_hash` never leak into the UI.
3. Mutations are enqueued upfront; the push manager's existing exponential backoff handles the `AssetImported → external_id → StackCreated` dependency via the strict `require_media_external_id` helper.

## Test plan

- [x] `make lint` clean (cargo fmt + clippy `-D warnings` × 2 feature combos)
- [x] `make test` — **611 pass**, 0 fail. New tests: XMP encode/decode/round-trip × 13, JPEG APP1 walker, `to_jpeg` output helper, `EditState::has_pixel_adjustments()` × 5, 4 mutation round-trips, ImmichClient response deserialization, push helpers (`require_media_external_id`, `persist_stack_locally`), `Library::save_pixel_edit` + `Library::revert_edit` orchestrators, `is_moments_render` INSERT/SELECT round-trip + upsert preservation, §8.2 grid filter (Moments-edit stack, ordinary stack control, unstacked rendered hidden).
- [x] §10.3 probes against the live v2.7.5 instance: tags PUT/attach/detach, stacks POST/DELETE, multipart upload with embedded XMP roundtrip (`cmp` reports byte-exact).
- [x] Internal code review (claude agent) — 2 blockers, 5 should-fix, 5 nits flagged. Blockers and 3 of 5 should-fix addressed in the same commit before push (prev-rendered orphan → `delete_permanently` records `AssetDeleted`; upsert clobber → preserve `is_moments_render` like `imported_at`; unstacked rendered visible → tightened §8.2 first WHERE branch; empty `content_hash` → fail-fast; missing round-trip test → added).
- [ ] Crop sync via this path is not exercised (no crop UI yet; same gap as Phase B — tracked in `project_phase_b_crop_untested.md` memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)