### PR TITLE
refactor: use glib::clone! for signal handlers in viewer widgets

### DIFF
--- a/src/ui/album_picker_dialog/dialog.rs
+++ b/src/ui/album_picker_dialog/dialog.rs
@@ -234,65 +234,78 @@ fn connect_signals(
     let new_album_stack = &new_album.stack;
     let new_album_entry = &new_album.entry;
     let create_add_btn = &new_album.create_button;
-    {
-        let d = dialog.clone();
-        cancel_btn.connect_clicked(move |_| {
-            d.close();
-        });
-    }
 
-    {
-        let i = Rc::clone(inner);
-        let stack = new_album_stack.clone();
-        let entry = new_album_entry.clone();
-        inner.list_box.connect_row_activated(move |_, row| {
+    cancel_btn.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        move |_| {
+            dialog.close();
+        }
+    ));
+
+    inner.list_box.connect_row_activated(glib::clone!(
+        #[strong]
+        inner,
+        #[weak]
+        new_album_stack,
+        #[weak]
+        new_album_entry,
+        move |_, row| {
             if row.widget_name() == "new-album" {
-                stack.set_visible_child_name("entry");
-                entry.grab_focus();
+                new_album_stack.set_visible_child_name("entry");
+                new_album_entry.grab_focus();
                 return;
             }
 
             let album_id_str = row.widget_name().to_string();
             debug!(album_id = %album_id_str, "album row activated");
 
-            for r in &i.rows {
+            for r in &inner.rows {
                 r.set_selected(false);
             }
 
-            if let Some(r) = i.rows.iter().find(|r| r.album_id.as_str() == album_id_str) {
+            if let Some(r) = inner
+                .rows
+                .iter()
+                .find(|r| r.album_id.as_str() == album_id_str)
+            {
                 r.set_selected(true);
-                *i.selected_album_id.borrow_mut() = Some(r.album_id.clone());
-                i.add_button.set_visible(true);
+                *inner.selected_album_id.borrow_mut() = Some(r.album_id.clone());
+                inner.add_button.set_visible(true);
             }
-        });
-    }
+        }
+    ));
 
-    {
-        let i = Rc::clone(inner);
-        add_button.connect_clicked(move |_| {
-            let album_id = i.selected_album_id.borrow().clone();
+    add_button.connect_clicked(glib::clone!(
+        #[strong]
+        inner,
+        move |_| {
+            let album_id = inner.selected_album_id.borrow().clone();
             if let Some(album_id) = album_id {
-                debug!(%album_id, count = i.media_ids.len(), "adding to album");
-                i.album_client.add_to_album(album_id, i.media_ids.clone());
-                i.dialog.close();
+                debug!(%album_id, count = inner.media_ids.len(), "adding to album");
+                inner
+                    .album_client
+                    .add_to_album(album_id, inner.media_ids.clone());
+                inner.dialog.close();
             }
-        });
-    }
+        }
+    ));
 
-    {
-        let i = Rc::clone(inner);
-        search_entry.connect_search_changed(move |entry| {
+    search_entry.connect_search_changed(glib::clone!(
+        #[strong]
+        inner,
+        move |entry| {
             let query = entry.text().to_string();
             let lower_query = query.to_lowercase();
 
-            for r in &i.rows {
+            for r in &inner.rows {
                 r.update_search_highlight(&query);
                 let matches =
                     lower_query.is_empty() || r.album_name.to_lowercase().contains(&lower_query);
                 r.row.set_visible(matches);
             }
-        });
-    }
+        }
+    ));
 
     {
         let i = Rc::clone(inner);
@@ -320,31 +333,37 @@ fn connect_signals(
         }
     }
 
-    {
-        let btn = create_add_btn.clone();
-        new_album_entry.connect_changed(move |entry| {
-            btn.set_sensitive(!entry.text().is_empty());
-        });
-    }
+    new_album_entry.connect_changed(glib::clone!(
+        #[weak]
+        create_add_btn,
+        move |entry| {
+            create_add_btn.set_sensitive(!entry.text().is_empty());
+        }
+    ));
 
-    {
-        let stack = new_album_stack.clone();
-        let key_ctrl = gtk::EventControllerKey::new();
-        new_album_entry.add_controller(key_ctrl.clone());
-        key_ctrl.connect_key_pressed(move |_, keyval, _, _| {
+    let key_ctrl = gtk::EventControllerKey::new();
+    new_album_entry.add_controller(key_ctrl.clone());
+    key_ctrl.connect_key_pressed(glib::clone!(
+        #[weak]
+        new_album_stack,
+        #[upgrade_or]
+        glib::Propagation::Proceed,
+        move |_, keyval, _, _| {
             if keyval == gtk::gdk::Key::Escape {
-                stack.set_visible_child_name("label");
+                new_album_stack.set_visible_child_name("label");
                 glib::Propagation::Stop
             } else {
                 glib::Propagation::Proceed
             }
-        });
-    }
+        }
+    ));
 
-    {
-        let d = dialog.clone();
-        let i = Rc::clone(inner);
-        empty_create_btn.connect_clicked(move |_| {
+    empty_create_btn.connect_clicked(glib::clone!(
+        #[weak]
+        dialog,
+        #[strong]
+        inner,
+        move |_| {
             let alert = adw::AlertDialog::builder().heading("New Album").build();
             alert.add_response("cancel", "Cancel");
             alert.add_response("create", "Create & add");
@@ -357,22 +376,28 @@ fn connect_signals(
             entry.set_activates_default(true);
             alert.set_extra_child(Some(&entry));
 
-            let ids = i.media_ids.clone();
-            let ac = i.album_client.clone();
-            let d2 = d.clone();
-            alert.connect_response(None, move |_, response| {
-                if response != "create" {
-                    return;
-                }
-                let name = entry.text().to_string();
-                if name.is_empty() {
-                    return;
-                }
-                ac.create_album(name, ids.clone());
-                d2.close();
-            });
+            let ids = inner.media_ids.clone();
+            let ac = inner.album_client.clone();
+            alert.connect_response(
+                None,
+                glib::clone!(
+                    #[weak]
+                    dialog,
+                    move |_, response| {
+                        if response != "create" {
+                            return;
+                        }
+                        let name = entry.text().to_string();
+                        if name.is_empty() {
+                            return;
+                        }
+                        ac.create_album(name, ids.clone());
+                        dialog.close();
+                    }
+                ),
+            );
 
-            alert.present(Some(&d));
-        });
-    }
+            alert.present(Some(&dialog));
+        }
+    ));
 }

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -296,43 +296,33 @@ impl VideoViewer {
         // `load_gen` so an in-flight `original_path` callback that resolves
         // after the pop doesn't call `set_file` on a pipeline we just tore
         // down.
-        {
-            let weak = self.downgrade();
-            self.connect_hidden(move |_| {
-                let Some(viewer) = weak.upgrade() else {
-                    return;
-                };
+        self.connect_hidden(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| {
                 let imp = viewer.imp();
                 imp.load_gen.set(imp.load_gen.get() + 1);
                 imp.video.set_file(None::<&gio::File>);
-            });
-        }
+            }
+        ));
 
-        // Prev button
-        {
-            let weak = self.downgrade();
-            imp.prev_btn.connect_clicked(move |_| {
-                if let Some(viewer) = weak.upgrade() {
-                    viewer.navigate_prev();
-                }
-            });
-        }
+        imp.prev_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| viewer.navigate_prev()
+        ));
 
