### PR TITLE
feat(editor): gate Adjustments and Filters sections behind GSettings (#657)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ Then run:
 cargo test
 ```
 
+## Experimental features
+
+Moments ships with non-destructive **rotate**, **flip**, and **crop**
+enabled by default. The pixel-adjustment and filter editing sections
+ship in the binary but are hidden by default while they get more
+real-world testing miles. You can opt in per-feature via GSettings.
+
+Because Moments is a sandboxed Flatpak with no dconf hole, run
+`gsettings` *inside* the sandbox with `flatpak run --command=gsettings`:
+
+```bash
+# Enable the Adjustments section (exposure, contrast, saturation,
+# temperature, tint, vignette).
+flatpak run --command=gsettings io.github.justinf555.Moments \
+    set io.github.justinf555.Moments enable-adjustments true
+
+# Enable the Filters section (Noir, Sepia, B&W).
+flatpak run --command=gsettings io.github.justinf555.Moments \
+    set io.github.justinf555.Moments enable-filters true
+```
+
+Restart Moments after changing either key. To revert, replace `set`
+with `reset` and drop the trailing value.
+
+For development builds (`make run-dev`, app id
+`io.github.justinf555.Moments.Devel`), substitute that app id in both
+positions (the `flatpak run` target *and* the schema id).
+
 ## Contributing
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggesting features, and submitting pull requests.

--- a/data/io.github.justinf555.Moments.gschema.xml.in
+++ b/data/io.github.justinf555.Moments.gschema.xml.in
@@ -95,5 +95,28 @@
 				Whether the main window was maximized when last closed.
 			</description>
 		</key>
+		<key name="enable-adjustments" type="b">
+			<default>false</default>
+			<summary>Show the Adjustments section in the photo editor</summary>
+			<description>
+				Experimental. When true, the photo editor exposes the
+				Adjustments section (exposure, contrast, saturation,
+				temperature, tint, vignette, and future clarity, HSL,
+				sharpness, and noise reduction sliders). Off by default;
+				opt in with `gsettings set @APP_ID@ enable-adjustments
+				true` and restart Moments.
+			</description>
+		</key>
+		<key name="enable-filters" type="b">
+			<default>false</default>
+			<summary>Show the Filters section in the photo editor</summary>
+			<description>
+				Experimental. When true, the photo editor exposes the
+				Filters section (preset looks such as Noir, Sepia, and
+				B&amp;W, plus future LUT-based film looks). Off by
+				default; opt in with `gsettings set @APP_ID@
+				enable-filters true` and restart Moments.
+			</description>
+		</key>
 	</schema>
 </schemalist>

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -124,6 +124,25 @@ impl Default for EditPanel {
     }
 }
 
+/// Read the editing-section feature flags from GSettings.
+///
+/// Returns `(enable_adjustments, enable_filters)`. Falls back to
+/// `(true, true)` when the schema isn't installed (e.g. `cargo test`
+/// outside the Flatpak sandbox), preserving pre-flag behaviour.
+fn read_experimental_flags() -> (bool, bool) {
+    use gtk::gio;
+    gio::SettingsSchemaSource::default()
+        .and_then(|src| src.lookup(crate::config::APP_ID, true))
+        .map(|_| {
+            let settings = gio::Settings::new(crate::config::APP_ID);
+            (
+                settings.boolean("enable-adjustments"),
+                settings.boolean("enable-filters"),
+            )
+        })
+        .unwrap_or((true, true))
+}
+
 impl EditPanel {
     pub fn new() -> Self {
         glib::Object::new()
@@ -154,6 +173,16 @@ impl EditPanel {
         imp.filter_section
             .setup(Rc::clone(&session), changed.clone());
         imp.adjust_section.setup(Rc::clone(&session), changed);
+
+        // Apply experimental-feature gating from GSettings. Read once at
+        // setup — restart required to apply changes.
+        let (show_adjustments, show_filters) = read_experimental_flags();
+        if !show_adjustments {
+            imp.adjust_section.set_visible(false);
+        }
+        if !show_filters {
+            imp.filter_section.set_visible(false);
+        }
 
         self.wire_revert_button();
         self.wire_compare_button();


### PR DESCRIPTION
## Summary

- Adds two GSettings boolean keys, `enable-adjustments` and `enable-filters`, both defaulting to `false`. Lets v0.4.0 ship with the editing pipeline gated as experimental while the code lives in main.
- Edit panel reads both keys at `setup()` and hides the corresponding section widget when the flag is off; the rotate/flip/crop transform section stays unconditional.
- Documents the `flatpak run --command=gsettings <APP_ID> set <SCHEMA_ID> <KEY> true` opt-in path in the README. No dconf hole in the manifest — keyfile backend is the recommended pattern for new Flatpaks per [Matthias Clasen's "Settings in a Sandbox World"](https://blogs.gnome.org/mclasen/2019/07/12/settings-in-a-sandbox-world/).

Closes #657. Unblocks the v0.4.0 cut-line tracker (#658).

## Test plan

- [ ] `make run` — only the Transform section is visible in the photo editor; Adjustments and Filters are hidden.
- [ ] Inside the sandbox: `flatpak run --command=gsettings io.github.justinf555.Moments set io.github.justinf555.Moments enable-adjustments true` → restart Moments → Adjustments section now appears.
- [ ] Same with `enable-filters` → Filters section appears.
- [ ] `reset` form drops back to hidden after restart.
- [ ] `make run-dev` (Devel app id) follows the same default-off behaviour; substituting `…Moments.Devel` in both positions of the gsettings command toggles correctly.
- [ ] `cargo test` outside Flatpak still passes (schema lookup fails gracefully, falls back to both flags `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)