### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "moments"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moments"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A GNOME photo management app with local and Immich server support"
 license = "GPL-3.0-or-later"

--- a/data/io.github.justinf555.Moments.metainfo.xml.in
+++ b/data/io.github.justinf555.Moments.metainfo.xml.in
@@ -64,6 +64,18 @@
   </screenshots>
 
   <releases>
+    <release version="0.4.0" date="2026-05-13">
+      <description translate="no">
+        <p>Non-destructive editing and bidirectional sync for edits.</p>
+        <ul>
+          <li>Rotate and flip photos non-destructively — edits round-trip with your Immich server</li>
+          <li>Edited photos appear as a single entry in the timeline via the new stacks model</li>
+          <li>Before/after comparison toggle in the editor</li>
+          <li>Pixel adjustments (exposure, contrast, saturation, vignette) and filter presets ship as experimental features — see the README to opt in</li>
+          <li>Reliability fixes for asset sync, content-hash dedup, and trash restore</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.3.0" date="2026-04-13">
       <description translate="no">
         <p>Referenced storage mode and Flatpak sandbox improvements.</p>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('moments', 'rust', 
-          version: '0.3.0',
+          version: '0.4.0',
     meson_version: '>= 1.0.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )


### PR DESCRIPTION
Bump version to 0.4.0. Merging this PR will automatically create a git tag and GitHub Release.