-        // Next button
-        {
-            let weak = self.downgrade();
-            imp.next_btn.connect_clicked(move |_| {
-                if let Some(viewer) = weak.upgrade() {
-                    viewer.navigate_next();
-                }
-            });
-        }
+        imp.next_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| viewer.navigate_next()
+        ));
 
         // Star (favourite) button — optimistic toggle with rollback on failure.
-        {
-            let weak = self.downgrade();
-            imp.star_btn.connect_clicked(move |btn| {
-                let Some(viewer) = weak.upgrade() else { return };
+        imp.star_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |btn| {
                 let imp = viewer.imp();
                 let items = imp.items.borrow();
                 let idx = imp.current_index.get();
@@ -348,14 +338,14 @@ impl VideoViewer {
                 {
                     mc.set_favorite(vec![id], new_fav);
                 }
-            });
-        }
+            }
+        ));
 
         // Info toggle → split view
-        {
-            let weak = self.downgrade();
-            imp.info_toggle.connect_toggled(move |btn| {
-                let Some(viewer) = weak.upgrade() else { return };
+        imp.info_toggle.connect_toggled(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |btn| {
                 let imp = viewer.imp();
                 imp.info_split.set_show_sidebar(btn.is_active());
 
@@ -371,28 +361,27 @@ impl VideoViewer {
                         drop(meta);
                     }
                 }
-            });
-        }
+            }
+        ));
 
         // Split view sidebar closed externally → sync toggle
-        {
-            let weak = self.downgrade();
-            imp.info_split.connect_show_sidebar_notify(move |split| {
-                if let Some(viewer) = weak.upgrade() {
-                    viewer.imp().info_toggle.set_active(split.shows_sidebar());
-                }
-            });
-        }
+        imp.info_split.connect_show_sidebar_notify(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |split| {
+                viewer.imp().info_toggle.set_active(split.shows_sidebar());
+            }
+        ));
 
         // Keyboard navigation (← → F9 Escape)
-        {
-            let key_ctrl = gtk::EventControllerKey::new();
-            imp.toolbar_view.add_controller(key_ctrl.clone());
-            let weak = self.downgrade();
-            key_ctrl.connect_key_pressed(move |_, keyval, _, _| {
-                let Some(viewer) = weak.upgrade() else {
-                    return glib::Propagation::Proceed;
-                };
+        let key_ctrl = gtk::EventControllerKey::new();
+        imp.toolbar_view.add_controller(key_ctrl.clone());
+        key_ctrl.connect_key_pressed(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            #[upgrade_or]
+            glib::Propagation::Proceed,
+            move |_, keyval, _, _| {
                 match keyval {
                     gdk::Key::Left | gdk::Key::KP_Left => {
                         viewer.navigate_prev();
@@ -420,8 +409,8 @@ impl VideoViewer {
                     }
                     _ => glib::Propagation::Proceed,
                 }
-            });
-        }
+            }
+        ));
 
         // ── Wire overflow menu buttons ──────────────────────────────────────
         wire_overflow_menu(menu_popover, menu_buttons, self);
@@ -435,14 +424,13 @@ fn wire_overflow_menu(
     viewer: &VideoViewer,
 ) {
     // Add to album
-    {
-        let weak = viewer.downgrade();
-        let pop = popover.downgrade();
-        buttons.add_to_album.connect_clicked(move |_| {
-            if let Some(p) = pop.upgrade() {
-                p.popdown();
-            }
-            let Some(viewer) = weak.upgrade() else { return };
+    buttons.add_to_album.connect_clicked(glib::clone!(
+        #[weak]
+        popover,
+        #[weak]
+        viewer,
+        move |_| {
+            popover.popdown();
             let imp = viewer.imp();
             let id = {
                 let items = imp.items.borrow();
@@ -454,8 +442,8 @@ fn wire_overflow_menu(
                 viewer.upcast_ref::<gtk::Widget>(),
                 vec![id],
             );
-        });
-    }
+        }
+    ));
 
     // Stub items — just close the popover on click.
     for btn in [
@@ -463,23 +451,21 @@ fn wire_overflow_menu(
         &buttons.export_original,
         &buttons.show_in_files,
     ] {
-        let pop = popover.downgrade();
-        btn.connect_clicked(move |_| {
-            if let Some(p) = pop.upgrade() {
-                p.popdown();
-            }
-        });
+        btn.connect_clicked(glib::clone!(
+            #[weak]
+            popover,
+            move |_| popover.popdown()
+        ));
     }
 
     // Delete video — trash + pop back to grid.
-    {
-        let weak = viewer.downgrade();
-        let pop = popover.downgrade();
-        buttons.delete.connect_clicked(move |_| {
-            if let Some(p) = pop.upgrade() {
-                p.popdown();
-            }
-            let Some(viewer) = weak.upgrade() else { return };
+    buttons.delete.connect_clicked(glib::clone!(
+        #[weak]
+        popover,
+        #[weak]
+        viewer,
+        move |_| {
+            popover.popdown();
             let imp = viewer.imp();
             let id = {
                 let items = imp.items.borrow();
@@ -496,6 +482,6 @@ fn wire_overflow_menu(
             {
                 nav_view.pop();
             }
-        });
-    }
+        }
+    ));
 }

--- a/src/ui/viewer/mod.rs
+++ b/src/ui/viewer/mod.rs
@@ -257,12 +257,10 @@ impl PhotoViewer {
 
         // Start deferred full-res load after the slide-in animation completes,
         // and grab focus so the key controller (← → F9 Escape) works immediately.
-        {
-            let viewer = self.downgrade();
-            self.connect_shown(move |_| {
-                let Some(viewer) = viewer.upgrade() else {
-                    return;
-                };
+        self.connect_shown(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| {
                 let imp = viewer.imp();
                 imp.toolbar_view.grab_focus();
                 let pending = imp.pending_load.borrow_mut().take();
@@ -271,8 +269,8 @@ impl PhotoViewer {
                     viewer.start_full_res_load(gen, id.clone());
                     viewer.load_metadata_async(gen, id);
                 }
-            });
-        }
+            }
+        ));
 
         // The viewer is a NavigationView page, so popping it doesn't drop the
         // widget — `imp.picture` keeps its `GdkMemoryTexture`, which holds
@@ -285,48 +283,36 @@ impl PhotoViewer {
         // cleared. Toggling `edit_toggle` off (if still active) routes the
         // `EditSession` teardown through the existing toggled handler so
         // the toggle's visual state stays in sync.
-        {
-            let viewer = self.downgrade();
-            self.connect_hidden(move |_| {
-                let Some(viewer) = viewer.upgrade() else {
-                    return;
-                };
+        self.connect_hidden(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| {
                 let imp = viewer.imp();
                 imp.load_gen.set(imp.load_gen.get() + 1);
                 imp.picture.set_paintable(gdk::Paintable::NONE);
                 if imp.edit_toggle.is_active() {
                     imp.edit_toggle.set_active(false);
                 }
-            });
-        }
+            }
+        ));
 
-        // Prev button
-        {
-            let viewer = self.downgrade();
-            imp.prev_btn.connect_clicked(move |_| {
-                if let Some(viewer) = viewer.upgrade() {
-                    viewer.navigate_prev();
-                }
-            });
-        }
+        imp.prev_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| viewer.navigate_prev()
+        ));
 
-        // Next button
-        {
-            let viewer = self.downgrade();
-            imp.next_btn.connect_clicked(move |_| {
-                if let Some(viewer) = viewer.upgrade() {
-                    viewer.navigate_next();
-                }
-            });
-        }
+        imp.next_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |_| viewer.navigate_next()
+        ));
 
         // Star (favourite) button — optimistic toggle with rollback on failure.
-        {
-            let viewer = self.downgrade();
-            imp.star_btn.connect_clicked(move |btn| {
-                let Some(viewer) = viewer.upgrade() else {
-                    return;
-                };
+        imp.star_btn.connect_clicked(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |btn| {
                 let imp = viewer.imp();
                 let items = imp.items.borrow();
                 let idx = imp.current_index.get();
@@ -344,16 +330,14 @@ impl PhotoViewer {
                 {
                     mc.set_favorite(vec![id], new_fav);
                 }
-            });
-        }
+            }
+        ));
 
         // Info toggle → show info sidebar
-        {
-            let viewer = self.downgrade();
-            imp.info_toggle.connect_toggled(move |btn| {
-                let Some(viewer) = viewer.upgrade() else {
-                    return;
-                };
+        imp.info_toggle.connect_toggled(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |btn| {
                 let imp = viewer.imp();
                 if btn.is_active() {
                     // Deactivate edit toggle (mutually exclusive).
@@ -374,16 +358,14 @@ impl PhotoViewer {
                 } else if !imp.edit_toggle.is_active() {
                     imp.info_split.set_show_sidebar(false);
                 }
-            });
-        }
+            }
+        ));
 
         // Edit toggle → show edit sidebar and start edit session
-        {
-            let viewer = self.downgrade();
-            imp.edit_toggle.connect_toggled(move |btn| {
-                let Some(viewer) = viewer.upgrade() else {
-                    return;
-                };
+        imp.edit_toggle.connect_toggled(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |btn| {
                 let imp = viewer.imp();
                 if btn.is_active() {
                     // Deactivate info toggle (mutually exclusive).
@@ -401,17 +383,15 @@ impl PhotoViewer {
                         panel.end_session();
                     }
                 }
-            });
-        }
+            }
+        ));
 
         // Split view sidebar closed externally → sync toggles
-        {
-            let viewer = self.downgrade();
-            imp.info_split.connect_show_sidebar_notify(move |split| {
+        imp.info_split.connect_show_sidebar_notify(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            move |split| {
                 if !split.shows_sidebar() {
-                    let Some(viewer) = viewer.upgrade() else {
-                        return;
-                    };
                     let imp = viewer.imp();
                     imp.info_toggle.set_active(false);
                     if imp.edit_toggle.is_active() {
@@ -421,18 +401,18 @@ impl PhotoViewer {
                         }
                     }
                 }
-            });
-        }
+            }
+        ));
 
         // Keyboard navigation (← → F9 Escape)
-        {
-            let key_ctrl = gtk::EventControllerKey::new();
-            imp.toolbar_view.add_controller(key_ctrl.clone());
-            let viewer = self.downgrade();
-            key_ctrl.connect_key_pressed(move |_, keyval, _, _| {
-                let Some(viewer) = viewer.upgrade() else {
-                    return glib::Propagation::Proceed;
-                };
+        let key_ctrl = gtk::EventControllerKey::new();
+        imp.toolbar_view.add_controller(key_ctrl.clone());
+        key_ctrl.connect_key_pressed(glib::clone!(
+            #[weak(rename_to = viewer)]
+            self,
+            #[upgrade_or]
+            glib::Propagation::Proceed,
+            move |_, keyval, _, _| {
                 match keyval {
                     gdk::Key::Left | gdk::Key::KP_Left => {
                         viewer.navigate_prev();
@@ -461,8 +441,8 @@ impl PhotoViewer {
                     }
                     _ => glib::Propagation::Proceed,
                 }
-            });
-        }
+            }
+        ));
 
         // Wire overflow menu buttons.
         menu::wire_overflow_menu(menu_popover, menu_buttons, self);


### PR DESCRIPTION
## Summary

Replace the manual `downgrade()` / `upgrade()` ceremony in three viewer widgets with the `glib::clone!` macro already used in newer code (`setup_window`, `application/mod.rs`, `photo_grid/factory.rs`, `import_dialog`). The handler bodies now sit directly on the connect call instead of being wrapped in `{ let weak = self.downgrade(); ... let Some(x) = weak.upgrade() else { return }; }` blocks.

Touched:
- `src/ui/viewer/mod.rs::setup_signals` — 10 signal handlers
- `src/ui/video_viewer/mod.rs` — `setup_signals` + `wire_overflow_menu`
- `src/ui/album_picker_dialog/dialog.rs::connect_signals` — 7 of 9 blocks (the `Rc<closure>` shared-handler pattern in the new-album path is unchanged — it's a different shape than mechanical weak-ref boilerplate)

Closures returning `glib::Propagation` use `#[upgrade_or] glib::Propagation::Proceed` for the fallback when the weak ref is gone.

Pure refactor — no behaviour change. Net −9 LOC, but the bigger win is removing the boilerplate from ~25 handlers so the signal bodies are now the visual focus.

## Test plan
- [x] `make typos`
- [x] `make lint` (fmt + clippy, both feature sets)
- [x] `make test` (611 passed)
- [x] `make test-integration` (21 passed)
- [ ] Manually drive the viewers (prev/next, star, info/edit toggles, F9/Escape) and the album picker dialog (search, select existing, create new, empty state) via \`make run-dev\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)