### PR TITLE
Refactor application/ — LibraryContext + decomposed module

### DIFF
--- a/docs/design-library-context.md
+++ b/docs/design-library-context.md
@@ -1,0 +1,348 @@
+# Design: LibraryContext and Application Wiring
+
+**Issue:** TBD
+**Status:** Proposed
+**Date:** 2026-05-27
+
+## Problem
+
+`application/mod.rs` is 898 lines, dominated by `load_library_async` (a 270-line function doing 7 distinct startup concerns) and a struct holding 13 nullable runtime fields:
+
+```rust
+pub settings: OnceCell<gio::Settings>,
+pub tokio: OnceCell<tokio::runtime::Handle>,
+pub library: RefCell<Option<Arc<Library>>>,
+pub import_client: RefCell<Option<crate::client::ImportClient>>,
+pub album_client_v2: RefCell<Option<crate::client::AlbumClientV2>>,
+pub people_client: RefCell<Option<crate::client::PeopleClientV2>>,
+pub media_client_v2: RefCell<Option<crate::client::MediaClientV2>>,
+pub sync_client: RefCell<Option<crate::client::SyncClient>>,
+pub render_pipeline: RefCell<Option<Arc<crate::renderer::pipeline::RenderPipeline>>>,
+pub immich_server_url: RefCell<Option<String>>,
+pub purge_handle: RefCell<Option<tokio::task::JoinHandle<()>>>,
+pub sync_handle: RefCell<Option<crate::sync::SyncHandle>>,
+```
+
+Symptoms:
+
+- **Implicit init order.** Each call site has to know whether a given service has been populated yet. The ActivityIndicator timing bug came from a UI element constructed before its dependency client was set.
+- **Runtime nullability everywhere.** Every access goes through `RefCell::borrow().as_ref().unwrap()`. Borrow panics and missing-initialization panics are not statically prevented.
+- **No architectural boundary.** Any widget can write `MomentsApplication::default().library()` and reach directly into the domain, bypassing the client layer that exists for exactly that purpose.
+- **Mixed concerns on one type.** `Application` holds GTK lifecycle, settings, the domain, UI-binding clients, background task handles, and one-off config strings.
+- **Hard to test in isolation.** Anything wanting to exercise domain code through the application path needs a real `adw::Application`.
+
+The reviewer report (`moments_repository_engineering_review.md`) flagged this as the highest-severity architectural finding. This document proposes a concrete refactor.
+
+## Goals
+
+1. Make GTK widgets *physically unable* to reach the domain except through clients (compile-time, not convention).
+2. Replace runtime nullability with `OnceCell` everywhere that initializes-once.
+3. Split startup into typed phases instead of one mega-function.
+4. Make domain code testable without a GTK Application.
+5. Keep the existing per-service `EventEmitter<T>` pattern and the existing client/widget GObject contract.
+
+Non-goals:
+
+- Introducing a service container / dependency-injection framework.
+- Trait-abstracting library services (no current second implementation or test demand).
+- Multi-window / per-window scoping (single-window app for the foreseeable future).
+
+## Taxonomy
+
+Five kinds of runtime objects, each with a distinct lifecycle and visibility:
+
+| Kind | Distinguishing trait | Example | Owned by | Visibility |
+|---|---|---|---|---|
+| Domain / Infrastructure | App lifetime, holds primary state | `Library`, `RenderPipeline`, `tokio::Handle` | `LibraryContext` | `pub(in crate::application)` |
+| Self-contained background task | App lifetime, no client holds a reference; configured via watch channel | `PurgeTask` — periodic trash auto-purge | `LibraryContext` (as `JoinHandle` + watch sender) | `pub(in crate::application)` |
+| Long-running service with client API | App lifetime, paired Client invokes methods on it | `SyncEngine` ↔ `SyncClient` — HTTP client, polling loop, push/pull queues | Field on `Application` | `pub(in crate::application)` |
+| Ephemeral per-operation work | Per call, built fresh and dropped | `ImportPipeline` — built, run, dropped on each `import()` | Internal to its paired Client | n/a (private impl) |
+| UI Client (GObject facade) | App lifetime, presents domain operations as a GObject for widget binding | `MediaClientV2`, `AlbumClientV2`, `SyncClient`, `ImportClient` | Field on `Application` | `pub` |
+
+**A note on language: "facade" vs "client".**
+
+The UI Client layer is, architecturally, a *facade* in the GoF sense — a tailored interface over the `LibraryContext` subsystem, shaped for one particular caller (GTK widgets). The codebase calls these types `*Client*` for historical reasons and that naming convention is kept. When future facades over the same `LibraryContext` arrive for *different* callers (e.g. a D-Bus interface), those layers will naturally be named to reflect their role (e.g. `DBusFacade`) and the asymmetry is intentional — it distinguishes the GTK facade from the D-Bus facade and from D-Bus *callers* (which would themselves be "clients" in the network sense). The architectural noun is **facade**; the GTK-side concrete naming is **Client**.
+
+**Decision rules:**
+
+1. **Lifecycle test — long-running vs ephemeral:** does it hold state that persists across operations (HTTP client pool, last-sync cursor, in-flight queues)? Yes → long-running. No → ephemeral, owned inside its client.
+
+2. **Reachability test — `LibraryContext` field vs `Application` field:** does any code outside the task itself need to invoke methods on it after startup (a paired Client driving it, a UI button cancelling it)? Yes → typed identity on `Application`. No → just a `JoinHandle` in `LibraryContext`.
+
+If a background task later grows a UI consumer (e.g. a "Purge Now" button), it gets promoted to its own `Application` field with a paired Client. Until that happens, the simpler shape is correct.
+
+## Proposed Architecture
+
+### LibraryContext
+
+A pure-Rust struct that owns the domain + infrastructure. Lives in `src/application/context.rs`. Module visibility is `pub(in crate::application)`, making it **unspellable outside the `application/` module tree**.
+
+```rust
+// src/application/context.rs
+pub(in crate::application) struct LibraryContext {
+    library: Arc<Library>,
+    render_pipeline: Arc<RenderPipeline>,
+    tokio: tokio::runtime::Handle,
+    purge_handle: OnceCell<tokio::task::JoinHandle<()>>,
+    config: AppConfig,
+}
+
+impl LibraryContext {
+    pub(in crate::application) async fn build(
+        bundle: Bundle,
+        tokio: tokio::runtime::Handle,
+        config: AppConfig,
+    ) -> Result<Arc<Self>, OpenError> {
+        let library = Library::open(bundle, config.mode, /* ... */).await?;
+        let render_pipeline = Arc::new(RenderPipeline::new(/* ... */));
+        Ok(Arc::new(Self {
+            library, render_pipeline, tokio, config,
+            purge_handle: OnceCell::new(),
+        }))
+    }
+
+    // Accessors return concrete sub-services with minimal surface.
+    pub(in crate::application) fn library(&self)         -> &Arc<Library>           { &self.library }
+    pub(in crate::application) fn render_pipeline(&self) -> &Arc<RenderPipeline>    { &self.render_pipeline }
+    pub(in crate::application) fn tokio(&self)           -> &tokio::runtime::Handle { &self.tokio }
+    pub(in crate::application) fn media_service(&self)   -> Arc<MediaService>       { self.library.media().clone() }
+    pub(in crate::application) fn album_service(&self)   -> Arc<AlbumService>       { self.library.albums().clone() }
+    pub(in crate::application) fn thumbnail_service(&self) -> Arc<ThumbnailService> { self.library.thumbnails().clone() }
+    // ...
+
+    pub(in crate::application) fn start_purge_task(&self) { /* ... */ }
+}
+```
+
+### MomentsApplication
+
+Public surface shrinks to GTK plumbing + UI-binding clients.
+
+```rust
+mod imp {
+    pub struct MomentsApplication {
+        // GTK
+        pub settings: OnceCell<gio::Settings>,
+
+        // pub(in crate::application) — invisible to ui/, client/, library/
+        pub library_context: OnceCell<Arc<LibraryContext>>,
+        pub sync_engine: OnceCell<Arc<SyncEngine>>,
+
+        // pub — UI access surface
+        pub media_client: OnceCell<MediaClientV2>,
+        pub album_client: OnceCell<AlbumClientV2>,
+        pub people_client: OnceCell<PeopleClientV2>,
+        pub import_client: OnceCell<ImportClient>,
+        pub sync_client: OnceCell<SyncClient>,
+    }
+}
+
+impl MomentsApplication {
+    // Public — anything in ui/ may call these.
+    pub fn media_client(&self)  -> &MediaClientV2  { self.imp().media_client.get().expect("client not initialized") }
+    pub fn album_client(&self)  -> &AlbumClientV2  { self.imp().album_client.get().expect("client not initialized") }
+    pub fn import_client(&self) -> &ImportClient   { self.imp().import_client.get().expect("client not initialized") }
+    pub fn sync_client(&self)   -> Option<&SyncClient> { self.imp().sync_client.get() }
+    // ...
+
+    // pub(in crate::application) — wiring only.
+    pub(in crate::application) fn library_context(&self) -> &Arc<LibraryContext> {
+        self.imp().library_context.get().expect("context not initialized")
+    }
+}
+```
+
+13 mixed-shape nullable fields → 8 `OnceCell` fields, with privacy reflecting purpose.
+
+### Construction convention
+
+Every Client and every long-running service exposes exactly one constructor, named **`build`**, taking concrete minimal dependencies. It is called only from inside `application/`:
+
+```rust
+impl MediaClientV2 {
+    pub fn build(media: Arc<MediaService>, thumbnails: Arc<ThumbnailService>) -> Self { /* ... */ }
+}
+
+impl SyncEngine {
+    pub fn build(library: Arc<Library>, tokio: tokio::runtime::Handle, /* ... */) -> Arc<Self> { /* ... */ }
+}
+```
+
+`build` is the canonical wiring entry point. The signature *is* the dependency contract.
+
+Use a builder-method-chain only when the dependency list is large (3+) or async, with `.build()` as the terminal method. Either way, `build` is what wiring code calls.
+
+### Type-system enforcement
+
+UI code in `src/ui/` cannot construct any client because:
+
+1. `LibraryContext` is `pub(in crate::application)` — the type cannot be named outside `application/`.
+2. There is no public accessor on `Application` returning `Arc<Library>`, `Arc<MediaService>`, etc.
+3. `Library::open` requires `Bundle`, `Database`, `MutationRecorder`, `OriginalResolver` — none of which UI code has any path to obtain.
+
+Therefore the **only** code path that can construct `MediaClientV2::build(...)` is inside `application/`. A widget that tries will fail to compile because it cannot produce the constructor arguments.
+
+This converts the existing convention ("widgets must use clients") into a compile-time invariant.
+
+### Startup phases
+
+Replace `load_library_async` with four phase functions, each returning a typed value the next phase consumes:
+
+```rust
+// src/application/startup.rs
+
+pub(in crate::application) async fn start(
+    app: &MomentsApplication,
+    settings: gio::Settings,
+) -> Result<(), StartupError> {
+    let config = AppConfig::from_settings(&settings);
+    let bundle = open_bundle(&config).await?;
+    let tokio  = app.tokio_handle().clone();
+
+    // Phase 1 — domain
+    let ctx = LibraryContext::build(bundle, tokio, config).await?;
+
+    // Phase 2 — long-running services (conditional on backend)
+    let sync_engine = if ctx.config().has_immich() {
+        Some(SyncEngine::build(
+            ctx.library().clone(),
+            ctx.tokio().clone(),
+            /* recorder, resolver, http, ... */
+        ).await?)
+    } else {
+        None
+    };
+
+    // Phase 3 — UI clients (minimal deps each)
+    let media_client  = MediaClientV2::build(ctx.media_service(), ctx.thumbnail_service());
+    let album_client  = AlbumClientV2::build(ctx.album_service());
+    let people_client = PeopleClientV2::build(ctx.faces_service());
+    let import_client = ImportClient::build(ctx.library().clone(), ctx.render_pipeline().clone(), ctx.tokio().clone());
+    let sync_client   = sync_engine.as_ref().map(|e| SyncClient::build(e.clone()));
+
+    // Phase 4 — install on Application, start background tasks
+    app.imp().library_context.set(ctx.clone()).ok();
+    if let Some(engine) = sync_engine { app.imp().sync_engine.set(engine).ok(); }
+    app.imp().media_client.set(media_client).ok();
+    app.imp().album_client.set(album_client).ok();
+    app.imp().people_client.set(people_client).ok();
+    app.imp().import_client.set(import_client).ok();
+    if let Some(c) = sync_client { app.imp().sync_client.set(c).ok(); }
+
+    ctx.start_purge_task();
+
+    Ok(())
+}
+```
+
+Compiler enforces phase ordering: you cannot build `MediaClientV2` before `LibraryContext` exists, because the constructor arguments don't exist.
+
+## Decisions Recorded From Discussion
+
+1. **No `AppContext` / `ServiceContainer` indirection layer.** The reviewer's recommendation of `Application → AppContext → ServiceContainer → Feature Services` is generic enterprise DI shaped for runtime-dynamic service sets, plugins, or multi-tenant scoping. Moments has none of those. Two layers (Application + LibraryContext) earn their keep; a third does not.
+
+2. **`LibraryContext` is `pub(in crate::application)`, not `pub(crate)`.** `pub(crate)` would let any UI widget reach in if Application exposed an accessor — privacy would degrade to convention again. `pub(in crate::application)` makes the type literally unnameable outside the module tree.
+
+3. **Clients hold minimal *concrete* sub-services, not the whole `LibraryContext` and not trait abstractions.** Concrete `Arc<MediaService>` over `Arc<Library>` because the constructor signature should be the explicit dependency contract; concrete over `Arc<dyn MediaService>` because there is no second implementation and no current test-mocking need (`feedback_no_preemptive_types`). Add traits later if/when polymorphism or test mocking demands it.
+
+4. **`build` is the canonical constructor name** for clients and long-running services. Greppable, distinguishable from generic `new`, consistent across simple cases and full builder patterns.
+
+5. **`ImportPipeline` is *not* a field on `Application`.** It is an internal implementation detail of `ImportClient`, constructed fresh per `import()` call. Only persistent stateful background services warrant a top-level Application field.
+
+6. **`PurgeTask` is *not* a field on `Application`; its `JoinHandle` lives in `LibraryContext`.** No client invokes methods on it after startup — it is a self-contained periodic task whose only runtime input is a watch channel for cache-limit config changes. By the reachability test above, it does not need a typed identity on `Application`. If it ever grows a UI consumer (e.g. a "Purge Now" action), promote it to its own field with a paired Client at that point.
+
+7. **`SyncEngine` is optional, gated by backend config.** `SyncClient` is `Option<SyncClient>` — matches the existing "People route hidden for Local backend" pattern.
+
+8. **No window argument to startup or background tasks.** Toast routing already works through `crate::client::show_toast` which finds the window via `MomentsApplication::default()` and uses `glib::idle_add_once` to dispatch — safe from any thread.
+
+## Migration Plan
+
+Incremental, not big-bang. Each step is one PR, each compiles and passes tests on its own.
+
+### Step 1 — Introduce `LibraryContext`, move domain fields into it
+
+- Create `src/application/context.rs` with `LibraryContext` holding `library`, `render_pipeline`, `tokio`, `purge_handle`.
+- Add `library_context: OnceCell<Arc<LibraryContext>>` to `Application` imp.
+- In `load_library_async`, construct the context and populate it before populating the individual `RefCell<Option<T>>` fields.
+- Keep the old `RefCell<Option<T>>` accessors as `#[deprecated]` shims that read from the context.
+- Verify nothing breaks.
+
+### Step 2 — Migrate client construction to take sub-services from `LibraryContext`
+
+- Add `build` constructors to each client taking concrete sub-services (`Arc<MediaService>` etc.).
+- Switch construction sites in startup to call `Client::build(ctx.media_service(), ...)`.
+- Keep old constructors temporarily; remove once nothing else calls them.
+
+### Step 3 — Migrate `RefCell<Option<T>>` client fields to `OnceCell<T>`
+
+- One client at a time. For each: change field type, update accessor, remove the `.borrow().as_ref().unwrap()` chain.
+- Verify each in isolation (`make lint && make test`).
+
+### Step 4 — Remove deprecated accessors
+
+- Drop the temporary `Application::library()`, `Application::render_pipeline()` etc. accessors.
+- All UI must now go through clients; all wiring goes through `library_context()` which is `pub(in crate::application)`.
+
+### Step 5 — Split startup into phase functions
+
+- Extract `start()` into `src/application/startup.rs` with the four phases.
+- Delete `load_library_async`.
+
+### Step 6 — Pull `SyncEngine` out as a dedicated top-level service
+
+- Reshape today's `SyncHandle` ownership: `SyncEngine` is the owned identity on `Application`; `SyncClient` holds a reference for UI binding.
+- Conditional on backend config.
+
+## Open Questions
+
+1. **Where does `MutationRecorder` / `OriginalResolver` injection live?** Today they are constructed in `application/` and passed into `Library::open`. They stay there — they're construction-time arguments to `LibraryContext::build`, not fields.
+
+2. **Test access path.** Integration tests in `tests/` cannot name `LibraryContext`. Options: (a) a `#[cfg(test)] pub` re-export from `application/`, (b) tests construct via a public `application::test_support::build_context(...)` helper, (c) tests go through full `MomentsApplication`. Likely (b) — it's a small, intentional seam.
+
+3. **Lazy initialization.** This refactor does not introduce lazy init. The `OnceCell` shape means lazy can be added later by switching `OnceCell::get` accessors to `get_or_init`. Whether any subsystem actually benefits from lazy is a follow-up question (likely candidates: GStreamer, libheif, libraw initialization at format-decoder level — not at the client level).
+
+4. **`AppConfig` shape.** The `immich_server_url: RefCell<Option<String>>` field on Application today suggests config is read piecemeal. An explicit `AppConfig` struct constructed once from `gio::Settings` and stored on `LibraryContext` cleans this up; the exact shape is TBD.
+
+## Future Scopes (Deferred)
+
+This refactor introduces exactly one typed context: `LibraryContext`. Two further scopes are anticipated and intentionally deferred. They are named here so the trajectory is visible, but no code is written for them now.
+
+### BackgroundContext (anticipated)
+
+A typed container for long-running background services with coordinated lifecycle operations. Would own `SyncEngine` and (when promoted from `LibraryContext`) `PurgeTask`, plus any future background workers.
+
+**What it would do that today's per-field approach cannot:**
+
+- `bg.pause_all()` — temporarily quiesce background tasks during heavy operations (e.g. large imports) to avoid resource contention.
+- `bg.shutdown_in_order()` — drain in-flight work, then cancel tasks in a defined order before `LibraryContext` is dropped.
+- `bg.apply_config(new_settings)` — push live config updates (sync interval, retention days, cache limit) to every running task that consumes them. Extends today's per-task `watch::Sender` pattern into a coordinated fan-out.
+
+**Trigger condition for introduction:**
+
+The *holder* shape (a struct grouping `sync_engine`, `purge_task`, etc.) becomes worthwhile once the Application field count for background work crosses ~3, purely as an organization win. The *methods* (`pause_all` etc.) are added when the first concrete coordination need arrives — designing the method set speculatively is preemptive.
+
+**Migration cost when it arrives:** low. All fields that would move are already `pub(in crate::application)`. No widget, domain, or client changes are required — the move is purely internal to `application/`.
+
+### ClientContext (speculative — depends on D-Bus design)
+
+A typed container that captures the *calling environment* and configures the facade layer for it. Distinct facade types for distinct callers:
+
+- GObject facade (today's `*Client*` types) for GTK widgets — emits property notifications, holds `ListStore` model refs.
+- D-Bus facade (e.g. `DBusFacade`) for D-Bus callers — synchronous-ish variant-shaped responses, no GObject signalling.
+- Possibly a CLI facade, a test facade, etc.
+
+A `ClientContext` becomes the right abstraction *only if* cross-cutting policy needs to be configured by calling environment — rate limiting, error routing (toast vs. D-Bus signal vs. stderr), capability checks, audit logging.
+
+**Trigger condition for introduction:**
+
+When `docs/design-dbus-api.md` is drafted and the concrete D-Bus surface is known. The shape of `ClientContext` (and whether it's needed at all, or whether sibling facade layers without a container suffice) depends on what cross-cutting policy actually differs between callers. Designing it now would be designing a container for hypothetical contents.
+
+**Why not pre-allocate it like `BackgroundContext`:**
+
+The set of contents and the access pattern for `ClientContext` are not predictable without the D-Bus design. `BackgroundContext`'s contents are already known (existing background tasks). For `ClientContext` the contents *are* the design.
+
+## What This Doesn't Solve
+
+- **Unbounded event channels.** Separate finding in the review; needs a separate change.
+- **Signal closure retention leaks.** Continuing the `glib::clone!` weak-ref sweep started in PR #662.
+- **Startup performance.** Phase-based startup makes lazy initialization *possible* but doesn't itself defer anything; profiling and selective deferral is a follow-up.

--- a/docs/design-library-context.md
+++ b/docs/design-library-context.md
@@ -293,6 +293,16 @@ Incremental, not big-bang. Each step is one PR, each compiles and passes tests o
 - Reshape today's `SyncHandle` ownership: `SyncEngine` is the owned identity on `Application`; `SyncClient` holds a reference for UI binding.
 - Conditional on backend config.
 
+### Step 7 — Extract `LibraryLoader` from the duplicated wizard/open paths
+
+After Step 5, `MomentsApplication::on_setup_complete` and `MomentsApplication::open_library` are each ~84 lines and share ~60 lines of nearly-identical "library loading pipeline" code: parse the bundle (`Bundle::open`), resolve the Immich session token from the keyring, present the appropriate error dialog on failure, persist (or clear) the GSettings library path, then construct the window and call `startup::start`.
+
+- Extract a `LibraryLoader` helper (`src/application/library_loader.rs`, pure Rust, `pub(in crate::application)`) that takes a path and returns a typed `LoadOutcome` (`Ready { bundle, config }` / `NeedsSetup` / `Cancelled`), presenting error dialogs as a side effect.
+- Both entry points reduce to ~10–15 lines: call the loader, match the outcome, present the window, call `startup::start`.
+- The setup *wizard* (`MomentsSetupWindow`) keeps its UI responsibilities; the loader owns the input → ready-library pipeline; `Application` orchestrates the transition.
+
+This step is architecturally adjacent cleanup surfaced during implementation, not part of the original analysis. It is bundled into the same PR because it lives in `application/` and the duplication is severe.
+
 ## Open Questions
 
 1. **Where does `MutationRecorder` / `OriginalResolver` injection live?** Today they are constructed in `application/` and passed into `Library::open`. They stay there — they're construction-time arguments to `LibraryContext::build`, not fields.

--- a/src/application/actions.rs
+++ b/src/application/actions.rs
@@ -1,0 +1,108 @@
+/* application/actions.rs
+ *
+ * Copyright 2026 Unknown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+//! App-level GAction wiring and the dialogs they present (about,
+//! shortcuts, preferences). Pure UI glue — no orchestration logic.
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use gettextrs::gettext;
+use gtk::gio;
+
+use super::MomentsApplication;
+use crate::config::{APP_ID, PROFILE, VERSION};
+
+impl MomentsApplication {
+    pub(in crate::application) fn setup_gactions(&self) {
+        let quit_action = gio::ActionEntry::builder("quit")
+            .activate(move |app: &Self, _, _| app.quit())
+            .build();
+        let about_action = gio::ActionEntry::builder("about")
+            .activate(move |app: &Self, _, _| app.show_about())
+            .build();
+        let import_action = gio::ActionEntry::builder("import")
+            .activate(move |app: &Self, _, _| app.show_import_dialog())
+            .build();
+        let preferences_action = gio::ActionEntry::builder("preferences")
+            .activate(move |app: &Self, _, _| app.show_preferences())
+            .build();
+        let shortcuts_action = gio::ActionEntry::builder("shortcuts")
+            .activate(move |app: &Self, _, _| app.show_shortcuts())
+            .build();
+        self.add_action_entries([
+            quit_action,
+            about_action,
+            import_action,
+            preferences_action,
+            shortcuts_action,
+        ]);
+    }
+
+    fn show_shortcuts(&self) {
+        let Some(window) = self.active_window() else {
+            return;
+        };
+        let builder =
+            gtk::Builder::from_resource("/io/github/justinf555/Moments/shortcuts-dialog.ui");
+        let dialog = builder
+            .object::<adw::ShortcutsDialog>("shortcuts_dialog")
+            .expect("shortcuts_dialog in resource");
+        dialog.present(Some(&window));
+    }
+
+    fn show_about(&self) {
+        let Some(window) = self.active_window() else {
+            return;
+        };
+        let app_name = if PROFILE == "development" {
+            "Moments (Development)"
+        } else {
+            "Moments"
+        };
+        let about = adw::AboutDialog::builder()
+            .application_name(app_name)
+            .application_icon(APP_ID)
+            .developer_name("Unknown")
+            .version(VERSION)
+            .developers(vec!["Unknown"])
+            .translator_credits(gettext("translator-credits"))
+            .copyright("© 2026 Unknown")
+            .build();
+
+        about.present(Some(&window));
+    }
+
+    fn show_preferences(&self) {
+        let window = match self.active_window() {
+            Some(w) => w,
+            None => return,
+        };
+        let settings = self
+            .imp()
+            .settings
+            .get()
+            .expect("settings initialised")
+            .clone();
+        let is_immich = self.imp().is_immich.get();
+        let immich_url = self.imp().immich_server_url.borrow().clone();
+
+        crate::ui::preferences_dialog::show_preferences(&window, &settings, is_immich, immich_url);
+    }
+}

--- a/src/application/context.rs
+++ b/src/application/context.rs
@@ -41,11 +41,13 @@ use crate::renderer::pipeline::RenderPipeline;
 /// hold the context as `Arc<LibraryContext>` and the Tokio executor may
 /// transport that `Arc` between threads.
 ///
-/// Step 1 of the refactor exposes accessors for every owned field; the
-/// `library` and `tokio` accessors have no callers yet. They are
-/// `#[allow(dead_code)]`-tolerated until Step 2, when client
-/// construction begins pulling sub-services from the context.
-#[allow(dead_code)]
+/// Step 2 of the refactor switches client construction over to use
+/// these accessors — `load_library_async` calls `Client::build(...)`
+/// with sub-services pulled from the context. The
+/// `MomentsApplication::library_context()` accessor remains unused
+/// at the end of Step 2 (`load_library_async` works with the local
+/// `library_context: Arc<LibraryContext>` it constructs directly);
+/// Step 5 introduces phase functions that need the accessor.
 pub(in crate::application) struct LibraryContext {
     library: Arc<Library>,
     render_pipeline: Arc<RenderPipeline>,
@@ -53,7 +55,6 @@ pub(in crate::application) struct LibraryContext {
     purge_handle: OnceLock<tokio::task::JoinHandle<()>>,
 }
 
-#[allow(dead_code)]
 impl LibraryContext {
     /// Wrap already-constructed domain + infrastructure values in a
     /// `LibraryContext`.
@@ -104,9 +105,8 @@ impl LibraryContext {
 
     /// Borrow the recorded purge-task handle, if one has been set.
     ///
-    /// Currently unused by other modules — exposed for completeness and
-    /// for forthcoming shutdown-ordering work. The struct-level
-    /// `#[allow(dead_code)]` covers Step 1's unused accessors.
+    /// Called from `MomentsApplication::shutdown` to abort the task
+    /// before the runtime is dropped.
     pub(in crate::application) fn purge_handle(&self) -> Option<&tokio::task::JoinHandle<()>> {
         self.purge_handle.get()
     }

--- a/src/application/context.rs
+++ b/src/application/context.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// LibraryContext — owns the domain + infrastructure objects that have
+// application lifetime (the `Library`, the `RenderPipeline`, the Tokio
+// runtime handle, and the periodic-purge background-task `JoinHandle`).
+//
+// The type is `pub(in crate::application)` so it is **unnameable outside
+// the `application/` module tree**. UI widgets and clients cannot import
+// it — by construction, anything that needs the domain must either be
+// inside `application/` or go through a UI Client. See
+// `docs/design-library-context.md` for the broader design.
+//
+// Step 1 of the migration plan: this struct is purely additive. Existing
+// `RefCell<Option<T>>` fields on `MomentsApplication` remain in place and
+// continue to be populated; this context is populated *alongside* them.
+// Subsequent steps will collapse the duplication.
+
+use std::sync::{Arc, OnceLock};
+
+use crate::library::Library;
+use crate::renderer::pipeline::RenderPipeline;
+
+/// Domain + infrastructure container.
+///
+/// Holds the long-lived objects that drive every backend operation:
+///
+/// * `library` — the composed feature services.
+/// * `render_pipeline` — the stateless render pipeline.
+/// * `tokio` — handle to the shared Tokio runtime.
+/// * `purge_handle` — `JoinHandle` for the periodic trash-purge task,
+///   populated after the task is spawned at the tail of startup.
+///
+/// Construction is performed by [`LibraryContext::build`] from inside
+/// `MomentsApplication::load_library_async` once the `Library` and
+/// `RenderPipeline` are ready. The context is then wrapped in an `Arc`
+/// and stored in the `library_context: OnceCell<Arc<LibraryContext>>`
+/// field on the application's `imp` struct.
+///
+/// `purge_handle` uses `std::sync::OnceLock` (not `std::cell::OnceCell`)
+/// so the whole struct is `Send + Sync` — necessary because consumers
+/// hold the context as `Arc<LibraryContext>` and the Tokio executor may
+/// transport that `Arc` between threads.
+///
+/// Step 1 of the refactor exposes accessors for every owned field; the
+/// `library` and `tokio` accessors have no callers yet. They are
+/// `#[allow(dead_code)]`-tolerated until Step 2, when client
+/// construction begins pulling sub-services from the context.
+#[allow(dead_code)]
+pub(in crate::application) struct LibraryContext {
+    library: Arc<Library>,
+    render_pipeline: Arc<RenderPipeline>,
+    tokio: tokio::runtime::Handle,
+    purge_handle: OnceLock<tokio::task::JoinHandle<()>>,
+}
+
+#[allow(dead_code)]
+impl LibraryContext {
+    /// Wrap already-constructed domain + infrastructure values in a
+    /// `LibraryContext`.
+    ///
+    /// Step 1 intentionally keeps this synchronous and minimal — it does
+    /// not open the `Library` or build the `RenderPipeline` itself.
+    /// Those are still constructed by `load_library_async`. Later steps
+    /// will move that construction into an async `build` taking a
+    /// `Bundle` + config.
+    pub(in crate::application) fn build(
+        library: Arc<Library>,
+        render_pipeline: Arc<RenderPipeline>,
+        tokio: tokio::runtime::Handle,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            library,
+            render_pipeline,
+            tokio,
+            purge_handle: OnceLock::new(),
+        })
+    }
+
+    /// The composed feature services.
+    pub(in crate::application) fn library(&self) -> &Arc<Library> {
+        &self.library
+    }
+
+    /// The stateless render pipeline.
+    pub(in crate::application) fn render_pipeline(&self) -> &Arc<RenderPipeline> {
+        &self.render_pipeline
+    }
+
+    /// Handle to the shared Tokio runtime.
+    pub(in crate::application) fn tokio(&self) -> &tokio::runtime::Handle {
+        &self.tokio
+    }
+
+    /// Record the `JoinHandle` returned when the periodic trash-purge
+    /// task is spawned. Called exactly once during startup, after the
+    /// rest of the context is wired. Returns `Err` with the unused
+    /// handle if a handle was already recorded (a programmer error).
+    pub(in crate::application) fn set_purge_handle(
+        &self,
+        handle: tokio::task::JoinHandle<()>,
+    ) -> Result<(), tokio::task::JoinHandle<()>> {
+        self.purge_handle.set(handle)
+    }
+
+    /// Borrow the recorded purge-task handle, if one has been set.
+    ///
+    /// Currently unused by other modules — exposed for completeness and
+    /// for forthcoming shutdown-ordering work. The struct-level
+    /// `#[allow(dead_code)]` covers Step 1's unused accessors.
+    pub(in crate::application) fn purge_handle(&self) -> Option<&tokio::task::JoinHandle<()>> {
+        self.purge_handle.get()
+    }
+}

--- a/src/application/context.rs
+++ b/src/application/context.rs
@@ -31,23 +31,15 @@ use crate::renderer::pipeline::RenderPipeline;
 ///   populated after the task is spawned at the tail of startup.
 ///
 /// Construction is performed by [`LibraryContext::build`] from inside
-/// `MomentsApplication::load_library_async` once the `Library` and
-/// `RenderPipeline` are ready. The context is then wrapped in an `Arc`
-/// and stored in the `library_context: OnceCell<Arc<LibraryContext>>`
-/// field on the application's `imp` struct.
+/// [`crate::application::startup::phase1_domain`] once the `Library`
+/// and `RenderPipeline` are ready. The context is then wrapped in an
+/// `Arc` and stored in the `library_context` field on the
+/// application's `imp` struct by phase 4.
 ///
 /// `purge_handle` uses `std::sync::OnceLock` (not `std::cell::OnceCell`)
 /// so the whole struct is `Send + Sync` — necessary because consumers
 /// hold the context as `Arc<LibraryContext>` and the Tokio executor may
 /// transport that `Arc` between threads.
-///
-/// Step 2 of the refactor switches client construction over to use
-/// these accessors — `load_library_async` calls `Client::build(...)`
-/// with sub-services pulled from the context. The
-/// `MomentsApplication::library_context()` accessor remains unused
-/// at the end of Step 2 (`load_library_async` works with the local
-/// `library_context: Arc<LibraryContext>` it constructs directly);
-/// Step 5 introduces phase functions that need the accessor.
 pub(in crate::application) struct LibraryContext {
     library: Arc<Library>,
     render_pipeline: Arc<RenderPipeline>,
@@ -59,11 +51,12 @@ impl LibraryContext {
     /// Wrap already-constructed domain + infrastructure values in a
     /// `LibraryContext`.
     ///
-    /// Step 1 intentionally keeps this synchronous and minimal — it does
-    /// not open the `Library` or build the `RenderPipeline` itself.
-    /// Those are still constructed by `load_library_async`. Later steps
-    /// will move that construction into an async `build` taking a
-    /// `Bundle` + config.
+    /// Step 1 intentionally keeps this synchronous and minimal — it
+    /// does not open the `Library` or build the `RenderPipeline`
+    /// itself. Those are still constructed by
+    /// [`crate::application::startup::phase1_domain`]. Later steps will
+    /// move that construction into an async `build` taking a `Bundle`
+    /// + config.
     pub(in crate::application) fn build(
         library: Arc<Library>,
         render_pipeline: Arc<RenderPipeline>,

--- a/src/application/context.rs
+++ b/src/application/context.rs
@@ -17,6 +17,9 @@
 
 use std::sync::{Arc, OnceLock};
 
+use crate::library::album::AlbumService;
+use crate::library::faces::FacesService;
+use crate::library::thumbnail::ThumbnailService;
 use crate::library::Library;
 use crate::renderer::pipeline::RenderPipeline;
 
@@ -78,6 +81,29 @@ impl LibraryContext {
     /// The stateless render pipeline.
     pub(in crate::application) fn render_pipeline(&self) -> &Arc<RenderPipeline> {
         &self.render_pipeline
+    }
+
+    /// A handle to the album sub-service.
+    ///
+    /// Returns an owned clone — `AlbumService` is a cheap `Clone` handle
+    /// over the DB pool plus its event emitter. Clients that only need
+    /// album operations take this instead of the whole `Arc<Library>`,
+    /// so their constructor signature declares their minimal dependency
+    /// surface (see `docs/design-library-context.md`).
+    pub(in crate::application) fn album_service(&self) -> AlbumService {
+        self.library.albums().clone()
+    }
+
+    /// A handle to the thumbnail sub-service. Owned clone; see
+    /// [`LibraryContext::album_service`] for the rationale.
+    pub(in crate::application) fn thumbnail_service(&self) -> ThumbnailService {
+        self.library.thumbnails().clone()
+    }
+
+    /// A handle to the faces sub-service. Owned clone; see
+    /// [`LibraryContext::album_service`] for the rationale.
+    pub(in crate::application) fn faces_service(&self) -> FacesService {
+        self.library.faces().clone()
     }
 
     /// Handle to the shared Tokio runtime.

--- a/src/application/import.rs
+++ b/src/application/import.rs
@@ -1,0 +1,124 @@
+/* application/import.rs
+ *
+ * Copyright 2026 Unknown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+//! Folder-import entry points: the folder picker dialog and the
+//! pipeline kickoff, plus the GIO helpers that preserve Flatpak portal
+//! grants while enumerating the selected folder.
+
+use std::path::PathBuf;
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use gtk::{gio, glib};
+use tracing::{debug, error, info, warn};
+
+use super::MomentsApplication;
+
+impl MomentsApplication {
+    /// Open a folder picker and start importing the selected folder.
+    pub(in crate::application) fn show_import_dialog(&self) {
+        let window = match self.active_window() {
+            Some(w) => w,
+            None => return,
+        };
+
+        let file_dialog = gtk::FileDialog::builder()
+            .title("Select Folder to Import")
+            .modal(true)
+            .build();
+
+        file_dialog.select_folder(
+            Some(&window),
+            gio::Cancellable::NONE,
+            glib::clone!(
+                #[weak(rename_to = app)]
+                self,
+                move |result| if let Ok(folder) = result {
+                    app.run_import(folder);
+                }
+            ),
+        );
+    }
+
+    /// Create the import progress dialog and kick off the import pipeline.
+    ///
+    /// Accepts the `gio::File` directly from the file dialog rather than
+    /// extracting a path. This is critical for Flatpak: the document portal
+    /// grants access to the `gio::File` object, but the underlying path
+    /// (`/run/user/…/doc/…`) becomes inaccessible once the dialog callback
+    /// returns. Using `gio::File::enumerate_children` on the original object
+    /// respects the portal grant.
+    fn run_import(&self, folder: gio::File) {
+        let Some(import_client) = self.imp().import_client.get() else {
+            error!("import requested but no library is open");
+            return;
+        };
+
+        let display_path = folder
+            .path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| folder.uri().to_string());
+        info!(path = %display_path, "starting import");
+
+        // Resolve folder contents via GIO to handle Flatpak portal paths.
+        let sources = resolve_folder_via_gio(&folder);
+        if sources.is_empty() {
+            warn!(path = %display_path, "no files found in folder");
+            return;
+        }
+        debug!(count = sources.len(), "resolved import sources via GIO");
+
+        import_client.import(sources);
+    }
+}
+
+/// Recursively enumerate a folder's contents using GIO.
+///
+/// Accepts the `gio::File` directly from the file dialog so that
+/// Flatpak document portal grants are preserved. Creating a new
+/// `gio::File::for_path` from the extracted path would lose the grant.
+fn resolve_folder_via_gio(folder: &gio::File) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    gio_walk(folder, &mut files);
+    files
+}
+
+fn gio_walk(dir: &gio::File, out: &mut Vec<PathBuf>) {
+    let enumerator = match dir.enumerate_children(
+        "standard::name,standard::type",
+        gio::FileQueryInfoFlags::NONE,
+        gio::Cancellable::NONE,
+    ) {
+        Ok(e) => e,
+        Err(e) => {
+            warn!(path = ?dir.path(), error = %e, "could not enumerate directory via GIO");
+            return;
+        }
+    };
+
+    while let Some(info) = enumerator.next_file(gio::Cancellable::NONE).ok().flatten() {
+        let child = enumerator.child(&info);
+        if info.file_type() == gio::FileType::Directory {
+            gio_walk(&child, out);
+        } else if let Some(path) = child.path() {
+            out.push(path);
+        }
+    }
+}

--- a/src/application/library_loader.rs
+++ b/src/application/library_loader.rs
@@ -1,0 +1,157 @@
+//! Shared library-loading pipeline for the two entry points that open a
+//! bundle and hand it to [`super::startup::start`].
+//!
+//! Both `MomentsApplication::on_setup_complete` (wizard finished) and
+//! `MomentsApplication::open_library` (saved path on launch) run the same
+//! sequence: open the bundle, and for Immich configs resolve the session
+//! token from the keyring. The two call sites differ only in *presentation*
+//! (the error wording is phrased for each context, and a different window
+//! parents the dialog) and in *side effects* on the GSettings library path.
+//!
+//! To keep that pipeline in exactly one place this module owns the input →
+//! ready-library logic and returns a plain-data [`LoadOutcome`]. On failure
+//! it reports a typed [`LoadFailure`] describing *what* went wrong (plus
+//! whether the saved path is stale); the caller in `application/mod.rs` owns
+//! all GTK presentation — it phrases the context-appropriate dialog text,
+//! shows the dialog parented to the right window, and writes/clears the
+//! GSettings library path.
+//!
+//! Keeping the loader free of widget and wording concerns makes it pure Rust
+//! and lets the pipeline be unit-tested without a GTK `Application`.
+
+use std::path::Path;
+
+use tracing::{error, instrument};
+
+use super::keyring::{self, TokenError};
+use crate::library::bundle::Bundle;
+use crate::library::config::LibraryConfig;
+
+/// Result of running the load pipeline for a single path.
+pub(in crate::application) enum LoadOutcome {
+    /// Bundle opened and (for Immich) the token resolved. Ready to start.
+    Ready {
+        bundle: Bundle,
+        config: LibraryConfig,
+    },
+    /// Loading failed. The caller phrases and presents the error dialog and
+    /// decides the GSettings path side effect (see [`LoadFailure::clear_path`]).
+    Failed(LoadFailure),
+}
+
+/// Why the load pipeline could not produce a ready library.
+///
+/// Carries the raw detail (paths, underlying error strings) so the caller can
+/// compose context-appropriate dialog text; the wording itself lives at the
+/// call site, not here.
+pub(in crate::application) enum LoadFailure {
+    /// `Bundle::open` failed — e.g. the directory was deleted while the
+    /// GSettings path entry still existed. `details` is the error string.
+    BundleOpen { details: String },
+    /// No (or empty) Immich session token in the keyring. The user must
+    /// sign in again.
+    TokenMissing,
+    /// libsecret returned an error (D-Bus unavailable, locked collection,
+    /// schema mismatch). Typically transient. `details` is the error string.
+    KeyringFailed { details: String },
+}
+
+impl LoadFailure {
+    /// Whether the saved `library-path` should be cleared in response.
+    ///
+    /// `true` when the path can never load as-is (deleted bundle, missing
+    /// token) so the user should be bounced into fresh setup; `false` for
+    /// transient keyring/D-Bus failures where a simple relaunch recovers and
+    /// the saved path must stay intact.
+    pub(in crate::application) fn clear_path(&self) -> bool {
+        match self {
+            LoadFailure::BundleOpen { .. } | LoadFailure::TokenMissing => true,
+            LoadFailure::KeyringFailed { .. } => false,
+        }
+    }
+}
+
+/// Runs the bundle-open + token-resolve pipeline shared by the wizard and
+/// the open-on-launch paths.
+pub(in crate::application) struct LibraryLoader;
+
+impl LibraryLoader {
+    /// Open the bundle at `path` and resolve any Immich session token.
+    ///
+    /// Returns [`LoadOutcome::Ready`] on success or [`LoadOutcome::Failed`]
+    /// with a typed [`LoadFailure`] otherwise. Logs failures here so the
+    /// single pipeline owns the diagnostic logging.
+    #[instrument(skip(self), fields(path = %path.display()))]
+    pub(in crate::application) fn load(&self, path: &Path) -> LoadOutcome {
+        let (bundle, config) = match Bundle::open(path) {
+            Ok(result) => result,
+            Err(e) => {
+                error!("failed to open library bundle: {e}");
+                return LoadOutcome::Failed(LoadFailure::BundleOpen {
+                    details: e.to_string(),
+                });
+            }
+        };
+
+        let config = match config {
+            LibraryConfig::Immich { server_url, .. } => {
+                match keyring::resolve_immich_token(&server_url) {
+                    Ok(access_token) => LibraryConfig::Immich {
+                        server_url,
+                        access_token,
+                    },
+                    Err(TokenError::Missing) => {
+                        return LoadOutcome::Failed(LoadFailure::TokenMissing);
+                    }
+                    Err(TokenError::KeyringFailed(e)) => {
+                        error!("keyring lookup failed during library load: {e}");
+                        return LoadOutcome::Failed(LoadFailure::KeyringFailed { details: e });
+                    }
+                }
+            }
+            other => other,
+        };
+
+        LoadOutcome::Ready { bundle, config }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_open_failure_clears_path() {
+        assert!(LoadFailure::BundleOpen {
+            details: "boom".into()
+        }
+        .clear_path());
+    }
+
+    #[test]
+    fn token_missing_clears_path() {
+        assert!(LoadFailure::TokenMissing.clear_path());
+    }
+
+    #[test]
+    fn keyring_failed_keeps_path() {
+        assert!(!LoadFailure::KeyringFailed {
+            details: "dbus down".into()
+        }
+        .clear_path());
+    }
+
+    #[test]
+    fn load_missing_bundle_reports_bundle_open() {
+        // A path that does not exist cannot open; the pipeline must classify
+        // this as a BundleOpen failure (which clears the stale path).
+        let loader = LibraryLoader;
+        let outcome = loader.load(Path::new("/nonexistent/moments/library/path"));
+        match outcome {
+            LoadOutcome::Failed(LoadFailure::BundleOpen { details }) => {
+                assert!(!details.is_empty());
+            }
+            _ => panic!("expected BundleOpen failure for a nonexistent path"),
+        }
+    }
+}

--- a/src/application/lifecycle.rs
+++ b/src/application/lifecycle.rs
@@ -1,0 +1,186 @@
+//! Library-open lifecycle for `MomentsApplication`.
+//!
+//! Hosts the setup-wizard and open-on-launch entry points that turn a
+//! library path into a running window: presenting the first-run setup
+//! window, handling its completion, and opening an existing library from
+//! a saved path. The shared input → ready-library pipeline lives in
+//! `library_loader`; this module orchestrates the window transition and
+//! the failure dialogs. See `docs/design-library-context.md`.
+
+use std::path::{Path, PathBuf};
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use gettextrs::gettext;
+use gtk::glib;
+use tracing::{error, instrument};
+
+use super::MomentsApplication;
+use crate::application::library_loader::{LibraryLoader, LoadFailure, LoadOutcome};
+use crate::application::startup;
+use crate::ui::MomentsSetupWindow;
+use crate::ui::MomentsWindow;
+
+impl MomentsApplication {
+    /// Show the first-run setup window.
+    pub(in crate::application) fn show_setup_window(&self) -> MomentsSetupWindow {
+        let setup = MomentsSetupWindow::new(self);
+        setup.connect_setup_complete(glib::clone!(
+            #[weak(rename_to = app)]
+            self,
+            move |win, path| {
+                app.on_setup_complete(win, path);
+            }
+        ));
+        setup.present();
+        setup
+    }
+
+    /// Called when the user completes the setup wizard.
+    ///
+    /// Creates the bundle, persists the path to GSettings, presents the main
+    /// window, closes the setup window, then loads the library asynchronously.
+    /// The main window is created before the setup window closes so there is
+    /// never a windowless state.
+    #[instrument(skip(self, setup_win), fields(path = %path))]
+    pub(in crate::application) fn on_setup_complete(
+        &self,
+        setup_win: &MomentsSetupWindow,
+        path: String,
+    ) {
+        // All setup pages (Local and Immich) create the bundle before
+        // emitting setup-complete. The loader opens it and resolves any
+        // Immich token from the keyring (the wizard stored it just before
+        // emitting setup-complete, so a failure here means the keyring became
+        // unavailable between store and lookup).
+        let (bundle, config) = match LibraryLoader.load(Path::new(&path)) {
+            LoadOutcome::Ready { bundle, config } => (bundle, config),
+            LoadOutcome::Failed(failure) => {
+                let (heading, body) = setup_failure_dialog(&failure, Path::new(&path));
+                show_library_error_dialog(setup_win, &heading, &body);
+                return;
+            }
+        };
+
+        let settings = self.imp().settings.get().expect("settings initialised");
+        if let Err(e) = settings.set_string("library-path", &path) {
+            error!("failed to save library path to GSettings: {e}");
+        }
+
+        // Present the main window first, then close setup — ensures there is
+        // always at least one window alive during the transition.
+        let window = MomentsWindow::new(self, settings);
+        window.present();
+        setup_win.close();
+
+        startup::start(self, bundle, config, window);
+    }
+
+    /// Open an existing library from a saved path.
+    ///
+    /// Creates and presents the main window immediately (loading page) so
+    /// there is no windowless gap while the async factory runs.
+    ///
+    /// If the bundle cannot be opened (e.g. the directory was deleted while
+    /// the GSettings path entry still exists) the stale path is cleared and
+    /// the setup window is shown so the user can reconfigure.
+    pub(in crate::application) fn open_library(&self, path: PathBuf) {
+        let (bundle, config) = match LibraryLoader.load(&path) {
+            LoadOutcome::Ready { bundle, config } => (bundle, config),
+            LoadOutcome::Failed(failure) => {
+                // Clear the stale path *before* showing the setup window so a
+                // missing bundle / missing token does not re-trigger an open
+                // on the next launch. Transient keyring failures leave it
+                // intact so a relaunch recovers once the keyring is healthy.
+                if failure.clear_path() {
+                    let settings = self.imp().settings.get().expect("settings initialised");
+                    if let Err(e) = settings.set_string("library-path", "") {
+                        error!("failed to clear stale library path: {e}");
+                    }
+                }
+                // No window exists yet on this path — show the setup window and
+                // parent the explanation dialog to it.
+                let setup_win = self.show_setup_window();
+                let (heading, body) = open_failure_dialog(&failure, &path);
+                show_library_error_dialog(&setup_win, &heading, &body);
+                return;
+            }
+        };
+
+        let settings = self.imp().settings.get().expect("settings initialised");
+        let window = MomentsWindow::new(self, settings);
+        window.present();
+
+        startup::start(self, bundle, config, window);
+    }
+}
+
+/// Dialog heading/body for a load failure in the *setup wizard* path.
+///
+/// Phrased for "the user just finished setup": the bundle was created moments
+/// ago, and an Immich token was stored just before this. See
+/// `library_loader::LoadFailure`.
+fn setup_failure_dialog(failure: &LoadFailure, path: &Path) -> (String, String) {
+    match failure {
+        LoadFailure::BundleOpen { details } => (
+            "Could not open library".to_string(),
+            format!(
+                "The library at {} could not be opened.\n\nDetails: {details}",
+                path.display()
+            ),
+        ),
+        LoadFailure::TokenMissing => (
+            gettext("Sign in required"),
+            gettext(
+                "The session token saved during setup could not be read back. Please try signing in again.",
+            ),
+        ),
+        LoadFailure::KeyringFailed { details } => (
+            gettext("Could not access the system keyring"),
+            format!(
+                "{}\n\nDetails: {details}",
+                gettext("Moments stored your session in the keyring but could not read it back. Please check your keyring service and try again.")
+            ),
+        ),
+    }
+}
+
+/// Dialog heading/body for a load failure in the *open-on-launch* path.
+///
+/// Phrased for "a previously-saved library could not be reopened" and
+/// includes the offending `path`. See `library_loader::LoadFailure`.
+fn open_failure_dialog(failure: &LoadFailure, path: &Path) -> (String, String) {
+    match failure {
+        LoadFailure::BundleOpen { details } => (
+            "Could not open library".to_string(),
+            format!(
+                "The library at {} could not be opened. Please set up a new library.\n\nDetails: {details}",
+                path.display()
+            ),
+        ),
+        LoadFailure::TokenMissing => (
+            gettext("Sign in required"),
+            gettext(
+                "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
+            ),
+        ),
+        LoadFailure::KeyringFailed { details } => (
+            gettext("Could not access the system keyring"),
+            format!(
+                "{}\n\nDetails: {details}",
+                gettext("Moments could not read your saved Immich session. Try restarting the app once your keyring service is available, or sign in again to continue.")
+            ),
+        ),
+    }
+}
+
+/// Show a blocking error dialog for library open/create failures.
+fn show_library_error_dialog(parent: &impl IsA<gtk::Widget>, heading: &str, body: &str) {
+    let dialog = adw::AlertDialog::builder()
+        .heading(heading)
+        .body(body)
+        .build();
+    dialog.add_response("ok", "OK");
+    dialog.set_default_response(Some("ok"));
+    dialog.present(Some(parent));
+}

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -791,14 +791,13 @@ impl MomentsApplication {
                         // Create the import client (GObject singleton).
                         let sync_thumbnails_dir = thumbnails_dir.clone();
                         {
-                            let import_client = crate::client::ImportClient::new();
-                            import_client.configure(
-                                Arc::clone(&library),
+                            let import_client = crate::client::ImportClient::build(
+                                Arc::clone(library_context.library()),
                                 originals_dir,
                                 thumbnails_dir,
-                                Arc::clone(&render_pipeline),
+                                Arc::clone(library_context.render_pipeline()),
                                 storage_mode,
-                                tokio.clone(),
+                                library_context.tokio().clone(),
                             );
                             app.set_import_client(import_client);
                         }
@@ -806,11 +805,10 @@ impl MomentsApplication {
                         // Create the album client (GObject singleton).
                         // Subscribe to AlbumEvent for reactive model updates.
                         {
-                            let albums_rx = library.albums().subscribe();
-                            let album_client_v2 = crate::client::AlbumClientV2::new();
-                            album_client_v2.configure(
-                                Arc::clone(&library),
-                                tokio.clone(),
+                            let albums_rx = library_context.library().albums().subscribe();
+                            let album_client_v2 = crate::client::AlbumClientV2::build(
+                                Arc::clone(library_context.library()),
+                                library_context.tokio().clone(),
                                 albums_rx,
                             );
                             *app.imp().album_client_v2.borrow_mut() = Some(album_client_v2);
@@ -819,9 +817,12 @@ impl MomentsApplication {
                         // Create the people client (GObject singleton).
                         // Subscribe to FacesEvent for reactive model updates.
                         {
-                            let faces_rx = library.faces().subscribe();
-                            let people_client = crate::client::PeopleClientV2::new();
-                            people_client.configure(Arc::clone(&library), tokio.clone(), faces_rx);
+                            let faces_rx = library_context.library().faces().subscribe();
+                            let people_client = crate::client::PeopleClientV2::build(
+                                Arc::clone(library_context.library()),
+                                library_context.tokio().clone(),
+                                faces_rx,
+                            );
                             *app.imp().people_client.borrow_mut() = Some(people_client);
                         }
 
@@ -829,8 +830,11 @@ impl MomentsApplication {
                         // Subscribes to MediaEvent via the service's fan-out
                         // channel for reactive model updates.
                         {
-                            let media_client_v2 = crate::client::MediaClientV2::new();
-                            media_client_v2.configure(Arc::clone(&library), tokio.clone());
+                            let media_client_v2 = crate::client::MediaClientV2::build(
+                                Arc::clone(library_context.library()),
+                                library_context.tokio().clone(),
+                                Arc::clone(library_context.render_pipeline()),
+                            );
                             *app.imp().media_client_v2.borrow_mut() = Some(media_client_v2);
                         }
 
@@ -913,8 +917,10 @@ impl MomentsApplication {
                             );
                             *app.imp().sync_handle.borrow_mut() = Some(handle);
 
-                            let sync_client = crate::client::SyncClient::new();
-                            sync_client.configure(sync_events_rx, tokio.clone());
+                            let sync_client = crate::client::SyncClient::build(
+                                sync_events_rx,
+                                library_context.tokio().clone(),
+                            );
                             sync_client.set_outbox_repository(
                                 crate::sync::outbox::OutboxRepository::new(db_for_sync),
                             );

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -21,6 +21,7 @@
 pub mod keyring;
 
 mod context;
+mod startup;
 
 use std::cell::{Cell, OnceCell, RefCell};
 use std::path::PathBuf;
@@ -36,7 +37,6 @@ use crate::application::context::LibraryContext;
 use crate::config::{APP_ID, PROFILE, VERSION};
 use crate::library::bundle::Bundle;
 use crate::library::config::LibraryConfig;
-use crate::library::Library;
 use crate::ui::MomentsSetupWindow;
 use crate::ui::MomentsWindow;
 
@@ -56,12 +56,13 @@ mod imp {
         /// runtime. The `OnceCell` shape can be revisited after Step 6
         /// reshapes `sync_handle`. See `docs/design-library-context.md`.
         pub(in crate::application) library_context: RefCell<Option<Arc<LibraryContext>>>,
-        // Client GObject singletons. Set once per `load_library_async`
-        // via `OnceCell::set` and read for the rest of the application
-        // lifetime. `sync_client` is left optional (no `.set()` call on
-        // the Local backend); the other clients are always populated
-        // before the main window is wired up, so accessors panic if
-        // read pre-init. See `docs/design-library-context.md` Step 3.
+        // Client GObject singletons. Set once during
+        // `startup::phase4_install` via `OnceCell::set` and read for
+        // the rest of the application lifetime. `sync_client` is left
+        // optional (no `.set()` call on the Local backend); the other
+        // clients are always populated before the main window is
+        // wired up, so accessors panic if read pre-init. See
+        // `docs/design-library-context.md` Step 3.
         pub import_client: OnceCell<crate::client::ImportClient>,
         pub album_client_v2: OnceCell<crate::client::AlbumClientV2>,
         pub people_client: OnceCell<crate::client::PeopleClientV2>,
@@ -258,11 +259,10 @@ impl MomentsApplication {
     /// go through a Client; other backend wiring code may call this.
     /// Returns `None` if no library has been opened yet.
     ///
-    /// Step 4 has no in-tree callers — `load_library_async` works with
-    /// the local `Arc<LibraryContext>` it just constructed. Step 5
-    /// introduces phase functions that re-acquire the context from the
-    /// application, at which point this accessor becomes live.
-    /// See `docs/design-library-context.md`.
+    /// Today `startup::phase4_install` works with the local
+    /// `Arc<LibraryContext>` it received from phase 1, so the only
+    /// in-tree caller of this accessor is `shutdown`. See
+    /// `docs/design-library-context.md`.
     #[allow(dead_code)]
     pub(in crate::application) fn library_context(&self) -> Option<Arc<LibraryContext>> {
         self.imp().library_context.borrow().clone()
@@ -271,7 +271,7 @@ impl MomentsApplication {
     /// Access the import client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().import_client()`.
-    /// Panics if called before `load_library_async` has populated the client.
+    /// Panics if called before `startup::start` has populated the client.
     pub fn import_client(&self) -> &crate::client::ImportClient {
         self.imp()
             .import_client
@@ -282,7 +282,7 @@ impl MomentsApplication {
     /// Access the album client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().album_client_v2()`.
-    /// Panics if called before `load_library_async` has populated the client.
+    /// Panics if called before `startup::start` has populated the client.
     pub fn album_client_v2(&self) -> &crate::client::AlbumClientV2 {
         self.imp()
             .album_client_v2
@@ -293,7 +293,7 @@ impl MomentsApplication {
     /// Access the people client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().people_client()`.
-    /// Panics if called before `load_library_async` has populated the client.
+    /// Panics if called before `startup::start` has populated the client.
     pub fn people_client(&self) -> &crate::client::PeopleClientV2 {
         self.imp()
             .people_client
@@ -304,7 +304,7 @@ impl MomentsApplication {
     /// Access the media client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().media_client_v2()`.
-    /// Panics if called before `load_library_async` has populated the client.
+    /// Panics if called before `startup::start` has populated the client.
     pub fn media_client_v2(&self) -> &crate::client::MediaClientV2 {
         self.imp()
             .media_client_v2
@@ -522,7 +522,7 @@ impl MomentsApplication {
         window.present();
         setup_win.close();
 
-        self.load_library_async(bundle, config, window);
+        startup::start(self, bundle, config, window);
     }
 
     /// Open an existing library from a saved path.
@@ -613,7 +613,7 @@ impl MomentsApplication {
         let window = MomentsWindow::new(self, settings);
         window.present();
 
-        self.load_library_async(bundle, config, window);
+        startup::start(self, bundle, config, window);
     }
 
     /// Open a folder picker and start importing the selected folder.
@@ -670,291 +670,6 @@ impl MomentsApplication {
         debug!(count = sources.len(), "resolved import sources via GIO");
 
         import_client.import(sources);
-    }
-
-    /// Spawn the async factory call on the glib main context.
-    ///
-    /// On success:
-    ///  1. Creates the event bus and opens the library backend.
-    ///  2. Wires the shell (sidebar, views, command dispatcher).
-    ///  3. Switches the window to its content page.
-    fn load_library_async(&self, bundle: Bundle, config: LibraryConfig, window: MomentsWindow) {
-        // Extract Immich connection info before the config is consumed.
-        let immich_info = match &config {
-            LibraryConfig::Immich {
-                server_url,
-                access_token,
-            } => Some((server_url.clone(), access_token.clone())),
-            _ => None,
-        };
-
-        // Store backend type for preferences dialog.
-        if let Some((ref server_url, _)) = immich_info {
-            self.imp().is_immich.set(true);
-            *self.imp().immich_server_url.borrow_mut() = Some(server_url.clone());
-        }
-
-        // Extract paths and mode for the ImportClient before the factory
-        // consumes the bundle and config.
-        let originals_dir = bundle.originals.clone();
-        let thumbnails_dir = bundle.thumbnails.clone();
-        let storage_mode = match &config {
-            LibraryConfig::Local { mode } => mode.clone(),
-            LibraryConfig::Immich { .. } => crate::library::config::LocalStorageMode::Managed,
-        };
-
-        glib::MainContext::default().spawn_local(glib::clone!(
-            #[weak(rename_to = app)]
-            self,
-            #[weak]
-            window,
-            async move {
-                let tokio = app.imp().tokio.get().expect("tokio handle set").clone();
-
-                let import_mode = storage_mode.clone();
-                let db = crate::library::db::Database::new();
-
-                // Build Immich client + recorder + resolver based on config.
-                let immich_client = immich_info.as_ref().and_then(|(url, token)| {
-                    crate::sync::providers::immich::client::ImmichClient::new(url, token).ok()
-                });
-
-                let recorder: std::sync::Arc<dyn crate::library::recorder::MutationRecorder> =
-                    if immich_client.is_some() {
-                        std::sync::Arc::new(crate::sync::outbox::QueueWriterOutbox::new(db.clone()))
-                    } else {
-                        std::sync::Arc::new(crate::sync::outbox::NoOpRecorder)
-                    };
-
-                let resolver: std::sync::Arc<dyn crate::library::resolver::OriginalResolver> =
-                    if let Some(ref client) = immich_client {
-                        std::sync::Arc::new(
-                            crate::sync::providers::immich::resolver::CachedResolver::new(
-                                std::sync::Arc::new(client.clone()),
-                                originals_dir.clone(),
-                            ),
-                        )
-                    } else {
-                        std::sync::Arc::new(crate::library::resolver::LocalResolver::new(
-                            originals_dir.clone(),
-                            import_mode.clone(),
-                        ))
-                    };
-
-                let db_for_sync = db.clone();
-                let open_result = tokio
-                    .spawn(async move {
-                        Library::open(bundle, storage_mode, db, recorder, resolver).await
-                    })
-                    .await
-                    .map_err(|e| crate::library::error::LibraryError::Runtime(e.to_string()));
-                let storage_mode = import_mode;
-                match open_result.and_then(|r| r) {
-                    Ok(library) => {
-                        let library = Arc::new(library);
-                        info!("library ready");
-
-                        // Construct the LibraryContext — the single
-                        // canonical home for the `Arc<Library>`, the
-                        // `Arc<RenderPipeline>`, and the periodic
-                        // trash-purge `JoinHandle`. All downstream
-                        // wiring pulls sub-services from this context.
-                        // See `docs/design-library-context.md`.
-                        let render_pipeline = std::sync::Arc::new(
-                            crate::renderer::pipeline::RenderPipeline::new(),
-                        );
-                        let library_context = LibraryContext::build(
-                            Arc::clone(&library),
-                            render_pipeline,
-                            tokio.clone(),
-                        );
-                        if app
-                            .imp()
-                            .library_context
-                            .borrow()
-                            .is_some()
-                        {
-                            warn!("library_context was already initialised — overwriting");
-                        }
-                        *app.imp().library_context.borrow_mut() =
-                            Some(Arc::clone(&library_context));
-
-                        // Create the import client (GObject singleton).
-                        let sync_thumbnails_dir = thumbnails_dir.clone();
-                        {
-                            let import_client = crate::client::ImportClient::build(
-                                Arc::clone(library_context.library()),
-                                originals_dir,
-                                thumbnails_dir,
-                                Arc::clone(library_context.render_pipeline()),
-                                storage_mode,
-                                library_context.tokio().clone(),
-                            );
-                            app.set_import_client(import_client);
-                        }
-
-                        // Create the album client (GObject singleton).
-                        // Subscribe to AlbumEvent for reactive model updates.
-                        {
-                            let albums_rx = library_context.library().albums().subscribe();
-                            let album_client_v2 = crate::client::AlbumClientV2::build(
-                                Arc::clone(library_context.library()),
-                                library_context.tokio().clone(),
-                                albums_rx,
-                            );
-                            app.imp()
-                                .album_client_v2
-                                .set(album_client_v2)
-                                .expect("album_client_v2 set once per load_library_async");
-                        }
-
-                        // Create the people client (GObject singleton).
-                        // Subscribe to FacesEvent for reactive model updates.
-                        {
-                            let faces_rx = library_context.library().faces().subscribe();
-                            let people_client = crate::client::PeopleClientV2::build(
-                                Arc::clone(library_context.library()),
-                                library_context.tokio().clone(),
-                                faces_rx,
-                            );
-                            app.imp()
-                                .people_client
-                                .set(people_client)
-                                .expect("people_client set once per load_library_async");
-                        }
-
-                        // Create the MediaClient (GObject singleton).
-                        // Subscribes to MediaEvent via the service's fan-out
-                        // channel for reactive model updates.
-                        {
-                            let media_client_v2 = crate::client::MediaClientV2::build(
-                                Arc::clone(library_context.library()),
-                                library_context.tokio().clone(),
-                                Arc::clone(library_context.render_pipeline()),
-                            );
-                            app.imp()
-                                .media_client_v2
-                                .set(media_client_v2)
-                                .expect("media_client_v2 set once per load_library_async");
-                        }
-
-                        // Wire the shell: builds sidebar, registers views,
-                        // and switches to the content page. Components react
-                        // to mutations via per-service event channels and
-                        // GObject signals on the client singletons.
-                        let settings = app
-                            .imp()
-                            .settings
-                            .get()
-                            .expect("settings initialised")
-                            .clone();
-                        window.setup(settings);
-
-                        // Start periodic trash purge task.
-                        {
-                            let lib = Arc::clone(library_context.library());
-                            let retention_days = app
-                                .imp()
-                                .settings
-                                .get()
-                                .expect("settings initialised")
-                                .uint("trash-retention-days");
-                            let handle = crate::tasks::purge_trash::start(
-                                lib,
-                                retention_days,
-                                tokio.clone(),
-                            );
-                            // The context is the single canonical owner
-                            // of the purge `JoinHandle` — `JoinHandle`
-                            // is not `Clone`, so there can be only one
-                            // home.
-                            if let Err(unused) =
-                                library_context.set_purge_handle(handle)
-                            {
-                                // Defensive: a duplicate populate could
-                                // only happen if `load_library_async`
-                                // ran twice on the same Application,
-                                // which the rest of the code prevents.
-                                // Abort the orphan task so it doesn't
-                                // outlive its (now-redundant) state.
-                                warn!(
-                                    "purge_handle already recorded on LibraryContext — aborting duplicate task"
-                                );
-                                unused.abort();
-                            }
-                        }
-
-                        // Start Immich sync engine and sync client.
-                        if let Some(client) = immich_client {
-                            let lib = Arc::clone(library_context.library());
-                            let sync_interval = app
-                                .imp()
-                                .settings
-                                .get()
-                                .expect("settings initialised")
-                                .uint("sync-interval-seconds")
-                                as u64;
-
-                            let (sync_events_tx, sync_events_rx) =
-                                tokio::sync::mpsc::unbounded_channel();
-
-                            let handle = crate::sync::SyncHandle::start(
-                                client,
-                                lib,
-                                db_for_sync.clone(),
-                                sync_events_tx,
-                                sync_thumbnails_dir,
-                                sync_interval,
-                                tokio.clone(),
-                            );
-                            *app.imp().sync_handle.borrow_mut() = Some(handle);
-
-                            let sync_client = crate::client::SyncClient::build(
-                                sync_events_rx,
-                                library_context.tokio().clone(),
-                            );
-                            sync_client.set_outbox_repository(
-                                crate::sync::outbox::OutboxRepository::new(db_for_sync),
-                            );
-                            app.set_sync_client(sync_client);
-                        }
-                    }
-                    Err(e) => {
-                        error!("failed to open library: {e}");
-
-                        let dialog = adw::AlertDialog::builder()
-                            .heading("Could not open library")
-                            .body(format!(
-                                "An error occurred while opening the library.\n\nDetails: {e}"
-                            ))
-                            .build();
-                        dialog.add_response("setup", "Set Up Library");
-                        dialog.add_response("quit", "Quit");
-                        dialog
-                            .set_response_appearance("quit", adw::ResponseAppearance::Destructive);
-                        dialog.set_default_response(Some("setup"));
-                        dialog.set_close_response("setup");
-
-                        let app_weak = app.downgrade();
-                        let win_weak = window.downgrade();
-                        dialog.connect_response(None, move |_, response| {
-                            if response == "setup" {
-                                if let Some(app) = app_weak.upgrade() {
-                                    if let Some(win) = win_weak.upgrade() {
-                                        win.close();
-                                    }
-                                    app.show_setup_window();
-                                }
-                            } else if let Some(app) = app_weak.upgrade() {
-                                app.quit();
-                            }
-                        });
-
-                        dialog.present(Some(&window));
-                    }
-                }
-            }
-        ));
     }
 }
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -47,18 +47,15 @@ mod imp {
     pub struct MomentsApplication {
         pub settings: OnceCell<gio::Settings>,
         pub tokio: OnceCell<tokio::runtime::Handle>,
-        /// Domain + infrastructure container. Populated alongside the
-        /// existing per-field `RefCell<Option<T>>` slots during
-        /// `load_library_async`. See `docs/design-library-context.md`.
+        /// Domain + infrastructure container.
         ///
         /// Stored in a `RefCell<Option<...>>` rather than the
         /// `OnceCell<Arc<...>>` sketched in the design doc so the
-        /// shutdown path can clear it (alongside the existing legacy
-        /// slots) and drop `Arc<Library>` before `main()` drops the
-        /// Tokio runtime. Step 4 of the migration removes the legacy
-        /// slots and can revisit this storage shape.
+        /// shutdown path can clear it and drop `Arc<Library>` (and the
+        /// `SqlitePool` it wraps) before `main()` drops the Tokio
+        /// runtime. The `OnceCell` shape can be revisited after Step 6
+        /// reshapes `sync_handle`. See `docs/design-library-context.md`.
         pub(in crate::application) library_context: RefCell<Option<Arc<LibraryContext>>>,
-        pub library: RefCell<Option<Arc<Library>>>,
         // Client GObject singletons. Set once per `load_library_async`
         // via `OnceCell::set` and read for the rest of the application
         // lifetime. `sync_client` is left optional (no `.set()` call on
@@ -70,7 +67,6 @@ mod imp {
         pub people_client: OnceCell<crate::client::PeopleClientV2>,
         pub media_client_v2: OnceCell<crate::client::MediaClientV2>,
         pub sync_client: OnceCell<crate::client::SyncClient>,
-        pub render_pipeline: RefCell<Option<Arc<crate::renderer::pipeline::RenderPipeline>>>,
         pub is_immich: Cell<bool>,
         pub immich_server_url: RefCell<Option<String>>,
         // Note: the periodic trash-purge `JoinHandle` lives on
@@ -145,21 +141,24 @@ mod imp {
             if let Some(ref handle) = *self.sync_handle.borrow() {
                 handle.shutdown();
             }
-
-            // Client GObject singletons are stored in `OnceCell<T>` and
-            // cannot be cleared from `&self` — they release their
-            // `Arc<Library>` clones when the `MomentsApplication` itself
-            // drops. The canonical `Arc<Library>` is dropped here via
-            // the legacy `self.library` slot and the
-            // `self.library_context` clear below, which releases the
-            // `SqlitePool` before `main()` shuts down the Tokio runtime.
             self.sync_handle.borrow_mut().take();
-            self.library.borrow_mut().take();
-            // Drop the LibraryContext last among domain state — it
-            // owns `Arc<Library>` and the purge-task `JoinHandle`.
-            // Aborting the purge task before dropping the runtime
-            // avoids the (unlikely but possible) race where it wakes
-            // and touches the DB after the pool has been freed.
+
+            // Drop the LibraryContext — it owns the canonical
+            // `Arc<Library>` (and the `Arc<RenderPipeline>`) and the
+            // purge-task `JoinHandle`. Aborting the purge task before
+            // dropping the runtime avoids the (unlikely but possible)
+            // race where it wakes and touches the DB after the pool
+            // has been freed.
+            //
+            // Client GObject singletons are stored in `OnceCell<T>` on
+            // `imp` and cannot be cleared from `&self`; they still
+            // hold their own `Arc<Library>` clones until the
+            // `MomentsApplication` itself drops. That is acceptable:
+            // the `SqlitePool` is reference-counted and only the
+            // *runtime* needs to outlive the *last* `Arc<Library>`
+            // drop, which happens during `MomentsApplication` drop —
+            // after `shutdown` returns but before `main()` drops the
+            // runtime.
             if let Some(ctx) = self.library_context.borrow_mut().take() {
                 if let Some(handle) = ctx.purge_handle() {
                     handle.abort();
@@ -259,10 +258,11 @@ impl MomentsApplication {
     /// go through a Client; other backend wiring code may call this.
     /// Returns `None` if no library has been opened yet.
     ///
-    /// Step 1 of the refactor adds this accessor with no in-tree
-    /// callers — `#[allow(dead_code)]` will be lifted in Step 2 once
-    /// client construction starts pulling sub-services from the
-    /// context. See `docs/design-library-context.md`.
+    /// Step 4 has no in-tree callers — `load_library_async` works with
+    /// the local `Arc<LibraryContext>` it just constructed. Step 5
+    /// introduces phase functions that re-acquire the context from the
+    /// application, at which point this accessor becomes live.
+    /// See `docs/design-library-context.md`.
     #[allow(dead_code)]
     pub(in crate::application) fn library_context(&self) -> Option<Arc<LibraryContext>> {
         self.imp().library_context.borrow().clone()
@@ -277,31 +277,6 @@ impl MomentsApplication {
             .import_client
             .get()
             .expect("import_client accessed before library was opened")
-    }
-
-    /// Access the shared render pipeline.
-    ///
-    /// Available from anywhere via `MomentsApplication::default().render_pipeline()`.
-    /// Returns `None` if no library is open yet.
-    ///
-    /// Deprecated in Step 1 of the LibraryContext refactor — the render
-    /// pipeline now lives on the `LibraryContext`. Callers in `ui/` will
-    /// migrate to acquiring it via their owning Client (which will hold
-    /// any sub-services it needs). See `docs/design-library-context.md`.
-    #[deprecated(
-        note = "Use library_context() (application-internal) or accept the pipeline via the owning Client; will be removed when migration completes"
-    )]
-    pub fn render_pipeline(&self) -> Option<Arc<crate::renderer::pipeline::RenderPipeline>> {
-        // Read from the context first when populated — keeps the context
-        // as the source of truth even while the legacy `RefCell` field
-        // is still being written. Falls back to the legacy field only
-        // for the brief window during startup where the legacy field
-        // could conceivably be populated before the context (it isn't
-        // today, but defending against future reordering is cheap).
-        if let Some(ctx) = self.imp().library_context.borrow().as_ref() {
-            return Some(Arc::clone(ctx.render_pipeline()));
-        }
-        self.imp().render_pipeline.borrow().clone()
     }
 
     /// Access the album client singleton.
@@ -779,19 +754,18 @@ impl MomentsApplication {
                         let library = Arc::new(library);
                         info!("library ready");
 
-                        // Construct the LibraryContext first, then mirror
-                        // the same `Arc` references into the legacy
-                        // `RefCell<Option<T>>` slots. Both shapes co-exist
-                        // during Step 1 of the LibraryContext refactor;
-                        // subsequent steps will remove the legacy fields
-                        // and migrate all readers to the context.
+                        // Construct the LibraryContext — the single
+                        // canonical home for the `Arc<Library>`, the
+                        // `Arc<RenderPipeline>`, and the periodic
+                        // trash-purge `JoinHandle`. All downstream
+                        // wiring pulls sub-services from this context.
                         // See `docs/design-library-context.md`.
                         let render_pipeline = std::sync::Arc::new(
                             crate::renderer::pipeline::RenderPipeline::new(),
                         );
                         let library_context = LibraryContext::build(
                             Arc::clone(&library),
-                            Arc::clone(&render_pipeline),
+                            render_pipeline,
                             tokio.clone(),
                         );
                         if app
@@ -804,12 +778,6 @@ impl MomentsApplication {
                         }
                         *app.imp().library_context.borrow_mut() =
                             Some(Arc::clone(&library_context));
-
-                        // Store library on the application (legacy slot).
-                        *app.imp().library.borrow_mut() = Some(Arc::clone(&library));
-                        // Mirror render pipeline into the legacy slot too.
-                        *app.imp().render_pipeline.borrow_mut() =
-                            Some(Arc::clone(&render_pipeline));
 
                         // Create the import client (GObject singleton).
                         let sync_thumbnails_dir = thumbnails_dir.clone();
@@ -884,9 +852,7 @@ impl MomentsApplication {
 
                         // Start periodic trash purge task.
                         {
-                            let lib = Arc::clone(
-                                app.imp().library.borrow().as_ref().expect("library set"),
-                            );
+                            let lib = Arc::clone(library_context.library());
                             let retention_days = app
                                 .imp()
                                 .settings
@@ -901,11 +867,7 @@ impl MomentsApplication {
                             // The context is the single canonical owner
                             // of the purge `JoinHandle` — `JoinHandle`
                             // is not `Clone`, so there can be only one
-                            // home. The legacy `RefCell<Option<...>>`
-                            // slot on `MomentsApplication::imp` has
-                            // been removed (no reader: `shutdown`
-                            // never aborted the purge task, the
-                            // runtime is dropped shortly after).
+                            // home.
                             if let Err(unused) =
                                 library_context.set_purge_handle(handle)
                             {
@@ -924,9 +886,7 @@ impl MomentsApplication {
 
                         // Start Immich sync engine and sync client.
                         if let Some(client) = immich_client {
-                            let lib = Arc::clone(
-                                app.imp().library.borrow().as_ref().expect("library set"),
-                            );
+                            let lib = Arc::clone(library_context.library());
                             let sync_interval = app
                                 .imp()
                                 .settings

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -37,6 +37,7 @@ use crate::application::context::LibraryContext;
 use crate::config::{APP_ID, PROFILE, VERSION};
 use crate::library::bundle::Bundle;
 use crate::library::config::LibraryConfig;
+use crate::sync::SyncEngine;
 use crate::ui::MomentsSetupWindow;
 use crate::ui::MomentsWindow;
 
@@ -74,8 +75,13 @@ mod imp {
         // `LibraryContext::purge_handle`, not here. `JoinHandle` is not
         // `Clone`, so the context is the single canonical owner per
         // `docs/design-library-context.md`.
-        /// Sync engine handle (Immich only).
-        pub sync_handle: RefCell<Option<crate::sync::SyncHandle>>,
+        /// Long-running Immich sync service. Populated by
+        /// `startup::phase4_install` only for Immich-backed libraries;
+        /// never set on the Local backend. `SyncClient` holds its own
+        /// `Arc<SyncEngine>` so widgets that need engine control go
+        /// through the client rather than this field. See
+        /// `docs/design-library-context.md` Step 6.
+        pub(in crate::application) sync_engine: OnceCell<Arc<SyncEngine>>,
     }
 
     #[glib::object_subclass]
@@ -139,10 +145,17 @@ mod imp {
             // (and the SqlitePool it wraps) is freed before drop(tokio)
             // in main() tries to shut down the runtime.
             // Shut down sync engine explicitly before dropping clients.
-            if let Some(ref handle) = *self.sync_handle.borrow() {
-                handle.shutdown();
+            //
+            // `sync_engine` is a `OnceCell<Arc<SyncEngine>>`, so we
+            // cannot remove the Arc — but the engine's spawned tasks
+            // observe the shutdown flag at their next polling
+            // boundary and exit. The remaining `Arc<SyncEngine>`
+            // clones (this one and the one held by `SyncClient`) are
+            // dropped when the `MomentsApplication` itself is dropped,
+            // after `shutdown` returns.
+            if let Some(engine) = self.sync_engine.get() {
+                engine.shutdown();
             }
-            self.sync_handle.borrow_mut().take();
 
             // Drop the LibraryContext — it owns the canonical
             // `Arc<Library>` (and the `Arc<RenderPipeline>`) and the
@@ -337,10 +350,13 @@ impl MomentsApplication {
         self.notify("import-client");
     }
 
-    /// Update the sync polling interval. No-op if no sync engine is running.
+    /// Update the sync polling interval. No-op if no sync engine is
+    /// running. Routes through the `SyncClient`'s `Arc<SyncEngine>`
+    /// reference so the preferences dialog never sees the engine
+    /// directly.
     pub fn set_sync_interval(&self, secs: u64) {
-        if let Some(ref handle) = *self.imp().sync_handle.borrow() {
-            handle.set_interval(secs);
+        if let Some(client) = self.imp().sync_client.get() {
+            client.set_interval(secs);
         }
     }
 

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -20,7 +20,9 @@
 
 pub mod keyring;
 
+mod actions;
 mod context;
+mod import;
 mod library_loader;
 mod startup;
 
@@ -32,11 +34,11 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gettextrs::gettext;
 use gtk::{gio, glib};
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{error, info, instrument};
 
 use crate::application::context::LibraryContext;
 use crate::application::library_loader::{LibraryLoader, LoadFailure, LoadOutcome};
-use crate::config::{APP_ID, PROFILE, VERSION};
+use crate::config::APP_ID;
 use crate::sync::SyncEngine;
 use crate::ui::MomentsSetupWindow;
 use crate::ui::MomentsWindow;
@@ -368,82 +370,6 @@ impl MomentsApplication {
             .expect("application is MomentsApplication")
     }
 
-    fn setup_gactions(&self) {
-        let quit_action = gio::ActionEntry::builder("quit")
-            .activate(move |app: &Self, _, _| app.quit())
-            .build();
-        let about_action = gio::ActionEntry::builder("about")
-            .activate(move |app: &Self, _, _| app.show_about())
-            .build();
-        let import_action = gio::ActionEntry::builder("import")
-            .activate(move |app: &Self, _, _| app.show_import_dialog())
-            .build();
-        let preferences_action = gio::ActionEntry::builder("preferences")
-            .activate(move |app: &Self, _, _| app.show_preferences())
-            .build();
-        let shortcuts_action = gio::ActionEntry::builder("shortcuts")
-            .activate(move |app: &Self, _, _| app.show_shortcuts())
-            .build();
-        self.add_action_entries([
-            quit_action,
-            about_action,
-            import_action,
-            preferences_action,
-            shortcuts_action,
-        ]);
-    }
-
-    fn show_shortcuts(&self) {
-        let Some(window) = self.active_window() else {
-            return;
-        };
-        let builder =
-            gtk::Builder::from_resource("/io/github/justinf555/Moments/shortcuts-dialog.ui");
-        let dialog = builder
-            .object::<adw::ShortcutsDialog>("shortcuts_dialog")
-            .expect("shortcuts_dialog in resource");
-        dialog.present(Some(&window));
-    }
-
-    fn show_about(&self) {
-        let Some(window) = self.active_window() else {
-            return;
-        };
-        let app_name = if PROFILE == "development" {
-            "Moments (Development)"
-        } else {
-            "Moments"
-        };
-        let about = adw::AboutDialog::builder()
-            .application_name(app_name)
-            .application_icon(APP_ID)
-            .developer_name("Unknown")
-            .version(VERSION)
-            .developers(vec!["Unknown"])
-            .translator_credits(gettext("translator-credits"))
-            .copyright("© 2026 Unknown")
-            .build();
-
-        about.present(Some(&window));
-    }
-
-    fn show_preferences(&self) {
-        let window = match self.active_window() {
-            Some(w) => w,
-            None => return,
-        };
-        let settings = self
-            .imp()
-            .settings
-            .get()
-            .expect("settings initialised")
-            .clone();
-        let is_immich = self.imp().is_immich.get();
-        let immich_url = self.imp().immich_server_url.borrow().clone();
-
-        crate::ui::preferences_dialog::show_preferences(&window, &settings, is_immich, immich_url);
-    }
-
     /// Show the first-run setup window.
     fn show_setup_window(&self) -> MomentsSetupWindow {
         let setup = MomentsSetupWindow::new(self);
@@ -531,62 +457,6 @@ impl MomentsApplication {
 
         startup::start(self, bundle, config, window);
     }
-
-    /// Open a folder picker and start importing the selected folder.
-    fn show_import_dialog(&self) {
-        let window = match self.active_window() {
-            Some(w) => w,
-            None => return,
-        };
-
-        let file_dialog = gtk::FileDialog::builder()
-            .title("Select Folder to Import")
-            .modal(true)
-            .build();
-
-        file_dialog.select_folder(
-            Some(&window),
-            gio::Cancellable::NONE,
-            glib::clone!(
-                #[weak(rename_to = app)]
-                self,
-                move |result| if let Ok(folder) = result {
-                    app.run_import(folder);
-                }
-            ),
-        );
-    }
-
-    /// Create the import progress dialog and kick off the import pipeline.
-    ///
-    /// Accepts the `gio::File` directly from the file dialog rather than
-    /// extracting a path. This is critical for Flatpak: the document portal
-    /// grants access to the `gio::File` object, but the underlying path
-    /// (`/run/user/…/doc/…`) becomes inaccessible once the dialog callback
-    /// returns. Using `gio::File::enumerate_children` on the original object
-    /// respects the portal grant.
-    fn run_import(&self, folder: gio::File) {
-        let Some(import_client) = self.imp().import_client.get() else {
-            error!("import requested but no library is open");
-            return;
-        };
-
-        let display_path = folder
-            .path()
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| folder.uri().to_string());
-        info!(path = %display_path, "starting import");
-
-        // Resolve folder contents via GIO to handle Flatpak portal paths.
-        let sources = resolve_folder_via_gio(&folder);
-        if sources.is_empty() {
-            warn!(path = %display_path, "no files found in folder");
-            return;
-        }
-        debug!(count = sources.len(), "resolved import sources via GIO");
-
-        import_client.import(sources);
-    }
 }
 
 /// Dialog heading/body for a load failure in the *setup wizard* path.
@@ -657,38 +527,4 @@ fn show_library_error_dialog(parent: &impl IsA<gtk::Widget>, heading: &str, body
     dialog.add_response("ok", "OK");
     dialog.set_default_response(Some("ok"));
     dialog.present(Some(parent));
-}
-
-/// Recursively enumerate a folder's contents using GIO.
-///
-/// Accepts the `gio::File` directly from the file dialog so that
-/// Flatpak document portal grants are preserved. Creating a new
-/// `gio::File::for_path` from the extracted path would lose the grant.
-fn resolve_folder_via_gio(folder: &gio::File) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    gio_walk(folder, &mut files);
-    files
-}
-
-fn gio_walk(dir: &gio::File, out: &mut Vec<PathBuf>) {
-    let enumerator = match dir.enumerate_children(
-        "standard::name,standard::type",
-        gio::FileQueryInfoFlags::NONE,
-        gio::Cancellable::NONE,
-    ) {
-        Ok(e) => e,
-        Err(e) => {
-            warn!(path = ?dir.path(), error = %e, "could not enumerate directory via GIO");
-            return;
-        }
-    };
-
-    while let Some(info) = enumerator.next_file(gio::Cancellable::NONE).ok().flatten() {
-        let child = enumerator.child(&info);
-        if info.file_type() == gio::FileType::Directory {
-            gio_walk(&child, out);
-        } else if let Some(path) = child.path() {
-            out.push(path);
-        }
-    }
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -265,21 +265,6 @@ impl MomentsApplication {
         self.imp().tokio.get().expect("tokio handle set").clone()
     }
 
-    /// Access the domain + infrastructure container.
-    ///
-    /// Visible only inside the `application/` module tree. UI code must
-    /// go through a Client; other backend wiring code may call this.
-    /// Returns `None` if no library has been opened yet.
-    ///
-    /// Today `startup::phase4_install` works with the local
-    /// `Arc<LibraryContext>` it received from phase 1, so the only
-    /// in-tree caller of this accessor is `shutdown`. See
-    /// `docs/design-library-context.md`.
-    #[allow(dead_code)]
-    pub(in crate::application) fn library_context(&self) -> Option<Arc<LibraryContext>> {
-        self.imp().library_context.borrow().clone()
-    }
-
     /// Access the import client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().import_client()`.

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -20,6 +20,8 @@
 
 pub mod keyring;
 
+mod context;
+
 use std::cell::{Cell, OnceCell, RefCell};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -30,6 +32,7 @@ use gettextrs::gettext;
 use gtk::{gio, glib};
 use tracing::{debug, error, info, instrument, warn};
 
+use crate::application::context::LibraryContext;
 use crate::config::{APP_ID, PROFILE, VERSION};
 use crate::library::bundle::Bundle;
 use crate::library::config::LibraryConfig;
@@ -44,6 +47,17 @@ mod imp {
     pub struct MomentsApplication {
         pub settings: OnceCell<gio::Settings>,
         pub tokio: OnceCell<tokio::runtime::Handle>,
+        /// Domain + infrastructure container. Populated alongside the
+        /// existing per-field `RefCell<Option<T>>` slots during
+        /// `load_library_async`. See `docs/design-library-context.md`.
+        ///
+        /// Stored in a `RefCell<Option<...>>` rather than the
+        /// `OnceCell<Arc<...>>` sketched in the design doc so the
+        /// shutdown path can clear it (alongside the existing legacy
+        /// slots) and drop `Arc<Library>` before `main()` drops the
+        /// Tokio runtime. Step 4 of the migration removes the legacy
+        /// slots and can revisit this storage shape.
+        pub(in crate::application) library_context: RefCell<Option<Arc<LibraryContext>>>,
         pub library: RefCell<Option<Arc<Library>>>,
         pub import_client: RefCell<Option<crate::client::ImportClient>>,
         pub album_client_v2: RefCell<Option<crate::client::AlbumClientV2>>,
@@ -53,8 +67,10 @@ mod imp {
         pub render_pipeline: RefCell<Option<Arc<crate::renderer::pipeline::RenderPipeline>>>,
         pub is_immich: Cell<bool>,
         pub immich_server_url: RefCell<Option<String>>,
-        /// Background task handle for periodic trash purge.
-        pub purge_handle: RefCell<Option<tokio::task::JoinHandle<()>>>,
+        // Note: the periodic trash-purge `JoinHandle` lives on
+        // `LibraryContext::purge_handle`, not here. `JoinHandle` is not
+        // `Clone`, so the context is the single canonical owner per
+        // `docs/design-library-context.md`.
         /// Sync engine handle (Immich only).
         pub sync_handle: RefCell<Option<crate::sync::SyncHandle>>,
     }
@@ -131,6 +147,16 @@ mod imp {
             self.media_client_v2.borrow_mut().take();
             self.sync_handle.borrow_mut().take();
             self.library.borrow_mut().take();
+            // Drop the LibraryContext last among domain state — it
+            // owns `Arc<Library>` and the purge-task `JoinHandle`.
+            // Aborting the purge task before dropping the runtime
+            // avoids the (unlikely but possible) race where it wakes
+            // and touches the DB after the pool has been freed.
+            if let Some(ctx) = self.library_context.borrow_mut().take() {
+                if let Some(handle) = ctx.purge_handle() {
+                    handle.abort();
+                }
+            }
 
             self.parent_shutdown();
         }
@@ -209,8 +235,29 @@ impl MomentsApplication {
     /// Access the shared Tokio runtime handle.
     ///
     /// Available from anywhere via `MomentsApplication::default().tokio_handle()`.
+    ///
+    /// Note: the `tokio` handle is set on the application at construction
+    /// — long before `LibraryContext` exists — so this accessor reads
+    /// the original `OnceCell<tokio::runtime::Handle>` field. The context
+    /// only sees the same handle once it has been built; it is not the
+    /// canonical source for this value in Step 1.
     pub fn tokio_handle(&self) -> tokio::runtime::Handle {
         self.imp().tokio.get().expect("tokio handle set").clone()
+    }
+
+    /// Access the domain + infrastructure container.
+    ///
+    /// Visible only inside the `application/` module tree. UI code must
+    /// go through a Client; other backend wiring code may call this.
+    /// Returns `None` if no library has been opened yet.
+    ///
+    /// Step 1 of the refactor adds this accessor with no in-tree
+    /// callers — `#[allow(dead_code)]` will be lifted in Step 2 once
+    /// client construction starts pulling sub-services from the
+    /// context. See `docs/design-library-context.md`.
+    #[allow(dead_code)]
+    pub(in crate::application) fn library_context(&self) -> Option<Arc<LibraryContext>> {
+        self.imp().library_context.borrow().clone()
     }
 
     /// Access the import client singleton.
@@ -225,7 +272,24 @@ impl MomentsApplication {
     ///
     /// Available from anywhere via `MomentsApplication::default().render_pipeline()`.
     /// Returns `None` if no library is open yet.
+    ///
+    /// Deprecated in Step 1 of the LibraryContext refactor — the render
+    /// pipeline now lives on the `LibraryContext`. Callers in `ui/` will
+    /// migrate to acquiring it via their owning Client (which will hold
+    /// any sub-services it needs). See `docs/design-library-context.md`.
+    #[deprecated(
+        note = "Use library_context() (application-internal) or accept the pipeline via the owning Client; will be removed when migration completes"
+    )]
     pub fn render_pipeline(&self) -> Option<Arc<crate::renderer::pipeline::RenderPipeline>> {
+        // Read from the context first when populated — keeps the context
+        // as the source of truth even while the legacy `RefCell` field
+        // is still being written. Falls back to the legacy field only
+        // for the brief window during startup where the legacy field
+        // could conceivably be populated before the context (it isn't
+        // today, but defending against future reordering is cheap).
+        if let Some(ctx) = self.imp().library_context.borrow().as_ref() {
+            return Some(Arc::clone(ctx.render_pipeline()));
+        }
         self.imp().render_pipeline.borrow().clone()
     }
 
@@ -692,18 +756,41 @@ impl MomentsApplication {
                         let library = Arc::new(library);
                         info!("library ready");
 
-                        // Store library on the application.
+                        // Construct the LibraryContext first, then mirror
+                        // the same `Arc` references into the legacy
+                        // `RefCell<Option<T>>` slots. Both shapes co-exist
+                        // during Step 1 of the LibraryContext refactor;
+                        // subsequent steps will remove the legacy fields
+                        // and migrate all readers to the context.
+                        // See `docs/design-library-context.md`.
+                        let render_pipeline = std::sync::Arc::new(
+                            crate::renderer::pipeline::RenderPipeline::new(),
+                        );
+                        let library_context = LibraryContext::build(
+                            Arc::clone(&library),
+                            Arc::clone(&render_pipeline),
+                            tokio.clone(),
+                        );
+                        if app
+                            .imp()
+                            .library_context
+                            .borrow()
+                            .is_some()
+                        {
+                            warn!("library_context was already initialised — overwriting");
+                        }
+                        *app.imp().library_context.borrow_mut() =
+                            Some(Arc::clone(&library_context));
+
+                        // Store library on the application (legacy slot).
                         *app.imp().library.borrow_mut() = Some(Arc::clone(&library));
+                        // Mirror render pipeline into the legacy slot too.
+                        *app.imp().render_pipeline.borrow_mut() =
+                            Some(Arc::clone(&render_pipeline));
 
                         // Create the import client (GObject singleton).
                         let sync_thumbnails_dir = thumbnails_dir.clone();
                         {
-                            let render_pipeline = std::sync::Arc::new(
-                                crate::renderer::pipeline::RenderPipeline::new(),
-                            );
-                            *app.imp().render_pipeline.borrow_mut() =
-                                Some(Arc::clone(&render_pipeline));
-
                             let import_client = crate::client::ImportClient::new();
                             import_client.configure(
                                 Arc::clone(&library),
@@ -775,7 +862,28 @@ impl MomentsApplication {
                                 retention_days,
                                 tokio.clone(),
                             );
-                            *app.imp().purge_handle.borrow_mut() = Some(handle);
+                            // The context is the single canonical owner
+                            // of the purge `JoinHandle` — `JoinHandle`
+                            // is not `Clone`, so there can be only one
+                            // home. The legacy `RefCell<Option<...>>`
+                            // slot on `MomentsApplication::imp` has
+                            // been removed (no reader: `shutdown`
+                            // never aborted the purge task, the
+                            // runtime is dropped shortly after).
+                            if let Err(unused) =
+                                library_context.set_purge_handle(handle)
+                            {
+                                // Defensive: a duplicate populate could
+                                // only happen if `load_library_async`
+                                // ran twice on the same Application,
+                                // which the rest of the code prevents.
+                                // Abort the orphan task so it doesn't
+                                // outlive its (now-redundant) state.
+                                warn!(
+                                    "purge_handle already recorded on LibraryContext — aborting duplicate task"
+                                );
+                                unused.abort();
+                            }
                         }
 
                         // Start Immich sync engine and sync client.

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -24,24 +24,21 @@ mod actions;
 mod context;
 mod import;
 mod library_loader;
+mod lifecycle;
 mod startup;
 
 use std::cell::{Cell, OnceCell, RefCell};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use adw::prelude::*;
 use adw::subclass::prelude::*;
-use gettextrs::gettext;
 use gtk::{gio, glib};
-use tracing::{error, info, instrument};
+use tracing::info;
 
 use crate::application::context::LibraryContext;
-use crate::application::library_loader::{LibraryLoader, LoadFailure, LoadOutcome};
 use crate::config::APP_ID;
 use crate::sync::SyncEngine;
-use crate::ui::MomentsSetupWindow;
-use crate::ui::MomentsWindow;
 
 mod imp {
     use super::*;
@@ -369,162 +366,4 @@ impl MomentsApplication {
             .and_downcast::<Self>()
             .expect("application is MomentsApplication")
     }
-
-    /// Show the first-run setup window.
-    fn show_setup_window(&self) -> MomentsSetupWindow {
-        let setup = MomentsSetupWindow::new(self);
-        setup.connect_setup_complete(glib::clone!(
-            #[weak(rename_to = app)]
-            self,
-            move |win, path| {
-                app.on_setup_complete(win, path);
-            }
-        ));
-        setup.present();
-        setup
-    }
-
-    /// Called when the user completes the setup wizard.
-    ///
-    /// Creates the bundle, persists the path to GSettings, presents the main
-    /// window, closes the setup window, then loads the library asynchronously.
-    /// The main window is created before the setup window closes so there is
-    /// never a windowless state.
-    #[instrument(skip(self, setup_win), fields(path = %path))]
-    fn on_setup_complete(&self, setup_win: &MomentsSetupWindow, path: String) {
-        // All setup pages (Local and Immich) create the bundle before
-        // emitting setup-complete. The loader opens it and resolves any
-        // Immich token from the keyring (the wizard stored it just before
-        // emitting setup-complete, so a failure here means the keyring became
-        // unavailable between store and lookup).
-        let (bundle, config) = match LibraryLoader.load(Path::new(&path)) {
-            LoadOutcome::Ready { bundle, config } => (bundle, config),
-            LoadOutcome::Failed(failure) => {
-                let (heading, body) = setup_failure_dialog(&failure, Path::new(&path));
-                show_library_error_dialog(setup_win, &heading, &body);
-                return;
-            }
-        };
-
-        let settings = self.imp().settings.get().expect("settings initialised");
-        if let Err(e) = settings.set_string("library-path", &path) {
-            error!("failed to save library path to GSettings: {e}");
-        }
-
-        // Present the main window first, then close setup — ensures there is
-        // always at least one window alive during the transition.
-        let window = MomentsWindow::new(self, settings);
-        window.present();
-        setup_win.close();
-
-        startup::start(self, bundle, config, window);
-    }
-
-    /// Open an existing library from a saved path.
-    ///
-    /// Creates and presents the main window immediately (loading page) so
-    /// there is no windowless gap while the async factory runs.
-    ///
-    /// If the bundle cannot be opened (e.g. the directory was deleted while
-    /// the GSettings path entry still exists) the stale path is cleared and
-    /// the setup window is shown so the user can reconfigure.
-    fn open_library(&self, path: PathBuf) {
-        let (bundle, config) = match LibraryLoader.load(&path) {
-            LoadOutcome::Ready { bundle, config } => (bundle, config),
-            LoadOutcome::Failed(failure) => {
-                // Clear the stale path *before* showing the setup window so a
-                // missing bundle / missing token does not re-trigger an open
-                // on the next launch. Transient keyring failures leave it
-                // intact so a relaunch recovers once the keyring is healthy.
-                if failure.clear_path() {
-                    let settings = self.imp().settings.get().expect("settings initialised");
-                    if let Err(e) = settings.set_string("library-path", "") {
-                        error!("failed to clear stale library path: {e}");
-                    }
-                }
-                // No window exists yet on this path — show the setup window and
-                // parent the explanation dialog to it.
-                let setup_win = self.show_setup_window();
-                let (heading, body) = open_failure_dialog(&failure, &path);
-                show_library_error_dialog(&setup_win, &heading, &body);
-                return;
-            }
-        };
-
-        let settings = self.imp().settings.get().expect("settings initialised");
-        let window = MomentsWindow::new(self, settings);
-        window.present();
-
-        startup::start(self, bundle, config, window);
-    }
-}
-
-/// Dialog heading/body for a load failure in the *setup wizard* path.
-///
-/// Phrased for "the user just finished setup": the bundle was created moments
-/// ago, and an Immich token was stored just before this. See
-/// `library_loader::LoadFailure`.
-fn setup_failure_dialog(failure: &LoadFailure, path: &Path) -> (String, String) {
-    match failure {
-        LoadFailure::BundleOpen { details } => (
-            "Could not open library".to_string(),
-            format!(
-                "The library at {} could not be opened.\n\nDetails: {details}",
-                path.display()
-            ),
-        ),
-        LoadFailure::TokenMissing => (
-            gettext("Sign in required"),
-            gettext(
-                "The session token saved during setup could not be read back. Please try signing in again.",
-            ),
-        ),
-        LoadFailure::KeyringFailed { details } => (
-            gettext("Could not access the system keyring"),
-            format!(
-                "{}\n\nDetails: {details}",
-                gettext("Moments stored your session in the keyring but could not read it back. Please check your keyring service and try again.")
-            ),
-        ),
-    }
-}
-
-/// Dialog heading/body for a load failure in the *open-on-launch* path.
-///
-/// Phrased for "a previously-saved library could not be reopened" and
-/// includes the offending `path`. See `library_loader::LoadFailure`.
-fn open_failure_dialog(failure: &LoadFailure, path: &Path) -> (String, String) {
-    match failure {
-        LoadFailure::BundleOpen { details } => (
-            "Could not open library".to_string(),
-            format!(
-                "The library at {} could not be opened. Please set up a new library.\n\nDetails: {details}",
-                path.display()
-            ),
-        ),
-        LoadFailure::TokenMissing => (
-            gettext("Sign in required"),
-            gettext(
-                "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
-            ),
-        ),
-        LoadFailure::KeyringFailed { details } => (
-            gettext("Could not access the system keyring"),
-            format!(
-                "{}\n\nDetails: {details}",
-                gettext("Moments could not read your saved Immich session. Try restarting the app once your keyring service is available, or sign in again to continue.")
-            ),
-        ),
-    }
-}
-
-/// Show a blocking error dialog for library open/create failures.
-fn show_library_error_dialog(parent: &impl IsA<gtk::Widget>, heading: &str, body: &str) {
-    let dialog = adw::AlertDialog::builder()
-        .heading(heading)
-        .body(body)
-        .build();
-    dialog.add_response("ok", "OK");
-    dialog.set_default_response(Some("ok"));
-    dialog.present(Some(parent));
 }

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -59,11 +59,17 @@ mod imp {
         /// slots and can revisit this storage shape.
         pub(in crate::application) library_context: RefCell<Option<Arc<LibraryContext>>>,
         pub library: RefCell<Option<Arc<Library>>>,
-        pub import_client: RefCell<Option<crate::client::ImportClient>>,
-        pub album_client_v2: RefCell<Option<crate::client::AlbumClientV2>>,
-        pub people_client: RefCell<Option<crate::client::PeopleClientV2>>,
-        pub media_client_v2: RefCell<Option<crate::client::MediaClientV2>>,
-        pub sync_client: RefCell<Option<crate::client::SyncClient>>,
+        // Client GObject singletons. Set once per `load_library_async`
+        // via `OnceCell::set` and read for the rest of the application
+        // lifetime. `sync_client` is left optional (no `.set()` call on
+        // the Local backend); the other clients are always populated
+        // before the main window is wired up, so accessors panic if
+        // read pre-init. See `docs/design-library-context.md` Step 3.
+        pub import_client: OnceCell<crate::client::ImportClient>,
+        pub album_client_v2: OnceCell<crate::client::AlbumClientV2>,
+        pub people_client: OnceCell<crate::client::PeopleClientV2>,
+        pub media_client_v2: OnceCell<crate::client::MediaClientV2>,
+        pub sync_client: OnceCell<crate::client::SyncClient>,
         pub render_pipeline: RefCell<Option<Arc<crate::renderer::pipeline::RenderPipeline>>>,
         pub is_immich: Cell<bool>,
         pub immich_server_url: RefCell<Option<String>>,
@@ -104,8 +110,8 @@ mod imp {
 
         fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
             match pspec.name() {
-                "sync-client" => self.sync_client.borrow().to_value(),
-                "import-client" => self.import_client.borrow().to_value(),
+                "sync-client" => self.sync_client.get().to_value(),
+                "import-client" => self.import_client.get().to_value(),
                 _ => unimplemented!(),
             }
         }
@@ -140,11 +146,13 @@ mod imp {
                 handle.shutdown();
             }
 
-            self.sync_client.borrow_mut().take();
-            self.import_client.borrow_mut().take();
-            self.album_client_v2.borrow_mut().take();
-            self.people_client.borrow_mut().take();
-            self.media_client_v2.borrow_mut().take();
+            // Client GObject singletons are stored in `OnceCell<T>` and
+            // cannot be cleared from `&self` — they release their
+            // `Arc<Library>` clones when the `MomentsApplication` itself
+            // drops. The canonical `Arc<Library>` is dropped here via
+            // the legacy `self.library` slot and the
+            // `self.library_context` clear below, which releases the
+            // `SqlitePool` before `main()` shuts down the Tokio runtime.
             self.sync_handle.borrow_mut().take();
             self.library.borrow_mut().take();
             // Drop the LibraryContext last among domain state — it
@@ -263,9 +271,12 @@ impl MomentsApplication {
     /// Access the import client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().import_client()`.
-    /// Returns `None` if no library is open yet.
-    pub fn import_client(&self) -> Option<crate::client::ImportClient> {
-        self.imp().import_client.borrow().clone()
+    /// Panics if called before `load_library_async` has populated the client.
+    pub fn import_client(&self) -> &crate::client::ImportClient {
+        self.imp()
+            .import_client
+            .get()
+            .expect("import_client accessed before library was opened")
     }
 
     /// Access the shared render pipeline.
@@ -296,43 +307,58 @@ impl MomentsApplication {
     /// Access the album client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().album_client_v2()`.
-    /// Returns `None` if no library is open yet.
-    pub fn album_client_v2(&self) -> Option<crate::client::AlbumClientV2> {
-        self.imp().album_client_v2.borrow().clone()
+    /// Panics if called before `load_library_async` has populated the client.
+    pub fn album_client_v2(&self) -> &crate::client::AlbumClientV2 {
+        self.imp()
+            .album_client_v2
+            .get()
+            .expect("album_client_v2 accessed before library was opened")
     }
 
     /// Access the people client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().people_client()`.
-    /// Returns `None` if no library is open yet.
-    pub fn people_client(&self) -> Option<crate::client::PeopleClientV2> {
-        self.imp().people_client.borrow().clone()
+    /// Panics if called before `load_library_async` has populated the client.
+    pub fn people_client(&self) -> &crate::client::PeopleClientV2 {
+        self.imp()
+            .people_client
+            .get()
+            .expect("people_client accessed before library was opened")
     }
 
     /// Access the media client singleton.
     ///
     /// Available from anywhere via `MomentsApplication::default().media_client_v2()`.
-    /// Returns `None` if no library is open yet.
-    pub fn media_client_v2(&self) -> Option<crate::client::MediaClientV2> {
-        self.imp().media_client_v2.borrow().clone()
+    /// Panics if called before `load_library_async` has populated the client.
+    pub fn media_client_v2(&self) -> &crate::client::MediaClientV2 {
+        self.imp()
+            .media_client_v2
+            .get()
+            .expect("media_client_v2 accessed before library was opened")
     }
 
     /// Access the sync client singleton (Immich only).
     ///
     /// Returns `None` for local libraries or if no library is open yet.
-    pub fn sync_client(&self) -> Option<crate::client::SyncClient> {
-        self.imp().sync_client.borrow().clone()
+    pub fn sync_client(&self) -> Option<&crate::client::SyncClient> {
+        self.imp().sync_client.get()
     }
 
     /// Store the sync client and notify listeners.
     pub fn set_sync_client(&self, client: crate::client::SyncClient) {
-        *self.imp().sync_client.borrow_mut() = Some(client);
+        self.imp()
+            .sync_client
+            .set(client)
+            .expect("sync_client set at most once per application lifetime");
         self.notify("sync-client");
     }
 
     /// Store the import client and notify listeners.
     pub fn set_import_client(&self, client: crate::client::ImportClient) {
-        *self.imp().import_client.borrow_mut() = Some(client);
+        self.imp()
+            .import_client
+            .set(client)
+            .expect("import_client set at most once per application lifetime");
         self.notify("import-client");
     }
 
@@ -649,12 +675,9 @@ impl MomentsApplication {
     /// returns. Using `gio::File::enumerate_children` on the original object
     /// respects the portal grant.
     fn run_import(&self, folder: gio::File) {
-        let import_client = match self.imp().import_client.borrow().clone() {
-            Some(c) => c,
-            None => {
-                error!("import requested but no library is open");
-                return;
-            }
+        let Some(import_client) = self.imp().import_client.get() else {
+            error!("import requested but no library is open");
+            return;
         };
 
         let display_path = folder
@@ -811,7 +834,10 @@ impl MomentsApplication {
                                 library_context.tokio().clone(),
                                 albums_rx,
                             );
-                            *app.imp().album_client_v2.borrow_mut() = Some(album_client_v2);
+                            app.imp()
+                                .album_client_v2
+                                .set(album_client_v2)
+                                .expect("album_client_v2 set once per load_library_async");
                         }
 
                         // Create the people client (GObject singleton).
@@ -823,7 +849,10 @@ impl MomentsApplication {
                                 library_context.tokio().clone(),
                                 faces_rx,
                             );
-                            *app.imp().people_client.borrow_mut() = Some(people_client);
+                            app.imp()
+                                .people_client
+                                .set(people_client)
+                                .expect("people_client set once per load_library_async");
                         }
 
                         // Create the MediaClient (GObject singleton).
@@ -835,7 +864,10 @@ impl MomentsApplication {
                                 library_context.tokio().clone(),
                                 Arc::clone(library_context.render_pipeline()),
                             );
-                            *app.imp().media_client_v2.borrow_mut() = Some(media_client_v2);
+                            app.imp()
+                                .media_client_v2
+                                .set(media_client_v2)
+                                .expect("media_client_v2 set once per load_library_async");
                         }
 
                         // Wire the shell: builds sidebar, registers views,

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -21,10 +21,11 @@
 pub mod keyring;
 
 mod context;
+mod library_loader;
 mod startup;
 
 use std::cell::{Cell, OnceCell, RefCell};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use adw::prelude::*;
@@ -34,9 +35,8 @@ use gtk::{gio, glib};
 use tracing::{debug, error, info, instrument, warn};
 
 use crate::application::context::LibraryContext;
+use crate::application::library_loader::{LibraryLoader, LoadFailure, LoadOutcome};
 use crate::config::{APP_ID, PROFILE, VERSION};
-use crate::library::bundle::Bundle;
-use crate::library::config::LibraryConfig;
 use crate::sync::SyncEngine;
 use crate::ui::MomentsSetupWindow;
 use crate::ui::MomentsWindow;
@@ -466,65 +466,18 @@ impl MomentsApplication {
     /// never a windowless state.
     #[instrument(skip(self, setup_win), fields(path = %path))]
     fn on_setup_complete(&self, setup_win: &MomentsSetupWindow, path: String) {
-        let bundle_path = PathBuf::from(&path);
-
-        // All setup pages (Local and Immich) create the bundle before emitting
-        // setup-complete. We just open it here.
-        let (bundle, config) = match Bundle::open(&bundle_path) {
-            Ok(result) => result,
-            Err(e) => {
-                error!("failed to open bundle: {e}");
-                show_library_error_dialog(
-                    setup_win,
-                    "Could not open library",
-                    &format!(
-                        "The library at {} could not be opened.\n\nDetails: {e}",
-                        bundle_path.display()
-                    ),
-                );
+        // All setup pages (Local and Immich) create the bundle before
+        // emitting setup-complete. The loader opens it and resolves any
+        // Immich token from the keyring (the wizard stored it just before
+        // emitting setup-complete, so a failure here means the keyring became
+        // unavailable between store and lookup).
+        let (bundle, config) = match LibraryLoader.load(Path::new(&path)) {
+            LoadOutcome::Ready { bundle, config } => (bundle, config),
+            LoadOutcome::Failed(failure) => {
+                let (heading, body) = setup_failure_dialog(&failure, Path::new(&path));
+                show_library_error_dialog(setup_win, &heading, &body);
                 return;
             }
-        };
-
-        // For Immich configs, inject the session token from the keyring.
-        // The setup wizard stores the token before emitting setup-complete,
-        // so a failure here means the keyring became unavailable between
-        // store and lookup — surface it rather than booting the user into a
-        // library that can never authenticate.
-        let config = match config {
-            LibraryConfig::Immich { server_url, .. } => {
-                match keyring::resolve_immich_token(&server_url) {
-                    Ok(access_token) => LibraryConfig::Immich {
-                        server_url,
-                        access_token,
-                    },
-                    Err(err) => {
-                        let (heading, body) = match err {
-                            keyring::TokenError::Missing => (
-                                gettext("Sign in required"),
-                                gettext(
-                                    "The session token saved during setup could not be read back. Please try signing in again.",
-                                ),
-                            ),
-                            keyring::TokenError::KeyringFailed(e) => {
-                                error!(
-                                    "keyring lookup failed immediately after setup: {e}"
-                                );
-                                (
-                                    gettext("Could not access the system keyring"),
-                                    format!(
-                                        "{}\n\nDetails: {e}",
-                                        gettext("Moments stored your session in the keyring but could not read it back. Please check your keyring service and try again.")
-                                    ),
-                                )
-                            }
-                        };
-                        show_library_error_dialog(setup_win, &heading, &body);
-                        return;
-                    }
-                }
-            }
-            other => other,
         };
 
         let settings = self.imp().settings.get().expect("settings initialised");
@@ -550,79 +503,26 @@ impl MomentsApplication {
     /// the GSettings path entry still exists) the stale path is cleared and
     /// the setup window is shown so the user can reconfigure.
     fn open_library(&self, path: PathBuf) {
-        let (bundle, config) = match Bundle::open(&path) {
-            Ok(result) => result,
-            Err(e) => {
-                error!("failed to open library bundle: {e}");
-                let settings = self.imp().settings.get().expect("settings initialised");
-                if let Err(e) = settings.set_string("library-path", "") {
-                    error!("failed to clear stale library path: {e}");
-                }
-                // Show setup window with an error dialog explaining what happened.
-                let setup_win = self.show_setup_window();
-                show_library_error_dialog(
-                    &setup_win,
-                    "Could not open library",
-                    &format!(
-                        "The library at {} could not be opened. Please set up a new library.\n\nDetails: {e}",
-                        path.display()
-                    ),
-                );
-                return;
-            }
-        };
-
-        // For Immich configs, inject the session token from the keyring.
-        // If the token cannot be resolved, refuse to load the library — passing
-        // an empty string downstream produces opaque 401 toasts and keeps the
-        // outbox spinning. Bounce the user back to the setup window with an
-        // explanation instead.
-        let config = match config {
-            LibraryConfig::Immich { server_url, .. } => {
-                match keyring::resolve_immich_token(&server_url) {
-                    Ok(access_token) => LibraryConfig::Immich {
-                        server_url,
-                        access_token,
-                    },
-                    Err(err) => {
-                        // Only `Missing` warrants clearing `library-path`: the
-                        // user has no credential for this server and must
-                        // re-run setup. `KeyringFailed` is typically transient
-                        // (D-Bus race during session start, locked collection
-                        // prompt timeout) — leave the saved path intact so a
-                        // simple relaunch recovers once the keyring is healthy.
-                        let setup_win = self.show_setup_window();
-                        let (heading, body) = match err {
-                            keyring::TokenError::Missing => {
-                                let settings =
-                                    self.imp().settings.get().expect("settings initialised");
-                                if let Err(e) = settings.set_string("library-path", "") {
-                                    error!("failed to clear stale library path: {e}");
-                                }
-                                (
-                                    gettext("Sign in required"),
-                                    gettext(
-                                        "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
-                                    ),
-                                )
-                            }
-                            keyring::TokenError::KeyringFailed(e) => {
-                                error!("keyring lookup failed during open_library: {e}");
-                                (
-                                    gettext("Could not access the system keyring"),
-                                    format!(
-                                        "{}\n\nDetails: {e}",
-                                        gettext("Moments could not read your saved Immich session. Try restarting the app once your keyring service is available, or sign in again to continue.")
-                                    ),
-                                )
-                            }
-                        };
-                        show_library_error_dialog(&setup_win, &heading, &body);
-                        return;
+        let (bundle, config) = match LibraryLoader.load(&path) {
+            LoadOutcome::Ready { bundle, config } => (bundle, config),
+            LoadOutcome::Failed(failure) => {
+                // Clear the stale path *before* showing the setup window so a
+                // missing bundle / missing token does not re-trigger an open
+                // on the next launch. Transient keyring failures leave it
+                // intact so a relaunch recovers once the keyring is healthy.
+                if failure.clear_path() {
+                    let settings = self.imp().settings.get().expect("settings initialised");
+                    if let Err(e) = settings.set_string("library-path", "") {
+                        error!("failed to clear stale library path: {e}");
                     }
                 }
+                // No window exists yet on this path — show the setup window and
+                // parent the explanation dialog to it.
+                let setup_win = self.show_setup_window();
+                let (heading, body) = open_failure_dialog(&failure, &path);
+                show_library_error_dialog(&setup_win, &heading, &body);
+                return;
             }
-            other => other,
         };
 
         let settings = self.imp().settings.get().expect("settings initialised");
@@ -686,6 +586,65 @@ impl MomentsApplication {
         debug!(count = sources.len(), "resolved import sources via GIO");
 
         import_client.import(sources);
+    }
+}
+
+/// Dialog heading/body for a load failure in the *setup wizard* path.
+///
+/// Phrased for "the user just finished setup": the bundle was created moments
+/// ago, and an Immich token was stored just before this. See
+/// `library_loader::LoadFailure`.
+fn setup_failure_dialog(failure: &LoadFailure, path: &Path) -> (String, String) {
+    match failure {
+        LoadFailure::BundleOpen { details } => (
+            "Could not open library".to_string(),
+            format!(
+                "The library at {} could not be opened.\n\nDetails: {details}",
+                path.display()
+            ),
+        ),
+        LoadFailure::TokenMissing => (
+            gettext("Sign in required"),
+            gettext(
+                "The session token saved during setup could not be read back. Please try signing in again.",
+            ),
+        ),
+        LoadFailure::KeyringFailed { details } => (
+            gettext("Could not access the system keyring"),
+            format!(
+                "{}\n\nDetails: {details}",
+                gettext("Moments stored your session in the keyring but could not read it back. Please check your keyring service and try again.")
+            ),
+        ),
+    }
+}
+
+/// Dialog heading/body for a load failure in the *open-on-launch* path.
+///
+/// Phrased for "a previously-saved library could not be reopened" and
+/// includes the offending `path`. See `library_loader::LoadFailure`.
+fn open_failure_dialog(failure: &LoadFailure, path: &Path) -> (String, String) {
+    match failure {
+        LoadFailure::BundleOpen { details } => (
+            "Could not open library".to_string(),
+            format!(
+                "The library at {} could not be opened. Please set up a new library.\n\nDetails: {details}",
+                path.display()
+            ),
+        ),
+        LoadFailure::TokenMissing => (
+            gettext("Sign in required"),
+            gettext(
+                "Your saved Immich session was not found in the system keyring. Please sign in again to continue.",
+            ),
+        ),
+        LoadFailure::KeyringFailed { details } => (
+            gettext("Could not access the system keyring"),
+            format!(
+                "{}\n\nDetails: {details}",
+                gettext("Moments could not read your saved Immich session. Try restarting the app once your keyring service is available, or sign in again to continue.")
+            ),
+        ),
     }
 }
 

--- a/src/application/startup.rs
+++ b/src/application/startup.rs
@@ -88,7 +88,6 @@ struct DomainArtifacts {
     db: Database,
     paths: ImportPaths,
     immich_client: Option<ImmichClient>,
-    thumbnails_dir_for_sync: PathBuf,
 }
 
 /// Output of [`phase2_background_services`]. When Immich is configured
@@ -161,7 +160,6 @@ pub(in crate::application) fn start(
             LibraryConfig::Immich { .. } => LocalStorageMode::Managed,
         },
     };
-    let thumbnails_dir_for_sync = bundle.thumbnails.clone();
     let tokio = app.tokio_handle();
 
     glib::MainContext::default().spawn_local(glib::clone!(
@@ -170,16 +168,7 @@ pub(in crate::application) fn start(
         #[weak]
         window,
         async move {
-            let domain = match phase1_domain(
-                bundle,
-                config,
-                paths,
-                immich_info,
-                thumbnails_dir_for_sync,
-                tokio,
-            )
-            .await
-            {
+            let domain = match phase1_domain(bundle, config, paths, immich_info, tokio).await {
                 Ok(d) => d,
                 Err(e) => {
                     present_open_error(&app, &window, e);
@@ -214,14 +203,19 @@ async fn phase1_domain(
     config: LibraryConfig,
     paths: ImportPaths,
     immich_info: Option<ImmichInfo>,
-    thumbnails_dir_for_sync: PathBuf,
     tokio: tokio::runtime::Handle,
 ) -> Result<DomainArtifacts, LibraryError> {
     let db = Database::new();
 
-    let immich_client = immich_info
-        .as_ref()
-        .and_then(|info| ImmichClient::new(&info.server_url, &info.access_token).ok());
+    let immich_client = immich_info.as_ref().and_then(|info| {
+        match ImmichClient::new(&info.server_url, &info.access_token) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                warn!("failed to build Immich HTTP client: {e}; continuing without sync");
+                None
+            }
+        }
+    });
 
     let recorder: Arc<dyn crate::library::recorder::MutationRecorder> = if immich_client.is_some() {
         Arc::new(crate::sync::outbox::QueueWriterOutbox::new(db.clone()))
@@ -268,7 +262,6 @@ async fn phase1_domain(
         db,
         paths,
         immich_client,
-        thumbnails_dir_for_sync,
     })
 }
 
@@ -312,7 +305,7 @@ fn phase2_background_services(
         Arc::clone(domain.ctx.library()),
         domain.db.clone(),
         sync_events_tx,
-        domain.thumbnails_dir_for_sync.clone(),
+        domain.paths.thumbnails_dir.clone(),
         sync_interval,
         domain.ctx.tokio().clone(),
     );

--- a/src/application/startup.rs
+++ b/src/application/startup.rs
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Phase-based startup for `MomentsApplication`.
+//
+// The legacy entry point was the 270-line `load_library_async` on
+// `MomentsApplication`. That function did seven distinct things in one
+// place: open the library, build the render pipeline, wire the import
+// client, the album / people / media clients, kick off the periodic
+// trash purge, and conditionally start the Immich sync engine + sync
+// client. There was no compile-time ordering between those steps.
+//
+// Step 5 of the LibraryContext refactor splits that work into four
+// typed phases. Each phase function consumes the previous phase's
+// output, so the compiler enforces the ordering: you cannot build a
+// client before the `LibraryContext` exists, because the constructor
+// arguments do not exist. See `docs/design-library-context.md`,
+// "Startup phases".
+//
+// The phases:
+//
+// 1. [`phase1_domain`] — open the `Library`, build the
+//    `RenderPipeline`, wrap them in a [`LibraryContext`].
+// 2. [`phase2_background_services`] — conditionally start the Immich
+//    sync engine. Step 6 will reshape `SyncHandle` into a dedicated
+//    `SyncEngine` top-level service; today the existing `SyncHandle`
+//    shape is preserved unchanged.
+// 3. [`phase3_clients`] — build the UI-facing client GObjects with
+//    minimal concrete dependencies from the context.
+// 4. [`phase4_install`] — install the context, sync handle, and
+//    clients on the application, then start the periodic purge task
+//    and wire the main window.
+//
+// Error handling matches the legacy function: open failures surface as
+// an `AdwAlertDialog` over the main window with "Set Up Library" /
+// "Quit" responses. Internal phase functions return `LibraryError` and
+// the orchestrator translates the failure into that dialog. The
+// orchestrator itself is fire-and-forget on the GTK main context —
+// `start` does not return a `Result` because there is no caller
+// equipped to handle a startup failure differently from the dialog.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use gtk::glib;
+use tracing::{error, info, instrument, warn};
+
+use crate::application::context::LibraryContext;
+use crate::application::MomentsApplication;
+use crate::client::{AlbumClientV2, ImportClient, MediaClientV2, PeopleClientV2, SyncClient};
+use crate::library::bundle::Bundle;
+use crate::library::config::{LibraryConfig, LocalStorageMode};
+use crate::library::db::Database;
+use crate::library::error::LibraryError;
+use crate::library::Library;
+use crate::renderer::pipeline::RenderPipeline;
+use crate::sync::providers::immich::client::ImmichClient;
+use crate::sync::SyncHandle;
+use crate::ui::MomentsWindow;
+
+/// Connection details for an Immich backend pulled out of the
+/// [`LibraryConfig`] before the config is consumed by `Library::open`.
+#[derive(Clone)]
+struct ImmichInfo {
+    server_url: String,
+    access_token: String,
+}
+
+/// Static paths and storage mode the [`ImportClient`] needs after the
+/// bundle has been consumed by the library open call.
+struct ImportPaths {
+    originals_dir: PathBuf,
+    thumbnails_dir: PathBuf,
+    storage_mode: LocalStorageMode,
+}
+
+/// Output of [`phase1_domain`]: the constructed [`LibraryContext`]
+/// plus the [`Database`] handle, paths, and the (optional) Immich
+/// client that later phases need.
+///
+/// The `db` field is carried forward so the sync push/pull pipeline
+/// and the [`crate::sync::outbox::OutboxRepository`] used by
+/// [`SyncClient`] share the same `SqlitePool` as the library.
+struct DomainArtifacts {
+    ctx: Arc<LibraryContext>,
+    db: Database,
+    paths: ImportPaths,
+    immich_client: Option<ImmichClient>,
+    thumbnails_dir_for_sync: PathBuf,
+}
+
+/// Output of [`phase2_background_services`]. When Immich is configured
+/// the sync engine is started and the receiving end of its event
+/// channel is handed to phase 3 so [`SyncClient`] can subscribe.
+struct BackgroundServices {
+    sync_handle: Option<SyncHandle>,
+    sync_events_rx: Option<tokio::sync::mpsc::UnboundedReceiver<crate::sync::event::SyncEvent>>,
+    db: Database,
+}
+
+/// Output of [`phase3_clients`]: every client GObject that phase 4
+/// installs on the application.
+///
+/// `sync_client` is optional because the Immich sync engine is only
+/// started for Immich-backed libraries.
+struct BuiltClients {
+    import_client: ImportClient,
+    album_client: AlbumClientV2,
+    people_client: PeopleClientV2,
+    media_client: MediaClientV2,
+    sync_client: Option<SyncClient>,
+}
+
+/// Run all four startup phases for the given library bundle.
+///
+/// Spawns the work on the GLib main context so the GTK side stays
+/// responsive while `Library::open` runs on the Tokio runtime. On any
+/// failure during phase 1 (the only fallible phase today) an
+/// `AdwAlertDialog` is presented over `window` so the user can either
+/// return to the setup wizard or quit.
+#[instrument(skip(app, bundle, config, window))]
+pub(in crate::application) fn start(
+    app: &MomentsApplication,
+    bundle: Bundle,
+    config: LibraryConfig,
+    window: MomentsWindow,
+) {
+    // Pull the values phase 1 needs out of the config + bundle before
+    // they are consumed.
+    let immich_info = match &config {
+        LibraryConfig::Immich {
+            server_url,
+            access_token,
+        } => Some(ImmichInfo {
+            server_url: server_url.clone(),
+            access_token: access_token.clone(),
+        }),
+        _ => None,
+    };
+
+    // Store backend type for the preferences dialog. This is read
+    // synchronously when the user opens preferences, so it must be in
+    // place before the main window finishes setup.
+    if let Some(ref info) = immich_info {
+        app.imp().is_immich.set(true);
+        *app.imp().immich_server_url.borrow_mut() = Some(info.server_url.clone());
+    }
+
+    let paths = ImportPaths {
+        originals_dir: bundle.originals.clone(),
+        thumbnails_dir: bundle.thumbnails.clone(),
+        storage_mode: match &config {
+            LibraryConfig::Local { mode } => mode.clone(),
+            LibraryConfig::Immich { .. } => LocalStorageMode::Managed,
+        },
+    };
+    let thumbnails_dir_for_sync = bundle.thumbnails.clone();
+    let tokio = app.tokio_handle();
+
+    glib::MainContext::default().spawn_local(glib::clone!(
+        #[weak]
+        app,
+        #[weak]
+        window,
+        async move {
+            let domain = match phase1_domain(
+                bundle,
+                config,
+                paths,
+                immich_info,
+                thumbnails_dir_for_sync,
+                tokio,
+            )
+            .await
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    present_open_error(&app, &window, e);
+                    return;
+                }
+            };
+
+            let background = phase2_background_services(&app, &domain);
+
+            let clients = phase3_clients(&domain, background.sync_events_rx, background.db.clone());
+
+            phase4_install(&app, &window, domain, background.sync_handle, clients);
+        }
+    ));
+}
+
+/// Phase 1 — open the library and build the render pipeline.
+///
+/// Returns the [`LibraryContext`] alongside the [`Database`], the
+/// import paths, and the optional Immich HTTP client. The database
+/// handle is carried forward (rather than re-opened from the bundle)
+/// so phases 2 and 3 share the exact `SqlitePool` that `Library`
+/// holds.
+#[instrument(skip_all)]
+async fn phase1_domain(
+    bundle: Bundle,
+    config: LibraryConfig,
+    paths: ImportPaths,
+    immich_info: Option<ImmichInfo>,
+    thumbnails_dir_for_sync: PathBuf,
+    tokio: tokio::runtime::Handle,
+) -> Result<DomainArtifacts, LibraryError> {
+    let db = Database::new();
+
+    let immich_client = immich_info
+        .as_ref()
+        .and_then(|info| ImmichClient::new(&info.server_url, &info.access_token).ok());
+
+    let recorder: Arc<dyn crate::library::recorder::MutationRecorder> = if immich_client.is_some() {
+        Arc::new(crate::sync::outbox::QueueWriterOutbox::new(db.clone()))
+    } else {
+        Arc::new(crate::sync::outbox::NoOpRecorder)
+    };
+
+    let resolver: Arc<dyn crate::library::resolver::OriginalResolver> =
+        if let Some(ref client) = immich_client {
+            Arc::new(
+                crate::sync::providers::immich::resolver::CachedResolver::new(
+                    Arc::new(client.clone()),
+                    paths.originals_dir.clone(),
+                ),
+            )
+        } else {
+            Arc::new(crate::library::resolver::LocalResolver::new(
+                paths.originals_dir.clone(),
+                paths.storage_mode.clone(),
+            ))
+        };
+
+    let storage_mode = match &config {
+        LibraryConfig::Local { mode } => mode.clone(),
+        LibraryConfig::Immich { .. } => LocalStorageMode::Managed,
+    };
+
+    let db_for_open = db.clone();
+    let library =
+        tokio
+            .spawn(async move {
+                Library::open(bundle, storage_mode, db_for_open, recorder, resolver).await
+            })
+            .await
+            .map_err(|e| LibraryError::Runtime(e.to_string()))??;
+    let library = Arc::new(library);
+    info!("library ready");
+
+    let render_pipeline = Arc::new(RenderPipeline::new());
+    let ctx = LibraryContext::build(Arc::clone(&library), render_pipeline, tokio);
+
+    Ok(DomainArtifacts {
+        ctx,
+        db,
+        paths,
+        immich_client,
+        thumbnails_dir_for_sync,
+    })
+}
+
+/// Phase 2 — start long-running background services.
+///
+/// Today the only long-running service in scope is the Immich
+/// [`SyncHandle`]. Step 6 of the refactor reshapes this into a
+/// dedicated `SyncEngine` top-level service with a paired
+/// [`SyncClient`]; until then the existing handle structure is kept
+/// unchanged and threaded through to phase 4.
+///
+/// The periodic trash-purge task is *not* started here — it is
+/// recorded on the [`LibraryContext`] itself and started in phase 4
+/// alongside window setup so the retention-days setting and the
+/// `JoinHandle` registration happen in one place.
+#[instrument(skip_all)]
+fn phase2_background_services(
+    app: &MomentsApplication,
+    domain: &DomainArtifacts,
+) -> BackgroundServices {
+    let Some(client) = domain.immich_client.clone() else {
+        return BackgroundServices {
+            sync_handle: None,
+            sync_events_rx: None,
+            db: domain.db.clone(),
+        };
+    };
+
+    let sync_interval = app
+        .imp()
+        .settings
+        .get()
+        .expect("settings initialised")
+        .uint("sync-interval-seconds") as u64;
+
+    let (sync_events_tx, sync_events_rx) = tokio::sync::mpsc::unbounded_channel();
+    let handle = SyncHandle::start(
+        client,
+        Arc::clone(domain.ctx.library()),
+        domain.db.clone(),
+        sync_events_tx,
+        domain.thumbnails_dir_for_sync.clone(),
+        sync_interval,
+        domain.ctx.tokio().clone(),
+    );
+
+    BackgroundServices {
+        sync_handle: Some(handle),
+        sync_events_rx: Some(sync_events_rx),
+        db: domain.db.clone(),
+    }
+}
+
+/// Phase 3 — build the UI-facing client GObjects.
+///
+/// Each client is given the exact concrete sub-services it needs —
+/// per [`docs/design-library-context.md`](../../docs/design-library-context.md),
+/// clients do not see the whole [`LibraryContext`]. The `sync_client`
+/// is only built when phase 2 produced a sync handle.
+#[instrument(skip_all)]
+fn phase3_clients(
+    domain: &DomainArtifacts,
+    sync_events_rx: Option<tokio::sync::mpsc::UnboundedReceiver<crate::sync::event::SyncEvent>>,
+    db: Database,
+) -> BuiltClients {
+    let ctx = &domain.ctx;
+
+    let import_client = ImportClient::build(
+        Arc::clone(ctx.library()),
+        domain.paths.originals_dir.clone(),
+        domain.paths.thumbnails_dir.clone(),
+        Arc::clone(ctx.render_pipeline()),
+        domain.paths.storage_mode.clone(),
+        ctx.tokio().clone(),
+    );
+
+    let albums_rx = ctx.library().albums().subscribe();
+    let album_client =
+        AlbumClientV2::build(Arc::clone(ctx.library()), ctx.tokio().clone(), albums_rx);
+
+    let faces_rx = ctx.library().faces().subscribe();
+    let people_client =
+        PeopleClientV2::build(Arc::clone(ctx.library()), ctx.tokio().clone(), faces_rx);
+
+    let media_client = MediaClientV2::build(
+        Arc::clone(ctx.library()),
+        ctx.tokio().clone(),
+        Arc::clone(ctx.render_pipeline()),
+    );
+
+    let sync_client = sync_events_rx.map(|rx| {
+        let client = SyncClient::build(rx, ctx.tokio().clone());
+        client.set_outbox_repository(crate::sync::outbox::OutboxRepository::new(db));
+        client
+    });
+
+    BuiltClients {
+        import_client,
+        album_client,
+        people_client,
+        media_client,
+        sync_client,
+    }
+}
+
+/// Phase 4 — install everything on the application and start the
+/// periodic purge task.
+///
+/// This is the only phase that mutates [`MomentsApplication`] state.
+/// Earlier phases hand back typed values; phase 4 owns the policy of
+/// "when in startup are these visible to widgets". Window setup is
+/// the very last step so widgets only resolve their client
+/// dependencies once every singleton is in place.
+#[instrument(skip_all)]
+fn phase4_install(
+    app: &MomentsApplication,
+    window: &MomentsWindow,
+    domain: DomainArtifacts,
+    sync_handle: Option<SyncHandle>,
+    clients: BuiltClients,
+) {
+    let DomainArtifacts { ctx, .. } = domain;
+
+    if app.imp().library_context.borrow().is_some() {
+        warn!("library_context was already initialised — overwriting");
+    }
+    *app.imp().library_context.borrow_mut() = Some(Arc::clone(&ctx));
+
+    app.set_import_client(clients.import_client);
+    app.imp()
+        .album_client_v2
+        .set(clients.album_client)
+        .expect("album_client_v2 set once per startup");
+    app.imp()
+        .people_client
+        .set(clients.people_client)
+        .expect("people_client set once per startup");
+    app.imp()
+        .media_client_v2
+        .set(clients.media_client)
+        .expect("media_client_v2 set once per startup");
+
+    if let Some(handle) = sync_handle {
+        *app.imp().sync_handle.borrow_mut() = Some(handle);
+    }
+    if let Some(client) = clients.sync_client {
+        app.set_sync_client(client);
+    }
+
+    // Start the periodic trash-purge task. The context is the single
+    // canonical owner of its `JoinHandle` (handles are not `Clone`).
+    let retention_days = app
+        .imp()
+        .settings
+        .get()
+        .expect("settings initialised")
+        .uint("trash-retention-days");
+    let purge_handle = crate::tasks::purge_trash::start(
+        Arc::clone(ctx.library()),
+        retention_days,
+        ctx.tokio().clone(),
+    );
+    if let Err(unused) = ctx.set_purge_handle(purge_handle) {
+        // Defensive: a duplicate populate could only happen if `start`
+        // ran twice on the same Application, which the rest of the
+        // code prevents. Abort the orphan task so it doesn't outlive
+        // its (now-redundant) state.
+        warn!("purge_handle already recorded on LibraryContext — aborting duplicate task");
+        unused.abort();
+    }
+
+    // Wire the shell: builds sidebar, registers views, switches to
+    // the content page. Widgets resolve their client dependencies
+    // through `MomentsApplication::default()` accessors, which are
+    // now all populated.
+    let settings = app
+        .imp()
+        .settings
+        .get()
+        .expect("settings initialised")
+        .clone();
+    window.setup(settings);
+}
+
+/// Present an `AdwAlertDialog` for a phase-1 library open failure and
+/// wire the response actions (return to setup wizard / quit).
+fn present_open_error(app: &MomentsApplication, window: &MomentsWindow, err: LibraryError) {
+    error!("failed to open library: {err}");
+
+    let dialog = adw::AlertDialog::builder()
+        .heading("Could not open library")
+        .body(format!(
+            "An error occurred while opening the library.\n\nDetails: {err}"
+        ))
+        .build();
+    dialog.add_response("setup", "Set Up Library");
+    dialog.add_response("quit", "Quit");
+    dialog.set_response_appearance("quit", adw::ResponseAppearance::Destructive);
+    dialog.set_default_response(Some("setup"));
+    dialog.set_close_response("setup");
+
+    let app_weak = app.downgrade();
+    let win_weak = window.downgrade();
+    dialog.connect_response(None, move |_, response| {
+        if response == "setup" {
+            if let Some(app) = app_weak.upgrade() {
+                if let Some(win) = win_weak.upgrade() {
+                    win.close();
+                }
+                app.show_setup_window();
+            }
+        } else if let Some(app) = app_weak.upgrade() {
+            app.quit();
+        }
+    });
+
+    dialog.present(Some(window));
+}

--- a/src/application/startup.rs
+++ b/src/application/startup.rs
@@ -352,12 +352,15 @@ fn phase3_clients(
     );
 
     let albums_rx = ctx.library().albums().subscribe();
-    let album_client =
-        AlbumClientV2::build(Arc::clone(ctx.library()), ctx.tokio().clone(), albums_rx);
+    let album_client = AlbumClientV2::build(
+        ctx.album_service(),
+        ctx.thumbnail_service(),
+        ctx.tokio().clone(),
+        albums_rx,
+    );
 
     let faces_rx = ctx.library().faces().subscribe();
-    let people_client =
-        PeopleClientV2::build(Arc::clone(ctx.library()), ctx.tokio().clone(), faces_rx);
+    let people_client = PeopleClientV2::build(ctx.faces_service(), ctx.tokio().clone(), faces_rx);
 
     let media_client = MediaClientV2::build(
         Arc::clone(ctx.library()),

--- a/src/application/startup.rs
+++ b/src/application/startup.rs
@@ -20,10 +20,11 @@
 //
 // 1. [`phase1_domain`] — open the `Library`, build the
 //    `RenderPipeline`, wrap them in a [`LibraryContext`].
-// 2. [`phase2_background_services`] — conditionally start the Immich
-//    sync engine. Step 6 will reshape `SyncHandle` into a dedicated
-//    `SyncEngine` top-level service; today the existing `SyncHandle`
-//    shape is preserved unchanged.
+// 2. [`phase2_background_services`] — conditionally build the Immich
+//    [`SyncEngine`] as a dedicated top-level service. The returned
+//    `Arc<SyncEngine>` is shared between phase 4 (installed on the
+//    application) and phase 3 (handed to `SyncClient::build` so the
+//    client can drive engine commands directly).
 // 3. [`phase3_clients`] — build the UI-facing client GObjects with
 //    minimal concrete dependencies from the context.
 // 4. [`phase4_install`] — install the context, sync handle, and
@@ -56,7 +57,7 @@ use crate::library::error::LibraryError;
 use crate::library::Library;
 use crate::renderer::pipeline::RenderPipeline;
 use crate::sync::providers::immich::client::ImmichClient;
-use crate::sync::SyncHandle;
+use crate::sync::SyncEngine;
 use crate::ui::MomentsWindow;
 
 /// Connection details for an Immich backend pulled out of the
@@ -91,10 +92,15 @@ struct DomainArtifacts {
 }
 
 /// Output of [`phase2_background_services`]. When Immich is configured
-/// the sync engine is started and the receiving end of its event
+/// the [`SyncEngine`] is built and the receiving end of its event
 /// channel is handed to phase 3 so [`SyncClient`] can subscribe.
+///
+/// The `Arc<SyncEngine>` is shared between phase 3 (handed to
+/// `SyncClient::build` so the client can drive engine commands) and
+/// phase 4 (installed on `MomentsApplication` as the engine's
+/// canonical owned identity).
 struct BackgroundServices {
-    sync_handle: Option<SyncHandle>,
+    sync_engine: Option<Arc<SyncEngine>>,
     sync_events_rx: Option<tokio::sync::mpsc::UnboundedReceiver<crate::sync::event::SyncEvent>>,
     db: Database,
 }
@@ -183,9 +189,14 @@ pub(in crate::application) fn start(
 
             let background = phase2_background_services(&app, &domain);
 
-            let clients = phase3_clients(&domain, background.sync_events_rx, background.db.clone());
+            let clients = phase3_clients(
+                &domain,
+                background.sync_engine.clone(),
+                background.sync_events_rx,
+                background.db.clone(),
+            );
 
-            phase4_install(&app, &window, domain, background.sync_handle, clients);
+            phase4_install(&app, &window, domain, background.sync_engine, clients);
         }
     ));
 }
@@ -263,11 +274,13 @@ async fn phase1_domain(
 
 /// Phase 2 — start long-running background services.
 ///
-/// Today the only long-running service in scope is the Immich
-/// [`SyncHandle`]. Step 6 of the refactor reshapes this into a
-/// dedicated `SyncEngine` top-level service with a paired
-/// [`SyncClient`]; until then the existing handle structure is kept
-/// unchanged and threaded through to phase 4.
+/// The only long-running service in scope today is the Immich
+/// [`SyncEngine`], built as `Arc<SyncEngine>` so phase 3
+/// ([`SyncClient::build`]) and phase 4 (installed on
+/// `MomentsApplication`) share ownership. The engine spawns its
+/// pull / push managers immediately on the Tokio runtime; the
+/// returned `Arc` is the canonical handle for shutdown and live
+/// interval updates.
 ///
 /// The periodic trash-purge task is *not* started here — it is
 /// recorded on the [`LibraryContext`] itself and started in phase 4
@@ -280,7 +293,7 @@ fn phase2_background_services(
 ) -> BackgroundServices {
     let Some(client) = domain.immich_client.clone() else {
         return BackgroundServices {
-            sync_handle: None,
+            sync_engine: None,
             sync_events_rx: None,
             db: domain.db.clone(),
         };
@@ -294,7 +307,7 @@ fn phase2_background_services(
         .uint("sync-interval-seconds") as u64;
 
     let (sync_events_tx, sync_events_rx) = tokio::sync::mpsc::unbounded_channel();
-    let handle = SyncHandle::start(
+    let engine = SyncEngine::build(
         client,
         Arc::clone(domain.ctx.library()),
         domain.db.clone(),
@@ -305,7 +318,7 @@ fn phase2_background_services(
     );
 
     BackgroundServices {
-        sync_handle: Some(handle),
+        sync_engine: Some(engine),
         sync_events_rx: Some(sync_events_rx),
         db: domain.db.clone(),
     }
@@ -316,10 +329,14 @@ fn phase2_background_services(
 /// Each client is given the exact concrete sub-services it needs —
 /// per [`docs/design-library-context.md`](../../docs/design-library-context.md),
 /// clients do not see the whole [`LibraryContext`]. The `sync_client`
-/// is only built when phase 2 produced a sync handle.
+/// is only built when phase 2 produced a [`SyncEngine`]; it holds an
+/// `Arc<SyncEngine>` clone so the preferences dialog can drive
+/// engine commands through the client surface instead of touching
+/// the engine directly.
 #[instrument(skip_all)]
 fn phase3_clients(
     domain: &DomainArtifacts,
+    sync_engine: Option<Arc<SyncEngine>>,
     sync_events_rx: Option<tokio::sync::mpsc::UnboundedReceiver<crate::sync::event::SyncEvent>>,
     db: Database,
 ) -> BuiltClients {
@@ -348,8 +365,13 @@ fn phase3_clients(
         Arc::clone(ctx.render_pipeline()),
     );
 
-    let sync_client = sync_events_rx.map(|rx| {
-        let client = SyncClient::build(rx, ctx.tokio().clone());
+    // Build `SyncClient` only when phase 2 produced both an engine
+    // and the receiver end of the event channel — the two are
+    // populated together so a mismatch can only come from a future
+    // refactor bug. `expect` documents the invariant.
+    let sync_client = sync_engine.map(|engine| {
+        let rx = sync_events_rx.expect("sync_engine implies sync_events_rx");
+        let client = SyncClient::build(engine, rx, ctx.tokio().clone());
         client.set_outbox_repository(crate::sync::outbox::OutboxRepository::new(db));
         client
     });
@@ -376,7 +398,7 @@ fn phase4_install(
     app: &MomentsApplication,
     window: &MomentsWindow,
     domain: DomainArtifacts,
-    sync_handle: Option<SyncHandle>,
+    sync_engine: Option<Arc<SyncEngine>>,
     clients: BuiltClients,
 ) {
     let DomainArtifacts { ctx, .. } = domain;
@@ -400,8 +422,11 @@ fn phase4_install(
         .set(clients.media_client)
         .expect("media_client_v2 set once per startup");
 
-    if let Some(handle) = sync_handle {
-        *app.imp().sync_handle.borrow_mut() = Some(handle);
+    if let Some(engine) = sync_engine {
+        app.imp()
+            .sync_engine
+            .set(engine)
+            .expect("sync_engine set once per application lifetime");
     }
     if let Some(client) = clients.sync_client {
         app.set_sync_client(client);

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -83,41 +83,42 @@ glib::wrapper! {
     pub struct AlbumClientV2(ObjectSubclass<imp::AlbumClientV2>);
 }
 
-impl Default for AlbumClientV2 {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl AlbumClientV2 {
+    /// Construct an unconfigured client.
+    ///
+    /// Intended only for unit tests that exercise pure model-patching
+    /// helpers without needing a real `Library`. Production code calls
+    /// [`AlbumClientV2::build`].
+    #[cfg(test)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
 
-    /// Set the dependencies required for album operations and start
-    /// listening for service events.
+    /// Construct a fully-wired album client.
     ///
-    /// Must be called once after construction, before any other method.
-    pub fn configure(
-        &self,
+    /// Stores dependencies and spawns the `AlbumEvent` listener on the
+    /// supplied Tokio runtime so model reconciliation begins
+    /// immediately.
+    pub fn build(
         library: Arc<Library>,
         tokio: tokio::runtime::Handle,
         events_rx: mpsc::UnboundedReceiver<AlbumEvent>,
-    ) {
-        *self.imp().deps.borrow_mut() = Some(AlbumDeps {
+    ) -> Self {
+        let client: Self = glib::Object::builder().build();
+        *client.imp().deps.borrow_mut() = Some(AlbumDeps {
             library: Arc::clone(&library),
             tokio: tokio.clone(),
         });
 
-        let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
+        let client_weak: glib::SendWeakRef<AlbumClientV2> = client.downgrade().into();
         tokio.spawn(Self::listen(events_rx, library, client_weak));
+        client
     }
 
     fn deps(&self) -> (Arc<Library>, tokio::runtime::Handle) {
         let deps = self.imp().deps.borrow();
-        let deps = deps
-            .as_ref()
-            .expect("AlbumClientV2::configure() not called");
+        let deps = deps.as_ref().expect("AlbumClientV2::build() not called");
         (deps.library.clone(), deps.tokio.clone())
     }
 

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -1,6 +1,5 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use gtk::gio;
 use gtk::glib;
@@ -10,14 +9,19 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, instrument, warn};
 
 use super::model::AlbumItemObject;
-use crate::library::album::{Album, AlbumEvent, AlbumId};
+use crate::library::album::{Album, AlbumEvent, AlbumId, AlbumService};
 use crate::library::error::LibraryError;
 use crate::library::media::MediaId;
-use crate::library::Library;
+use crate::library::thumbnail::ThumbnailService;
 
 /// Non-GObject dependencies for album operations.
+///
+/// Holds only the concrete sub-services this client uses, not the whole
+/// `Library` — the dependency surface is the constructor contract (see
+/// `docs/design-library-context.md`).
 struct AlbumDeps {
-    library: Arc<Library>,
+    albums: AlbumService,
+    thumbnails: ThumbnailService,
     tokio: tokio::runtime::Handle,
 }
 
@@ -101,25 +105,34 @@ impl AlbumClientV2 {
     /// supplied Tokio runtime so model reconciliation begins
     /// immediately.
     pub fn build(
-        library: Arc<Library>,
+        albums: AlbumService,
+        thumbnails: ThumbnailService,
         tokio: tokio::runtime::Handle,
         events_rx: mpsc::UnboundedReceiver<AlbumEvent>,
     ) -> Self {
         let client: Self = glib::Object::builder().build();
         *client.imp().deps.borrow_mut() = Some(AlbumDeps {
-            library: Arc::clone(&library),
+            albums: albums.clone(),
+            thumbnails,
             tokio: tokio.clone(),
         });
 
         let client_weak: glib::SendWeakRef<AlbumClientV2> = client.downgrade().into();
-        tokio.spawn(Self::listen(events_rx, library, client_weak));
+        tokio.spawn(Self::listen(events_rx, albums, client_weak));
         client
     }
 
-    fn deps(&self) -> (Arc<Library>, tokio::runtime::Handle) {
+    /// Snapshot the stored dependencies. The album and thumbnail
+    /// services are cheap `Clone` handles, so each command/query clones
+    /// the pair it needs and moves them into its async block.
+    fn deps(&self) -> (AlbumService, ThumbnailService, tokio::runtime::Handle) {
         let deps = self.imp().deps.borrow();
         let deps = deps.as_ref().expect("AlbumClientV2::build() not called");
-        (deps.library.clone(), deps.tokio.clone())
+        (
+            deps.albums.clone(),
+            deps.thumbnails.clone(),
+            deps.tokio.clone(),
+        )
     }
 
     // ── Event listener ─────────────────────────────────────────────────
@@ -128,13 +141,13 @@ impl AlbumClientV2 {
     /// dispatches model patches on the GTK thread.
     async fn listen(
         mut rx: mpsc::UnboundedReceiver<AlbumEvent>,
-        library: Arc<Library>,
+        albums: AlbumService,
         client_weak: glib::SendWeakRef<AlbumClientV2>,
     ) {
         while let Some(event) = rx.recv().await {
             match event {
                 AlbumEvent::AlbumAdded(id) => {
-                    let album = library.albums().get_album(&id).await;
+                    let album = albums.get_album(&id).await;
                     let weak = client_weak.clone();
                     glib::idle_add_once(move || {
                         if let Some(client) = weak.upgrade() {
@@ -156,7 +169,7 @@ impl AlbumClientV2 {
                     });
                 }
                 AlbumEvent::AlbumUpdated(id) => {
-                    let album = library.albums().get_album(&id).await;
+                    let album = albums.get_album(&id).await;
                     let weak = client_weak.clone();
                     glib::idle_add_once(move || {
                         if let Some(client) = weak.upgrade() {
@@ -200,16 +213,16 @@ impl AlbumClientV2 {
     /// cover thumbnails.
     #[instrument(skip(self, media_ids))]
     pub fn create_album(&self, name: String, media_ids: Vec<MediaId>) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let result = crate::client::spawn_on(&tokio, async move {
-                let id = library.albums().create_album(&name).await?;
+                let id = albums.create_album(&name).await?;
                 if !media_ids.is_empty() {
-                    library.albums().add_to_album(&id, &media_ids).await?;
+                    albums.add_to_album(&id, &media_ids).await?;
                 }
-                library.albums().get_album(&id).await?.ok_or_else(|| {
+                albums.get_album(&id).await?.ok_or_else(|| {
                     LibraryError::Runtime(format!("album {id} not found after create"))
                 })
             })
@@ -245,17 +258,16 @@ impl AlbumClientV2 {
     /// `album-deleted` for each ID.
     #[instrument(skip(self, ids))]
     pub fn delete_album(&self, ids: Vec<AlbumId>) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             for id in ids {
-                let lib = Arc::clone(&library);
+                let svc = albums.clone();
                 let aid = id.clone();
-                let result = crate::client::spawn_on(&tokio, async move {
-                    lib.albums().delete_album(&aid).await
-                })
-                .await;
+                let result =
+                    crate::client::spawn_on(&tokio, async move { svc.delete_album(&aid).await })
+                        .await;
 
                 match result {
                     Ok(()) => {
@@ -279,15 +291,14 @@ impl AlbumClientV2 {
     /// On success, refreshes the album metadata in all tracked models.
     #[instrument(skip(self, media_ids), fields(album_id = %album_id))]
     pub fn add_to_album(&self, album_id: AlbumId, media_ids: Vec<MediaId>) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let aid = album_id.clone();
             let result = crate::client::spawn_on(&tokio, async move {
-                library.albums().add_to_album(&aid, &media_ids).await?;
-                library
-                    .albums()
+                albums.add_to_album(&aid, &media_ids).await?;
+                albums
                     .get_album(&aid)
                     .await?
                     .ok_or_else(|| LibraryError::Runtime(format!("album {aid} not found")))
@@ -318,15 +329,14 @@ impl AlbumClientV2 {
     /// On success, refreshes the album metadata in all tracked models.
     #[instrument(skip(self, media_ids), fields(album_id = %album_id))]
     pub fn remove_from_album(&self, album_id: AlbumId, media_ids: Vec<MediaId>) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let aid = album_id.clone();
             let result = crate::client::spawn_on(&tokio, async move {
-                library.albums().remove_from_album(&aid, &media_ids).await?;
-                library
-                    .albums()
+                albums.remove_from_album(&aid, &media_ids).await?;
+                albums
                     .get_album(&aid)
                     .await?
                     .ok_or_else(|| LibraryError::Runtime(format!("album {aid} not found")))
@@ -357,14 +367,14 @@ impl AlbumClientV2 {
     /// On success, patches the name in all tracked models.
     #[instrument(skip(self), fields(album_id = %id))]
     pub fn rename_album(&self, id: AlbumId, name: String) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let rename_id = id.clone();
             let n = name.clone();
             let result = crate::client::spawn_on(&tokio, async move {
-                library.albums().rename_album(&rename_id, &n).await
+                albums.rename_album(&rename_id, &n).await
             })
             .await;
 
@@ -399,15 +409,17 @@ impl AlbumClientV2 {
 
     #[instrument(skip(self), fields(album_id = %id))]
     fn set_pinned(&self, id: AlbumId, pinned: bool) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let pin_id = id.clone();
-            let result = crate::client::spawn_on(&tokio, async move {
-                library.albums().set_pinned(&pin_id, pinned).await
-            })
-            .await;
+            let result =
+                crate::client::spawn_on(
+                    &tokio,
+                    async move { albums.set_pinned(&pin_id, pinned).await },
+                )
+                .await;
 
             match result {
                 Ok(()) => {
@@ -442,17 +454,13 @@ impl AlbumClientV2 {
     /// the GTK thread. Views should call this on realize.
     #[instrument(skip(self, model))]
     pub fn list_albums(&self, model: &gio::ListStore) {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         let store = model.clone();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let result =
-                crate::client::spawn_on(
-                    &tokio,
-                    async move { library.albums().list_albums().await },
-                )
-                .await;
+                crate::client::spawn_on(&tokio, async move { albums.list_albums().await }).await;
 
             match result {
                 Ok(albums) => {
@@ -515,9 +523,9 @@ impl AlbumClientV2 {
         &self,
         media_ids: Vec<MediaId>,
     ) -> Result<HashMap<AlbumId, usize>, LibraryError> {
-        let (library, tokio) = self.deps();
+        let (albums, _thumbnails, tokio) = self.deps();
         crate::client::spawn_on(&tokio, async move {
-            library.albums().albums_containing_media(&media_ids).await
+            albums.albums_containing_media(&media_ids).await
         })
         .await
     }
@@ -547,7 +555,7 @@ impl AlbumClientV2 {
     /// Load cover thumbnails for an album and apply to the item in all models.
     #[instrument(skip(self), fields(album_id = %album_id))]
     fn load_cover_thumbnails(&self, album_id: &AlbumId) {
-        let (library, tokio) = self.deps();
+        let (albums, thumbnails, tokio) = self.deps();
         let aid = album_id.clone();
         let client_weak: glib::SendWeakRef<AlbumClientV2> = self.downgrade().into();
 
@@ -555,17 +563,14 @@ impl AlbumClientV2 {
             // Single spawn: fetch cover IDs + decode thumbnails.
             let aid_query = aid.clone();
             let decoded = crate::client::spawn_on(&tokio, async move {
-                let cover_ids = library
-                    .albums()
-                    .album_cover_media_ids(&aid_query, 4)
-                    .await?;
+                let cover_ids = albums.album_cover_media_ids(&aid_query, 4).await?;
                 if cover_ids.is_empty() {
                     return Ok(Vec::new());
                 }
 
                 let paths: Vec<_> = cover_ids
                     .iter()
-                    .map(|mid| library.thumbnails().thumbnail_path(mid))
+                    .map(|mid| thumbnails.thumbnail_path(mid))
                     .collect();
 
                 // File I/O + image decode are blocking — run on the

--- a/src/client/import/client.rs
+++ b/src/client/import/client.rs
@@ -122,33 +122,35 @@ glib::wrapper! {
     pub struct ImportClient(ObjectSubclass<imp::ImportClient>);
 }
 
-impl Default for ImportClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ImportClient {
+    /// Construct an unconfigured client.
+    ///
+    /// Intended only for unit tests that exercise pure property
+    /// setters without needing a real `Library`. Production code calls
+    /// [`ImportClient::build`].
+    #[cfg(test)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
 
-    /// Set the dependencies required for building import pipelines
-    /// and start the event listener.
+    /// Construct a fully-wired import client.
     ///
-    /// Must be called once after construction, before the first `import()` call.
-    pub fn configure(
-        &self,
+    /// Stores dependencies and spawns the import-event listener on the
+    /// supplied Tokio runtime so progress updates are marshalled to the
+    /// GTK main thread for property updates.
+    pub fn build(
         library: Arc<Library>,
         originals_dir: PathBuf,
         thumbnails_dir: PathBuf,
         render_pipeline: Arc<RenderPipeline>,
         mode: LocalStorageMode,
         tokio: tokio::runtime::Handle,
-    ) {
+    ) -> Self {
+        let client: Self = glib::Object::builder().build();
         let (events_tx, events_rx) = mpsc::unbounded_channel();
 
-        *self.imp().deps.borrow_mut() = Some(ImportDeps {
+        *client.imp().deps.borrow_mut() = Some(ImportDeps {
             library,
             originals_dir,
             thumbnails_dir,
@@ -158,8 +160,9 @@ impl ImportClient {
             events_tx,
         });
 
-        let client_weak: glib::SendWeakRef<ImportClient> = self.downgrade().into();
+        let client_weak: glib::SendWeakRef<ImportClient> = client.downgrade().into();
         tokio.spawn(Self::listen(events_rx, client_weak));
+        client
     }
 
     // ── Property accessors ───────────────────────────────────────────
@@ -284,7 +287,7 @@ impl ImportClient {
             let deps = match deps.as_ref() {
                 Some(d) => d,
                 None => {
-                    error!("import called before configure()");
+                    error!("import called before build()");
                     return;
                 }
             };

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -38,10 +38,11 @@ struct TrackedMediaModel {
     id_index: RefCell<HashMap<MediaId, glib::WeakRef<MediaItemObject>>>,
 }
 
-/// Non-GObject dependencies set once by [`MediaClientV2::configure`].
+/// Non-GObject dependencies set once by [`MediaClientV2::build`].
 struct MediaDeps {
     library: Arc<Library>,
     tokio: tokio::runtime::Handle,
+    render_pipeline: Arc<crate::renderer::pipeline::RenderPipeline>,
 }
 
 mod imp {
@@ -106,37 +107,45 @@ glib::wrapper! {
     pub struct MediaClientV2(ObjectSubclass<imp::MediaClientV2>);
 }
 
-impl Default for MediaClientV2 {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl MediaClientV2 {
+    /// Construct an unconfigured client.
+    ///
+    /// Intended only for unit tests that exercise pure model-patching
+    /// helpers without needing a real `Library`. Production code calls
+    /// [`MediaClientV2::build`].
+    #[cfg(test)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
 
-    /// Store dependencies and start listening for service events. Must be
-    /// called once after construction, before any other method.
+    /// Construct a fully-wired media client.
     ///
-    /// Subscribes to four service channels:
+    /// Stores dependencies and spawns the four service-event listeners
+    /// on the supplied Tokio runtime:
+    ///
     /// - `MediaEvent` — media-row changes (Added/Updated/Removed).
     /// - `ThumbnailEvent` — thumbnails ready on disk.
     /// - `AlbumEvent` — filtered down to `AlbumMediaChanged` for
     ///   album-filtered model refresh.
     /// - `FacesEvent` — filtered down to `PersonMediaChanged` for
     ///   person-filtered model refresh (never fires on local backends).
-    pub fn configure(&self, library: Arc<Library>, tokio: tokio::runtime::Handle) {
+    pub fn build(
+        library: Arc<Library>,
+        tokio: tokio::runtime::Handle,
+        render_pipeline: Arc<crate::renderer::pipeline::RenderPipeline>,
+    ) -> Self {
+        let client: Self = glib::Object::builder().build();
         let media_rx = library.media().subscribe();
         let thumb_rx = library.thumbnails().subscribe();
         let album_rx = library.albums().subscribe();
         let faces_rx = library.faces().subscribe();
-        *self.imp().deps.borrow_mut() = Some(MediaDeps {
+        *client.imp().deps.borrow_mut() = Some(MediaDeps {
             library: Arc::clone(&library),
             tokio: tokio.clone(),
+            render_pipeline,
         });
-        let client_weak: glib::SendWeakRef<MediaClientV2> = self.downgrade().into();
+        let client_weak: glib::SendWeakRef<MediaClientV2> = client.downgrade().into();
         tokio.spawn(Self::listen_media(
             media_rx,
             Arc::clone(&library),
@@ -145,14 +154,19 @@ impl MediaClientV2 {
         tokio.spawn(Self::listen_thumbnail(thumb_rx, client_weak.clone()));
         tokio.spawn(Self::listen_album(album_rx, client_weak.clone()));
         tokio.spawn(Self::listen_faces(faces_rx, client_weak));
+        client
     }
 
     fn deps(&self) -> (Arc<Library>, tokio::runtime::Handle) {
         let deps = self.imp().deps.borrow();
-        let deps = deps
-            .as_ref()
-            .expect("MediaClientV2::configure() not called");
+        let deps = deps.as_ref().expect("MediaClientV2::build() not called");
         (Arc::clone(&deps.library), deps.tokio.clone())
+    }
+
+    fn render_pipeline(&self) -> Arc<crate::renderer::pipeline::RenderPipeline> {
+        let deps = self.imp().deps.borrow();
+        let deps = deps.as_ref().expect("MediaClientV2::build() not called");
+        Arc::clone(&deps.render_pipeline)
     }
 
     // ── Factory ────────────────────────────────────────────────────────
@@ -337,13 +351,14 @@ impl MediaClientV2 {
         cb: impl FnOnce(Result<(), LibraryError>) + 'static,
     ) {
         let (library, tokio) = self.deps();
+        let pipeline = self.render_pipeline();
         let id = id.clone();
         let state = state.clone();
 
         glib::MainContext::default().spawn_local(async move {
             let result = crate::client::spawn_on(&tokio, async move {
                 if state.has_pixel_adjustments() {
-                    render_and_save_pixel_edit(&library, &id, &state).await
+                    render_and_save_pixel_edit(&library, &pipeline, &id, &state).await
                 } else {
                     library.editing().save_edit_state(&id, &state).await
                 }
@@ -1058,6 +1073,7 @@ fn remove_item_from_tracked(tracked: &TrackedMediaModel, store: &gio::ListStore,
 /// Runs the decode + edit pipeline on a Tokio blocking thread.
 async fn render_and_save_pixel_edit(
     library: &std::sync::Arc<crate::library::Library>,
+    pipeline: &std::sync::Arc<crate::renderer::pipeline::RenderPipeline>,
     id: &MediaId,
     state: &EditState,
 ) -> Result<(), LibraryError> {
@@ -1067,14 +1083,7 @@ async fn render_and_save_pixel_edit(
         .await?
         .ok_or_else(|| LibraryError::Runtime(format!("original file for {id} not found")))?;
 
-    // TODO(library-context refactor, Step 2): take the render pipeline
-    // as a constructor argument on the owning Client instead of
-    // reaching into the global Application singleton.
-    #[allow(deprecated)]
-    let pipeline = crate::application::MomentsApplication::default()
-        .render_pipeline()
-        .ok_or_else(|| LibraryError::Runtime("render pipeline not initialised".into()))?;
-
+    let pipeline = std::sync::Arc::clone(pipeline);
     let state_for_render = state.clone();
     let jpeg = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, LibraryError> {
         let options = crate::renderer::pipeline::RenderOptions {

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -163,7 +163,13 @@ impl MediaClientV2 {
         (Arc::clone(&deps.library), deps.tokio.clone())
     }
 
-    fn render_pipeline(&self) -> Arc<crate::renderer::pipeline::RenderPipeline> {
+    /// Borrow the shared render pipeline.
+    ///
+    /// Exposed so widgets that already use this client (the viewer's
+    /// full-res loader, the editing entry point) can decode through the
+    /// same pipeline instance the client uses internally, without
+    /// reaching for a global accessor on `MomentsApplication`.
+    pub fn render_pipeline(&self) -> Arc<crate::renderer::pipeline::RenderPipeline> {
         let deps = self.imp().deps.borrow();
         let deps = deps.as_ref().expect("MediaClientV2::build() not called");
         Arc::clone(&deps.render_pipeline)

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -1067,6 +1067,10 @@ async fn render_and_save_pixel_edit(
         .await?
         .ok_or_else(|| LibraryError::Runtime(format!("original file for {id} not found")))?;
 
+    // TODO(library-context refactor, Step 2): take the render pipeline
+    // as a constructor argument on the owning Client instead of
+    // reaching into the global Application singleton.
+    #[allow(deprecated)]
     let pipeline = crate::application::MomentsApplication::default()
         .render_pipeline()
         .ok_or_else(|| LibraryError::Runtime("render pipeline not initialised".into()))?;

--- a/src/client/people/client_v2.rs
+++ b/src/client/people/client_v2.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::sync::Arc;
 
 use gtk::gio;
 use gtk::glib;
@@ -9,12 +8,15 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, instrument, warn};
 
 use super::model::PersonItemObject;
-use crate::library::faces::{FacesEvent, Person, PersonId};
-use crate::library::Library;
+use crate::library::faces::{FacesEvent, FacesService, Person, PersonId};
 
 /// Non-GObject dependencies for people operations.
+///
+/// Holds only the concrete faces sub-service this client uses, not the
+/// whole `Library` — the dependency surface is the constructor contract
+/// (see `docs/design-library-context.md`).
 struct PeopleDeps {
-    library: Arc<Library>,
+    faces: FacesService,
     tokio: tokio::runtime::Handle,
 }
 
@@ -77,25 +79,28 @@ impl PeopleClientV2 {
     /// supplied Tokio runtime so model reconciliation begins
     /// immediately.
     pub fn build(
-        library: Arc<Library>,
+        faces: FacesService,
         tokio: tokio::runtime::Handle,
         events_rx: mpsc::UnboundedReceiver<FacesEvent>,
     ) -> Self {
         let client: Self = glib::Object::builder().build();
         *client.imp().deps.borrow_mut() = Some(PeopleDeps {
-            library: Arc::clone(&library),
+            faces: faces.clone(),
             tokio: tokio.clone(),
         });
 
         let client_weak: glib::SendWeakRef<PeopleClientV2> = client.downgrade().into();
-        tokio.spawn(Self::listen(events_rx, library, client_weak));
+        tokio.spawn(Self::listen(events_rx, faces, client_weak));
         client
     }
 
-    fn deps(&self) -> (Arc<Library>, tokio::runtime::Handle) {
+    /// Snapshot the stored dependencies. `FacesService` is a cheap
+    /// `Clone` handle, so each command/query clones it and moves the
+    /// clone into its async block.
+    fn deps(&self) -> (FacesService, tokio::runtime::Handle) {
         let deps = self.imp().deps.borrow();
         let deps = deps.as_ref().expect("PeopleClientV2::build() not called");
-        (deps.library.clone(), deps.tokio.clone())
+        (deps.faces.clone(), deps.tokio.clone())
     }
 
     // ── Event listener ─────────────────────────────────────────────────
@@ -104,14 +109,14 @@ impl PeopleClientV2 {
     /// dispatches model patches on the GTK thread.
     async fn listen(
         mut rx: mpsc::UnboundedReceiver<FacesEvent>,
-        library: Arc<Library>,
+        faces: FacesService,
         client_weak: glib::SendWeakRef<PeopleClientV2>,
     ) {
         while let Some(event) = rx.recv().await {
             match event {
                 FacesEvent::PersonAdded(id) => {
-                    let person = library.faces().get_person(&id).await;
-                    let thumb = library.faces().person_thumbnail_path(&id);
+                    let person = faces.get_person(&id).await;
+                    let thumb = faces.person_thumbnail_path(&id);
                     let weak = client_weak.clone();
                     glib::idle_add_once(move || {
                         if let Some(client) = weak.upgrade() {
@@ -129,7 +134,7 @@ impl PeopleClientV2 {
                     });
                 }
                 FacesEvent::PersonUpdated(id) => {
-                    let person = library.faces().get_person(&id).await;
+                    let person = faces.get_person(&id).await;
                     let weak = client_weak.clone();
                     glib::idle_add_once(move || {
                         if let Some(client) = weak.upgrade() {
@@ -190,21 +195,20 @@ impl PeopleClientV2 {
     /// contents. Views apply their own filtering via `FilterListModel`.
     #[instrument(skip(self, model))]
     pub fn list_people(&self, model: &gio::ListStore) {
-        let (library, tokio) = self.deps();
+        let (faces, tokio) = self.deps();
         let store = model.clone();
 
         glib::MainContext::default().spawn_local(async move {
-            let lib = library.clone();
+            let svc = faces.clone();
             let result =
-                crate::client::spawn_on(&tokio, async move { lib.faces().list_people().await })
-                    .await;
+                crate::client::spawn_on(&tokio, async move { svc.list_people().await }).await;
 
             match result {
                 Ok(people) => {
                     let objects: Vec<glib::Object> = people
                         .iter()
                         .map(|person| {
-                            let thumb = library.faces().person_thumbnail_path(&person.id);
+                            let thumb = faces.person_thumbnail_path(&person.id);
                             PersonItemObject::new(person, thumb).upcast()
                         })
                         .collect();
@@ -224,14 +228,14 @@ impl PeopleClientV2 {
     /// Rename a person. On success, patches the name in all tracked models.
     #[instrument(skip(self))]
     pub fn rename_person(&self, id: PersonId, name: String) {
-        let (library, tokio) = self.deps();
+        let (faces, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<PeopleClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let rename_id = id.clone();
             let n = name.clone();
             let result = crate::client::spawn_on(&tokio, async move {
-                library.faces().rename_person(&rename_id, &n).await
+                faces.rename_person(&rename_id, &n).await
             })
             .await;
 
@@ -257,13 +261,13 @@ impl PeopleClientV2 {
     /// visibility automatically.
     #[instrument(skip(self))]
     pub fn set_person_hidden(&self, id: PersonId, hidden: bool) {
-        let (library, tokio) = self.deps();
+        let (faces, tokio) = self.deps();
         let client_weak: glib::SendWeakRef<PeopleClientV2> = self.downgrade().into();
 
         glib::MainContext::default().spawn_local(async move {
             let hide_id = id.clone();
             let result = crate::client::spawn_on(&tokio, async move {
-                library.faces().set_person_hidden(&hide_id, hidden).await
+                faces.set_person_hidden(&hide_id, hidden).await
             })
             .await;
 

--- a/src/client/people/client_v2.rs
+++ b/src/client/people/client_v2.rs
@@ -295,8 +295,16 @@ impl PeopleClientV2 {
     fn insert_into_models(&self, person: &Person, thumb: Option<std::path::PathBuf>) {
         let mut models = self.imp().models.borrow_mut();
         let obj = PersonItemObject::new(person, thumb);
+        let id_str = person.id.as_str();
         models.retain(|weak| {
             if let Some(store) = weak.upgrade() {
+                // Idempotent: skip if an item with this ID is already in
+                // the store. Both the command path and the FacesEvent
+                // listener insert on person creation; without this guard
+                // they race to produce duplicate rows.
+                if find_by_id(&store, id_str).is_some() {
+                    return true;
+                }
                 store.append(&obj);
                 true
             } else {
@@ -449,6 +457,21 @@ mod tests {
 
         client.insert_into_models(&test_person("p1", "Alice"), None);
         assert_eq!(live.n_items(), 1);
+    }
+
+    #[test]
+    fn insert_into_models_is_idempotent() {
+        let client = PeopleClientV2::new();
+        let store = client.create_model();
+
+        client.insert_into_models(&test_person("p1", "Alice"), None);
+        client.insert_into_models(&test_person("p1", "Alice"), None);
+
+        assert_eq!(
+            store.n_items(),
+            1,
+            "second insert of same ID should be a no-op"
+        );
     }
 
     // ── update_in_models ──────────────────────────────────────────────

--- a/src/client/people/client_v2.rs
+++ b/src/client/people/client_v2.rs
@@ -59,41 +59,42 @@ glib::wrapper! {
     pub struct PeopleClientV2(ObjectSubclass<imp::PeopleClientV2>);
 }
 
-impl Default for PeopleClientV2 {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl PeopleClientV2 {
+    /// Construct an unconfigured client.
+    ///
+    /// Intended only for unit tests that exercise pure model-patching
+    /// helpers without needing a real `Library`. Production code calls
+    /// [`PeopleClientV2::build`].
+    #[cfg(test)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
 
-    /// Set the dependencies required for people operations and start
-    /// listening for service events.
+    /// Construct a fully-wired people client.
     ///
-    /// Must be called once after construction, before any other method.
-    pub fn configure(
-        &self,
+    /// Stores dependencies and spawns the `FacesEvent` listener on the
+    /// supplied Tokio runtime so model reconciliation begins
+    /// immediately.
+    pub fn build(
         library: Arc<Library>,
         tokio: tokio::runtime::Handle,
         events_rx: mpsc::UnboundedReceiver<FacesEvent>,
-    ) {
-        *self.imp().deps.borrow_mut() = Some(PeopleDeps {
+    ) -> Self {
+        let client: Self = glib::Object::builder().build();
+        *client.imp().deps.borrow_mut() = Some(PeopleDeps {
             library: Arc::clone(&library),
             tokio: tokio.clone(),
         });
 
-        let client_weak: glib::SendWeakRef<PeopleClientV2> = self.downgrade().into();
+        let client_weak: glib::SendWeakRef<PeopleClientV2> = client.downgrade().into();
         tokio.spawn(Self::listen(events_rx, library, client_weak));
+        client
     }
 
     fn deps(&self) -> (Arc<Library>, tokio::runtime::Handle) {
         let deps = self.imp().deps.borrow();
-        let deps = deps
-            .as_ref()
-            .expect("PeopleClientV2::configure() not called");
+        let deps = deps.as_ref().expect("PeopleClientV2::build() not called");
         (deps.library.clone(), deps.tokio.clone())
     }
 

--- a/src/client/sync/client.rs
+++ b/src/client/sync/client.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::sync::Arc;
 
 use gtk::glib;
 use gtk::prelude::*;
@@ -9,6 +10,7 @@ use tracing::debug;
 use crate::library::error::LibraryError;
 use crate::sync::event::SyncEvent;
 use crate::sync::outbox::{OutboxCounts, OutboxRepository};
+use crate::sync::SyncEngine;
 
 /// Sync lifecycle state exposed as a GObject property.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, glib::Enum)]
@@ -37,6 +39,12 @@ mod imp {
         // Set by Application during Immich bootstrap; absent for the
         // local backend.
         pub(super) outbox_repo: RefCell<Option<OutboxRepository>>,
+        // ── Sync engine reference ───────────────────────────────────
+        // `Arc<SyncEngine>` lets the client drive engine commands
+        // (interval changes, future "Sync Now" actions) without
+        // routing through the Application singleton. Set once in
+        // `build`; the test-only `new()` constructor leaves it absent.
+        pub(super) engine: RefCell<Option<Arc<SyncEngine>>>,
     }
 
     impl Default for SyncClient {
@@ -48,6 +56,7 @@ mod imp {
                 last_synced_at: Cell::new(0),
                 error_message: RefCell::new(String::new()),
                 outbox_repo: RefCell::new(None),
+                engine: RefCell::new(None),
             }
         }
     }
@@ -119,17 +128,31 @@ impl SyncClient {
 
     /// Construct a fully-wired sync client.
     ///
-    /// Spawns a background task on the Tokio runtime that receives
+    /// Holds an `Arc<SyncEngine>` reference for UI-driven control
+    /// (interval changes, future "Sync Now" actions) and spawns a
+    /// background task on the Tokio runtime that receives
     /// `SyncEvent`s and updates GObject properties on the GTK main
     /// thread.
     pub fn build(
+        engine: Arc<SyncEngine>,
         events_rx: mpsc::UnboundedReceiver<SyncEvent>,
         tokio: tokio::runtime::Handle,
     ) -> Self {
         let client: Self = glib::Object::builder().build();
+        *client.imp().engine.borrow_mut() = Some(engine);
         let client_weak: glib::SendWeakRef<SyncClient> = client.downgrade().into();
         tokio.spawn(Self::listen(events_rx, client_weak));
         client
+    }
+
+    /// Forward a new polling interval (seconds) to the running engine.
+    ///
+    /// No-op when the client was constructed via the test-only
+    /// `new()` helper without an engine.
+    pub fn set_interval(&self, secs: u64) {
+        if let Some(engine) = self.imp().engine.borrow().as_ref() {
+            engine.set_interval(secs);
+        }
     }
 
     // ── Property accessors ───────────────────────────────────────────

--- a/src/client/sync/client.rs
+++ b/src/client/sync/client.rs
@@ -105,29 +105,31 @@ glib::wrapper! {
     pub struct SyncClient(ObjectSubclass<imp::SyncClient>);
 }
 
-impl Default for SyncClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl SyncClient {
+    /// Construct an unconfigured client.
+    ///
+    /// Intended only for unit tests that exercise pure property
+    /// setters without needing a sync event channel. Production code
+    /// calls [`SyncClient::build`].
+    #[cfg(test)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
 
-    /// Start listening for sync events.
+    /// Construct a fully-wired sync client.
     ///
-    /// Must be called once after construction. Spawns a background task
-    /// on the Tokio runtime that receives `SyncEvent`s and updates
-    /// GObject properties on the GTK main thread.
-    pub fn configure(
-        &self,
+    /// Spawns a background task on the Tokio runtime that receives
+    /// `SyncEvent`s and updates GObject properties on the GTK main
+    /// thread.
+    pub fn build(
         events_rx: mpsc::UnboundedReceiver<SyncEvent>,
         tokio: tokio::runtime::Handle,
-    ) {
-        let client_weak: glib::SendWeakRef<SyncClient> = self.downgrade().into();
+    ) -> Self {
+        let client: Self = glib::Object::builder().build();
+        let client_weak: glib::SendWeakRef<SyncClient> = client.downgrade().into();
         tokio.spawn(Self::listen(events_rx, client_weak));
+        client
     }
 
     // ── Property accessors ───────────────────────────────────────────

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,16 +1,17 @@
 //! Bidirectional sync engine.
 //!
-//! Backend-agnostic orchestration lives here (`SyncHandle`, `outbox/`).
+//! Backend-agnostic orchestration lives here (`SyncEngine`, `outbox/`).
 //! Provider-specific protocol code lives under `providers/`.
 //!
-//! Start with [`SyncHandle::start`], which spawns three background tasks:
-//! pull manager, push manager, and thumbnail downloader.
+//! Start with [`SyncEngine::build`], which spawns two background tasks:
+//! pull manager and push manager. Thumbnails are downloaded inline by
+//! the pull manager.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, watch};
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 
 use crate::library::db::Database;
 use crate::library::Library;
@@ -20,26 +21,44 @@ pub mod outbox;
 pub mod providers;
 pub mod state;
 
-/// Handle to the running sync engine.
+/// Long-running Immich sync service.
 ///
-/// Provides shutdown and live interval update. Drop to abandon tasks
-/// (use [`shutdown`](Self::shutdown) for graceful stop).
-pub struct SyncHandle {
+/// Owns the pull / push background tasks and the channels used to
+/// signal shutdown and live interval changes. Constructed via
+/// [`SyncEngine::build`] and held as `Arc<SyncEngine>` on
+/// `MomentsApplication`; [`crate::client::SyncClient`] also holds an
+/// `Arc<SyncEngine>` reference for UI-driven control (interval
+/// changes, future "Sync Now" actions, …).
+///
+/// Lifecycle:
+/// - `build` spawns the pull and push managers and returns the
+///   `Arc<SyncEngine>` immediately. Tasks run until `shutdown` is
+///   called or the shutdown watch channel is dropped.
+/// - [`SyncEngine::shutdown`] signals graceful stop by flipping the
+///   shutdown watch channel. Idempotent — safe to call multiple times.
+/// - [`SyncEngine::set_interval`] forwards a new polling interval to
+///   the running tasks.
+#[derive(Debug)]
+pub struct SyncEngine {
     shutdown_tx: watch::Sender<bool>,
     interval_tx: watch::Sender<u64>,
 }
 
-impl SyncHandle {
-    /// Start the bidirectional sync engine.
+impl SyncEngine {
+    /// Build the bidirectional sync engine and spawn its background
+    /// tasks on the supplied Tokio runtime.
     ///
     /// Spawns two Tokio tasks:
     /// - **PullManager**: streams changes from Immich, upserts locally,
-    ///   downloads thumbnails inline
-    /// - **PushManager**: drains the outbox, pushes local mutations to Immich
+    ///   downloads thumbnails inline.
+    /// - **PushManager**: drains the outbox, pushes local mutations to
+    ///   Immich.
     ///
-    /// Returns a handle for shutdown and interval control.
+    /// Returns an `Arc<SyncEngine>` so the application and the paired
+    /// [`crate::client::SyncClient`] can share ownership.
     #[allow(clippy::too_many_arguments)]
-    pub fn start(
+    #[instrument(skip_all)]
+    pub fn build(
         client: providers::immich::client::ImmichClient,
         library: Arc<Library>,
         db: Database,
@@ -47,7 +66,7 @@ impl SyncHandle {
         thumbnails_dir: PathBuf,
         initial_interval_secs: u64,
         tokio: tokio::runtime::Handle,
-    ) -> Self {
+    ) -> Arc<Self> {
         use providers::immich::{pull, push};
 
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
@@ -86,19 +105,27 @@ impl SyncHandle {
         });
 
         info!("sync engine started");
-        Self {
+        Arc::new(Self {
             shutdown_tx,
             interval_tx,
-        }
+        })
     }
 
     /// Signal all sync tasks to shut down gracefully.
+    ///
+    /// Idempotent: calling twice is a no-op. The spawned tasks observe
+    /// the shutdown flag at their next polling boundary and exit their
+    /// loops; this method returns immediately and does not wait for
+    /// the tasks to drain.
+    #[instrument(skip_all)]
     pub fn shutdown(&self) {
         let _ = self.shutdown_tx.send(true);
         info!("sync engine shutdown requested");
     }
 
-    /// Update the sync polling interval (seconds). Takes effect next cycle.
+    /// Update the sync polling interval (seconds). Takes effect on
+    /// the next cycle of the pull / push managers.
+    #[instrument(skip(self))]
     pub fn set_interval(&self, secs: u64) {
         let _ = self.interval_tx.send(secs);
         info!(secs, "sync interval updated");
@@ -109,51 +136,55 @@ impl SyncHandle {
 mod tests {
     use super::*;
 
+    fn make_engine() -> SyncEngine {
+        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+        let (interval_tx, _interval_rx) = watch::channel(60u64);
+        SyncEngine {
+            shutdown_tx,
+            interval_tx,
+        }
+    }
+
     #[test]
     fn immich_constants_are_sensible() {
         const { assert!(providers::immich::ACK_FLUSH_THRESHOLD > 0) };
     }
 
     #[test]
-    fn sync_handle_shutdown_does_not_panic() {
-        let (shutdown_tx, _shutdown_rx) = watch::channel(false);
-        let (interval_tx, _interval_rx) = watch::channel(60u64);
-        let handle = SyncHandle {
-            shutdown_tx,
-            interval_tx,
-        };
-        handle.shutdown();
+    fn sync_engine_shutdown_does_not_panic() {
+        let engine = make_engine();
+        engine.shutdown();
         // Calling shutdown again is also safe.
-        handle.shutdown();
+        engine.shutdown();
     }
 
     #[test]
-    fn sync_handle_set_interval() {
+    fn sync_engine_set_interval() {
         let (shutdown_tx, _shutdown_rx) = watch::channel(false);
         let (interval_tx, interval_rx) = watch::channel(60u64);
-        let handle = SyncHandle {
+        let engine = SyncEngine {
             shutdown_tx,
             interval_tx,
         };
 
-        handle.set_interval(120);
+        engine.set_interval(120);
         assert_eq!(*interval_rx.borrow(), 120);
 
-        handle.set_interval(0);
+        engine.set_interval(0);
         assert_eq!(*interval_rx.borrow(), 0);
     }
 
     #[test]
-    fn sync_handle_shutdown_sets_flag() {
+    fn sync_engine_shutdown_sets_flag() {
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let (interval_tx, _interval_rx) = watch::channel(60u64);
-        let handle = SyncHandle {
+        let engine = SyncEngine {
             shutdown_tx,
             interval_tx,
         };
 
         assert!(!*shutdown_rx.borrow());
-        handle.shutdown();
+        engine.shutdown();
         assert!(*shutdown_rx.borrow());
     }
 }

--- a/src/ui/album_grid/actions.rs
+++ b/src/ui/album_grid/actions.rs
@@ -17,9 +17,7 @@ pub(crate) fn open_album_drilldown(
     album_name: &str,
 ) {
     let filter = MediaFilter::Album { album_id };
-    let media_client = MomentsApplication::default()
-        .media_client_v2()
-        .expect("media client available");
+    let media_client = MomentsApplication::default().media_client_v2().clone();
     let store = media_client.create_model(filter.clone());
     let view = PhotoGridView::new();
     view.setup(settings.clone(), Rc::clone(texture_cache));

--- a/src/ui/album_grid/factory.rs
+++ b/src/ui/album_grid/factory.rs
@@ -127,9 +127,7 @@ fn setup_context_menu(
     let album_name = item.name();
     let is_pinned = item.pinned();
 
-    let album_client = MomentsApplication::default()
-        .album_client_v2()
-        .expect("album client v2 available");
+    let album_client = MomentsApplication::default().album_client_v2().clone();
 
     let action_group = gio::SimpleActionGroup::new();
 

--- a/src/ui/album_grid/mod.rs
+++ b/src/ui/album_grid/mod.rs
@@ -125,7 +125,7 @@ impl AlbumGridView {
 
         let album_client = crate::application::MomentsApplication::default()
             .album_client_v2()
-            .expect("album client v2 available after library load");
+            .clone();
         assert!(
             imp.album_client.set(album_client.clone()).is_ok(),
             "setup called twice"

--- a/src/ui/album_grid/selection.rs
+++ b/src/ui/album_grid/selection.rs
@@ -179,10 +179,9 @@ fn wire_batch_delete(
             if response != "delete" {
                 return;
             }
-            let album_client = MomentsApplication::default()
+            MomentsApplication::default()
                 .album_client_v2()
-                .expect("album client v2 available");
-            album_client.delete_album(ids.clone());
+                .delete_album(ids.clone());
             exit.activate(None);
         });
 

--- a/src/ui/album_picker_dialog/mod.rs
+++ b/src/ui/album_picker_dialog/mod.rs
@@ -16,9 +16,7 @@ pub mod dialog;
 /// Uses `AlbumClientV2` for the membership query and album commands.
 /// Album list comes from a shared model; thumbnails are handled by the client.
 pub fn show_album_picker_dialog(parent: &impl IsA<gtk::Widget>, ids: Vec<MediaId>) {
-    let album_client = MomentsApplication::default()
-        .album_client_v2()
-        .expect("album client v2 available");
+    let album_client = MomentsApplication::default().album_client_v2().clone();
 
     let parent_weak: glib::WeakRef<gtk::Widget> = parent.as_ref().downgrade();
 

--- a/src/ui/import_dialog/mod.rs
+++ b/src/ui/import_dialog/mod.rs
@@ -59,52 +59,46 @@ mod imp {
         fn realize(&self) {
             self.parent_realize();
 
-            if let Some(import_client) =
-                crate::application::MomentsApplication::default().import_client()
-            {
-                let mut handlers = self._import_handlers.borrow_mut();
-                let obj = self.obj().clone();
+            let app = crate::application::MomentsApplication::default();
+            let import_client = app.import_client();
+            let mut handlers = self._import_handlers.borrow_mut();
+            let obj = self.obj().clone();
 
-                // Progress updates.
-                let weak = obj.downgrade();
-                handlers.push(import_client.connect_notify_local(
-                    Some("current"),
-                    move |client, _| {
-                        if let Some(dialog) = weak.upgrade() {
-                            dialog.set_progress(client.current() as usize, client.total() as usize);
-                        }
-                    },
-                ));
+            // Progress updates.
+            let weak = obj.downgrade();
+            handlers.push(
+                import_client.connect_notify_local(Some("current"), move |client, _| {
+                    if let Some(dialog) = weak.upgrade() {
+                        dialog.set_progress(client.current() as usize, client.total() as usize);
+                    }
+                }),
+            );
 
-                // State changes (completion).
-                let weak = obj.downgrade();
-                handlers.push(import_client.connect_notify_local(
-                    Some("state"),
-                    move |client, _| {
-                        if let Some(dialog) = weak.upgrade() {
-                            if client.state() == crate::client::ImportState::Complete {
-                                let summary = crate::importer::ImportSummary {
-                                    imported: client.imported() as usize,
-                                    skipped_duplicates: client.skipped() as usize,
-                                    skipped_unsupported: 0,
-                                    failed: client.failed() as usize,
-                                    elapsed_secs: client.elapsed_secs(),
-                                };
-                                dialog.set_complete(&summary);
-                            }
+            // State changes (completion).
+            let weak = obj.downgrade();
+            handlers.push(
+                import_client.connect_notify_local(Some("state"), move |client, _| {
+                    if let Some(dialog) = weak.upgrade() {
+                        if client.state() == crate::client::ImportState::Complete {
+                            let summary = crate::importer::ImportSummary {
+                                imported: client.imported() as usize,
+                                skipped_duplicates: client.skipped() as usize,
+                                skipped_unsupported: 0,
+                                failed: client.failed() as usize,
+                                elapsed_secs: client.elapsed_secs(),
+                            };
+                            dialog.set_complete(&summary);
                         }
-                    },
-                ));
-            }
+                    }
+                }),
+            );
         }
 
         fn unrealize(&self) {
-            if let Some(import_client) =
-                crate::application::MomentsApplication::default().import_client()
-            {
-                for handler_id in self._import_handlers.borrow_mut().drain(..) {
-                    import_client.disconnect(handler_id);
-                }
+            let app = crate::application::MomentsApplication::default();
+            let import_client = app.import_client();
+            for handler_id in self._import_handlers.borrow_mut().drain(..) {
+                import_client.disconnect(handler_id);
             }
             self.parent_unrealize();
         }

--- a/src/ui/people_grid/actions.rs
+++ b/src/ui/people_grid/actions.rs
@@ -41,7 +41,7 @@ pub(super) fn wire_activation(
         };
         let mc = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
         let store = mc.create_model(filter.clone());
         let view = PhotoGridView::new();
         view.setup(s.clone(), Rc::clone(&tc));

--- a/src/ui/people_grid/mod.rs
+++ b/src/ui/people_grid/mod.rs
@@ -100,7 +100,7 @@ impl PeopleGridView {
 
         let people_client = crate::application::MomentsApplication::default()
             .people_client()
-            .expect("people client available after library load");
+            .clone();
         assert!(
             imp.people_client.set(people_client.clone()).is_ok(),
             "setup called twice"

--- a/src/ui/photo_grid/action_bar.rs
+++ b/src/ui/photo_grid/action_bar.rs
@@ -161,9 +161,9 @@ fn wire_favourite(btn: &gtk::Button, state: &SelectionState, store: &gio::ListSt
         });
         let new_state = !all_fav;
 
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.set_favorite(ids, new_state);
-        }
+        crate::application::MomentsApplication::default()
+            .media_client_v2()
+            .set_favorite(ids, new_state);
         actions::update_fav_button(&btn_ref, new_state);
     });
 }
@@ -175,9 +175,9 @@ fn wire_trash(btn: &gtk::Button, state: &SelectionState) {
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.trash(ids);
-        }
+        crate::application::MomentsApplication::default()
+            .media_client_v2()
+            .trash(ids);
     });
 }
 
@@ -188,9 +188,9 @@ fn wire_restore(btn: &gtk::Button, state: &SelectionState) {
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.restore(ids);
-        }
+        crate::application::MomentsApplication::default()
+            .media_client_v2()
+            .restore(ids);
     });
 }
 
@@ -225,11 +225,9 @@ fn wire_delete_permanently(btn: &gtk::Button, state: &SelectionState) {
             gtk::gio::Cancellable::NONE,
             move |response| {
                 if response == "delete" {
-                    if let Some(mc) =
-                        crate::application::MomentsApplication::default().media_client_v2()
-                    {
-                        mc.delete(ids);
-                    }
+                    crate::application::MomentsApplication::default()
+                        .media_client_v2()
+                        .delete(ids);
                 }
             },
         );
@@ -244,8 +242,8 @@ fn wire_remove_from_album(btn: &gtk::Button, state: &SelectionState, album_id: &
         if ids.is_empty() {
             return;
         }
-        if let Some(ac) = crate::application::MomentsApplication::default().album_client_v2() {
-            ac.remove_from_album(aid.clone(), ids);
-        }
+        crate::application::MomentsApplication::default()
+            .album_client_v2()
+            .remove_from_album(aid.clone(), ids);
     });
 }

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -210,9 +210,9 @@ fn build_standard_menu(
             if ids_for_remove.is_empty() {
                 return;
             }
-            if let Some(ac) = crate::application::MomentsApplication::default().album_client_v2() {
-                ac.remove_from_album(aid.clone(), ids_for_remove.clone());
-            }
+            crate::application::MomentsApplication::default()
+                .album_client_v2()
+                .remove_from_album(aid.clone(), ids_for_remove.clone());
         });
     }
 
@@ -234,9 +234,9 @@ fn wire_restore_button(
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.restore(ids.clone());
-        }
+        crate::application::MomentsApplication::default()
+            .media_client_v2()
+            .restore(ids.clone());
     });
 }
 
@@ -279,11 +279,9 @@ fn wire_permanent_delete_button(
             gtk::gio::Cancellable::NONE,
             move |response| {
                 if response == "delete" {
-                    if let Some(mc) =
-                        crate::application::MomentsApplication::default().media_client_v2()
-                    {
-                        mc.delete(ids_for_dialog);
-                    }
+                    crate::application::MomentsApplication::default()
+                        .media_client_v2()
+                        .delete(ids_for_dialog);
                 }
             },
         );
@@ -305,9 +303,9 @@ fn wire_favourite_button(
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.set_favorite(ids.clone(), new_fav);
-        }
+        crate::application::MomentsApplication::default()
+            .media_client_v2()
+            .set_favorite(ids.clone(), new_fav);
     });
 }
 
@@ -321,9 +319,9 @@ fn wire_trash_button(btn: &gtk::Button, pop_ref: &glib::WeakRef<gtk::Popover>, i
         if ids.is_empty() {
             return;
         }
-        if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-            mc.trash(ids.clone());
-        }
+        crate::application::MomentsApplication::default()
+            .media_client_v2()
+            .trash(ids.clone());
     });
 }
 

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -450,7 +450,8 @@ mod view_imp {
                 let app = crate::application::MomentsApplication::default();
                 let mut handlers: Vec<(glib::Object, glib::SignalHandlerId)> = Vec::new();
 
-                if let Some(mc) = app.media_client_v2() {
+                {
+                    let mc = app.media_client_v2();
                     let mc_obj: glib::Object = mc.clone().upcast();
                     for sig in ["items-trashed", "items-restored", "items-deleted"] {
                         let exit = exit.clone();
@@ -476,7 +477,8 @@ mod view_imp {
                     handlers.push((mc_obj, h));
                 }
 
-                if let Some(ac) = app.album_client_v2() {
+                {
+                    let ac = app.album_client_v2();
                     let ac_obj: glib::Object = ac.clone().upcast();
                     let exit = exit.clone();
                     let h = ac.connect_closure(
@@ -725,7 +727,7 @@ impl PhotoGridView {
 
         let media_client = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
         let texture_cache = Rc::clone(imp.texture_cache());
 
         imp.photo_grid.set_store(
@@ -831,11 +833,9 @@ impl PhotoGridView {
                 dialog.set_close_response("cancel");
                 dialog.connect_response(None, move |_, response| {
                     if response == "restore" {
-                        if let Some(mc) =
-                            crate::application::MomentsApplication::default().media_client_v2()
-                        {
-                            mc.restore_all_trash();
-                        }
+                        crate::application::MomentsApplication::default()
+                            .media_client_v2()
+                            .restore_all_trash();
                     }
                 });
                 dialog.present(win.as_ref());
@@ -856,11 +856,9 @@ impl PhotoGridView {
                 dialog.set_close_response("cancel");
                 dialog.connect_response(None, move |_, response| {
                     if response == "delete" {
-                        if let Some(mc) =
-                            crate::application::MomentsApplication::default().media_client_v2()
-                        {
-                            mc.empty_trash();
-                        }
+                        crate::application::MomentsApplication::default()
+                            .media_client_v2()
+                            .empty_trash();
                     }
                 });
                 dialog.present(win.as_ref());

--- a/src/ui/preferences_dialog/mod.rs
+++ b/src/ui/preferences_dialog/mod.rs
@@ -221,10 +221,9 @@ fn build_storage_group(
 }
 
 fn spawn_library_stats(rows: LibraryStatsRows) {
-    let Some(media_client) = crate::application::MomentsApplication::default().media_client_v2()
-    else {
-        return;
-    };
+    let media_client = crate::application::MomentsApplication::default()
+        .media_client_v2()
+        .clone();
     let photos_weak = rows.photos.downgrade();
     let videos_weak = rows.videos.downgrade();
     let albums_weak = rows.albums.downgrade();
@@ -372,10 +371,9 @@ fn build_server_stats_group() -> (adw::PreferencesGroup, ServerStatsRows) {
 }
 
 fn spawn_server_stats(rows: ServerStatsRows) {
-    let Some(media_client) = crate::application::MomentsApplication::default().media_client_v2()
-    else {
-        return;
-    };
+    let media_client = crate::application::MomentsApplication::default()
+        .media_client_v2()
+        .clone();
     let sp_weak = rows.photos.downgrade();
     let sv_weak = rows.videos.downgrade();
     let sd_weak = rows.disk.downgrade();
@@ -459,7 +457,10 @@ fn build_outbox_group() -> (adw::PreferencesGroup, OutboxRows) {
 }
 
 fn spawn_outbox_status(rows: OutboxRows) {
-    let Some(sync_client) = crate::application::MomentsApplication::default().sync_client() else {
+    let Some(sync_client) = crate::application::MomentsApplication::default()
+        .sync_client()
+        .cloned()
+    else {
         return;
     };
     if !sync_client.has_outbox() {

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -174,10 +174,8 @@ mod imp {
                         .item(index)
                         .and_then(|o| o.downcast::<crate::client::AlbumItemObject>().ok())
                     {
-                        let album_client = crate::application::MomentsApplication::default()
+                        crate::application::MomentsApplication::default()
                             .album_client_v2()
-                            .expect("album client v2 available");
-                        album_client
                             .unpin_album(crate::library::album::AlbumId::from_raw(obj.id()));
                     }
                 });
@@ -194,10 +192,8 @@ mod imp {
         fn realize(&self) {
             self.parent_realize();
 
-            let Some(mc) = crate::application::MomentsApplication::default().media_client_v2()
-            else {
-                return;
-            };
+            let app = crate::application::MomentsApplication::default();
+            let mc = app.media_client_v2();
             let mc_obj: glib::Object = mc.clone().upcast();
 
             let weak1 = self.obj().downgrade();
@@ -339,7 +335,7 @@ impl MomentsSidebar {
 
         let album_client = crate::application::MomentsApplication::default()
             .album_client_v2()
-            .expect("album client v2 available");
+            .clone();
 
         let store = album_client.create_model();
         album_client.list_albums(&store);

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -178,7 +178,7 @@ impl VideoViewer {
 
         let mc = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         let weak = self.downgrade();
         mc.original_path(&id, move |path| {
@@ -215,7 +215,7 @@ impl VideoViewer {
     fn load_metadata_async(&self, gen: u64, id: MediaId) {
         let mc = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         let weak = self.downgrade();
         mc.media_metadata(&id, move |metadata| {
@@ -333,11 +333,9 @@ impl VideoViewer {
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();
-                if let Some(mc) =
-                    crate::application::MomentsApplication::default().media_client_v2()
-                {
-                    mc.set_favorite(vec![id], new_fav);
-                }
+                crate::application::MomentsApplication::default()
+                    .media_client_v2()
+                    .set_favorite(vec![id], new_fav);
             }
         ));
 
@@ -473,9 +471,9 @@ fn wire_overflow_menu(
                 items.get(idx).map(|obj| obj.item().id.clone())
             };
             let Some(id) = id else { return };
-            if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-                mc.trash(vec![id]);
-            }
+            crate::application::MomentsApplication::default()
+                .media_client_v2()
+                .trash(vec![id]);
             if let Some(nav_view) = viewer
                 .parent()
                 .and_then(|p| p.downcast::<adw::NavigationView>().ok())

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -282,7 +282,7 @@ impl EditPanel {
                 let id_log = id.clone();
                 let mc = crate::application::MomentsApplication::default()
                     .media_client_v2()
-                    .expect("media client available");
+                    .clone();
                 let weak = self.downgrade();
                 mc.revert_edits(&id, move |result| {
                     if let Some(panel) = weak.upgrade() {
@@ -313,7 +313,7 @@ impl EditPanel {
         let id_log = id.clone();
         let mc = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         let weak = self.downgrade();
         mc.save_edit_state(&id, &state, move |result| {
@@ -466,7 +466,7 @@ impl EditPanel {
                 let id_log = id.clone();
                 let mc = crate::application::MomentsApplication::default()
                     .media_client_v2()
-                    .expect("media client available");
+                    .clone();
                 mc.revert_edits(&id, move |result| match result {
                     Ok(()) => debug!(media_id = %id_log, "revert edits"),
                     Err(e) => {

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -22,19 +22,11 @@ impl PhotoViewer {
             .media_client_v2()
             .clone();
 
-        // TODO(library-context refactor, Step 2): take the render
-        // pipeline from the owning Client (or pass it in here)
-        // rather than reaching into the global Application singleton.
-        #[allow(deprecated)]
-        let pipeline = match crate::application::MomentsApplication::default().render_pipeline() {
-            Some(p) => p,
-            None => {
-                error!("render pipeline not available");
-                imp.spinner.set_spinning(false);
-                imp.spinner.set_visible(false);
-                return;
-            }
-        };
+        // Decode through the same `RenderPipeline` instance the media
+        // client uses internally — the client owns it as part of its
+        // build-time dependencies, so widgets that already use the
+        // client never need a separate path to the pipeline.
+        let pipeline = media_client.render_pipeline();
 
         let weak = self.downgrade();
         media_client.original_path(&id, move |path| {
@@ -148,17 +140,9 @@ impl PhotoViewer {
             .media_client_v2()
             .clone();
 
-        // TODO(library-context refactor, Step 2): take the render
-        // pipeline from the owning Client rather than reaching into
-        // the global Application singleton.
-        #[allow(deprecated)]
-        let pipeline = match crate::application::MomentsApplication::default().render_pipeline() {
-            Some(p) => p,
-            None => {
-                error!("render pipeline not available for edit session");
-                return;
-            }
-        };
+        // Decode through the same `RenderPipeline` instance the media
+        // client uses internally — see `start_full_res_load` above.
+        let pipeline = media_client.render_pipeline();
 
         // Fetch edit state and original path in parallel via two client calls.
         let weak = self.downgrade();

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -22,6 +22,10 @@ impl PhotoViewer {
             .media_client_v2()
             .expect("media client available");
 
+        // TODO(library-context refactor, Step 2): take the render
+        // pipeline from the owning Client (or pass it in here)
+        // rather than reaching into the global Application singleton.
+        #[allow(deprecated)]
         let pipeline = match crate::application::MomentsApplication::default().render_pipeline() {
             Some(p) => p,
             None => {
@@ -144,6 +148,10 @@ impl PhotoViewer {
             .media_client_v2()
             .expect("media client available");
 
+        // TODO(library-context refactor, Step 2): take the render
+        // pipeline from the owning Client rather than reaching into
+        // the global Application singleton.
+        #[allow(deprecated)]
         let pipeline = match crate::application::MomentsApplication::default().render_pipeline() {
             Some(p) => p,
             None => {

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -20,7 +20,7 @@ impl PhotoViewer {
 
         let media_client = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         // TODO(library-context refactor, Step 2): take the render
         // pipeline from the owning Client (or pass it in here)
@@ -146,7 +146,7 @@ impl PhotoViewer {
 
         let media_client = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         // TODO(library-context refactor, Step 2): take the render
         // pipeline from the owning Client rather than reaching into
@@ -264,7 +264,7 @@ impl PhotoViewer {
     pub(super) fn load_metadata_async(&self, gen: u64, id: crate::library::media::MediaId) {
         let media_client = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         let weak = self.downgrade();
         media_client.media_metadata(&id, move |metadata| {

--- a/src/ui/viewer/menu.rs
+++ b/src/ui/viewer/menu.rs
@@ -173,9 +173,9 @@ pub(super) fn wire_overflow_menu(
                 items.get(idx).map(|obj| obj.item().id.clone())
             };
             let Some(id) = id else { return };
-            if let Some(mc) = crate::application::MomentsApplication::default().media_client_v2() {
-                mc.trash(vec![id]);
-            }
+            crate::application::MomentsApplication::default()
+                .media_client_v2()
+                .trash(vec![id]);
             if let Some(nav_view) = viewer
                 .parent()
                 .and_then(|p| p.downcast::<adw::NavigationView>().ok())

--- a/src/ui/viewer/mod.rs
+++ b/src/ui/viewer/mod.rs
@@ -325,11 +325,9 @@ impl PhotoViewer {
                 obj.set_is_favorite(new_fav);
 
                 let id = obj.item().id.clone();
-                if let Some(mc) =
-                    crate::application::MomentsApplication::default().media_client_v2()
-                {
-                    mc.set_favorite(vec![id], new_fav);
-                }
+                crate::application::MomentsApplication::default()
+                    .media_client_v2()
+                    .set_favorite(vec![id], new_fav);
             }
         ));
 

--- a/src/ui/widgets/activity_indicator/mod.rs
+++ b/src/ui/widgets/activity_indicator/mod.rs
@@ -110,10 +110,9 @@ mod imp {
                     sc.disconnect(id);
                 }
             }
-            if let Some(ic) = app.import_client() {
-                for id in self.import_handlers.borrow_mut().drain(..) {
-                    ic.disconnect(id);
-                }
+            let ic = app.import_client();
+            for id in self.import_handlers.borrow_mut().drain(..) {
+                ic.disconnect(id);
             }
             self.parent_unrealize();
         }
@@ -142,13 +141,17 @@ impl ActivityIndicator {
 
         // Bind any clients that already exist.
         if let Some(sc) = app.sync_client() {
-            self.bind_sync_client(&sc);
+            self.bind_sync_client(sc);
         }
-        if let Some(ic) = app.import_client() {
-            self.bind_import_client(&ic);
-        }
+        self.bind_import_client(app.import_client());
 
-        // Subscribe for late-arriving clients.
+        // Subscribe for late-arriving clients. `sync-client` is the
+        // only one that may still be unset at bind time (Local backend
+        // never installs a sync client; an Immich session installs it
+        // partway through `load_library_async` after the main window
+        // has already been built). `import-client` is set before any
+        // sidebar widget realizes, so its `notify` subscription is
+        // unnecessary — the bind above is always sufficient.
         let mut app_handlers = self.imp().app_handlers.borrow_mut();
 
         let weak = self.downgrade();
@@ -156,17 +159,7 @@ impl ActivityIndicator {
             app.connect_notify_local(Some("sync-client"), move |app, _| {
                 let Some(this) = weak.upgrade() else { return };
                 if let Some(sc) = app.sync_client() {
-                    this.bind_sync_client(&sc);
-                }
-            }),
-        );
-
-        let weak = self.downgrade();
-        app_handlers.push(
-            app.connect_notify_local(Some("import-client"), move |app, _| {
-                let Some(this) = weak.upgrade() else { return };
-                if let Some(ic) = app.import_client() {
-                    this.bind_import_client(&ic);
+                    this.bind_sync_client(sc);
                 }
             }),
         );
@@ -468,9 +461,7 @@ impl ActivityIndicator {
         let sync_active = app
             .sync_client()
             .is_some_and(|c| c.state() == SyncState::Syncing);
-        let import_active = app
-            .import_client()
-            .is_some_and(|c| c.state() == ImportState::Running);
+        let import_active = app.import_client().state() == ImportState::Running;
         sync_active || import_active
     }
 

--- a/src/ui/widgets/activity_indicator/mod.rs
+++ b/src/ui/widgets/activity_indicator/mod.rs
@@ -148,7 +148,7 @@ impl ActivityIndicator {
         // Subscribe for late-arriving clients. `sync-client` is the
         // only one that may still be unset at bind time (Local backend
         // never installs a sync client; an Immich session installs it
-        // partway through `load_library_async` after the main window
+        // partway through `startup::start` after the main window
         // has already been built). `import-client` is set before any
         // sidebar widget realizes, so its `notify` subscription is
         // unnecessary — the bind above is always sufficient.

--- a/src/ui/window/mod.rs
+++ b/src/ui/window/mod.rs
@@ -205,41 +205,39 @@ impl MomentsWindow {
         // Navigate to Recent Imports when an import completes.
         // Deferred via idle_add_local_once because navigate() can materialise
         // a lazy view, which triggers realize → subscribe() on the new widget.
-        if let Some(import_client) = app.import_client() {
-            let weak = self.downgrade();
-            import_client.connect_notify_local(Some("state"), move |client, _| {
-                if client.state() == crate::client::ImportState::Complete {
-                    let weak = weak.clone();
-                    glib::idle_add_local_once(move || {
-                        if let Some(win) = weak.upgrade() {
-                            win.navigate("recent");
-                        }
-                    });
-                }
-            });
-        }
+        let import_client = app.import_client();
+        let weak = self.downgrade();
+        import_client.connect_notify_local(Some("state"), move |client, _| {
+            if client.state() == crate::client::ImportState::Complete {
+                let weak = weak.clone();
+                glib::idle_add_local_once(move || {
+                    if let Some(win) = weak.upgrade() {
+                        win.navigate("recent");
+                    }
+                });
+            }
+        });
 
         // Unregister deleted album routes from the coordinator before
         // AlbumGridView processes the event (avoids a navigation race).
-        if let Some(ac) = app.album_client_v2() {
-            let weak = self.downgrade();
-            let h = ac.connect_closure(
-                "album-deleted",
-                false,
-                glib::closure_local!(move |_: crate::client::AlbumClientV2, id: String| {
-                    if let Some(win) = weak.upgrade() {
-                        if let Some(coord) = win.imp().coordinator.get() {
-                            let route = format!("album:{}", id);
-                            coord.borrow_mut().unregister(&route);
-                        }
+        let ac = app.album_client_v2();
+        let weak = self.downgrade();
+        let h = ac.connect_closure(
+            "album-deleted",
+            false,
+            glib::closure_local!(move |_: crate::client::AlbumClientV2, id: String| {
+                if let Some(win) = weak.upgrade() {
+                    if let Some(coord) = win.imp().coordinator.get() {
+                        let route = format!("album:{}", id);
+                        coord.borrow_mut().unregister(&route);
                     }
-                }),
-            );
-            self.imp()
-                ._signal_handlers
-                .borrow_mut()
-                .push((ac.upcast(), h));
-        }
+                }
+            }),
+        );
+        self.imp()
+            ._signal_handlers
+            .borrow_mut()
+            .push((ac.clone().upcast(), h));
     }
 
     fn setup_sidebar(&self) -> MomentsSidebar {
@@ -260,14 +258,13 @@ impl MomentsWindow {
 
         {
             let sb = sidebar.clone();
-            let media_client = crate::application::MomentsApplication::default()
+            crate::application::MomentsApplication::default()
                 .media_client_v2()
-                .expect("media client available");
-            media_client.library_stats(move |result| {
-                if let Ok(stats) = result {
-                    sb.set_trash_count(stats.trashed_count as u32);
-                }
-            });
+                .library_stats(move |result| {
+                    if let Ok(stats) = result {
+                        sb.set_trash_count(stats.trashed_count as u32);
+                    }
+                });
         }
 
         sidebar.setup_pinned_albums();
@@ -285,7 +282,7 @@ impl MomentsWindow {
 
         let media_client = crate::application::MomentsApplication::default()
             .media_client_v2()
-            .expect("media client available");
+            .clone();
 
         let content_stack = gtk::Stack::new();
         content_stack.set_transition_type(gtk::StackTransitionType::Crossfade);
@@ -321,7 +318,7 @@ impl MomentsWindow {
             coordinator.register_lazy("favorites", move || {
                 let mc = crate::application::MomentsApplication::default()
                     .media_client_v2()
-                    .expect("media client available");
+                    .clone();
                 let store = mc.create_model(MediaFilter::Favorites);
                 let view = PhotoGridView::new();
                 view.setup(s, tc);
@@ -339,7 +336,7 @@ impl MomentsWindow {
                 let filter = MediaFilter::RecentImports { since };
                 let mc = crate::application::MomentsApplication::default()
                     .media_client_v2()
-                    .expect("media client available");
+                    .clone();
                 let store = mc.create_model(filter.clone());
                 let view = PhotoGridView::new();
                 view.setup(s, tc);
@@ -354,7 +351,7 @@ impl MomentsWindow {
             coordinator.register_lazy("trash", move || {
                 let mc = crate::application::MomentsApplication::default()
                     .media_client_v2()
-                    .expect("media client available");
+                    .clone();
                 let store = mc.create_model(MediaFilter::Trashed);
                 let view = PhotoGridView::new();
                 view.setup(s, tc);
@@ -430,7 +427,7 @@ impl MomentsWindow {
                     let filter = MediaFilter::Album { album_id };
                     let mc = crate::application::MomentsApplication::default()
                         .media_client_v2()
-                        .expect("media client available");
+                        .clone();
                     let store = mc.create_model(filter.clone());
                     let view = PhotoGridView::new();
                     view.setup(s.clone(), Rc::clone(&tc));


### PR DESCRIPTION
## Summary

- Introduces `LibraryContext`, a pure-Rust `pub(in crate::application)` container for the domain + infrastructure (`Library`, `RenderPipeline`, Tokio handle, purge-task handle). UI code physically cannot name the type — the architectural boundary is now enforced by the type system, not by convention.
- Decomposes the 898-line `application/mod.rs` god-object into seven sibling files with clear roles (`context.rs`, `startup.rs`, `lifecycle.rs`, `library_loader.rs`, `import.rs`, `actions.rs`, plus the existing `keyring.rs`). `mod.rs` drops to 369 lines — essentially the GObject subclass machinery + public accessor API.
- Replaces 13 `RefCell<Option<T>>` fields on `MomentsApplication` with `OnceCell<T>` for clients and `LibraryContext`-owned shapes for domain state. Tightens client constructor signatures to declare minimal sub-service dependencies via a `build()` convention enforced inside `application/`.

Triggered by an external engineering review (`Downloads/moments_repository_engineering_review.md`) which flagged "Application State Container Is Trending Toward a God Object" as the highest-severity architectural finding.

Full design doc landed as the first commit of this PR: `docs/design-library-context.md`.

## Architectural property achieved

- **`LibraryContext` is `pub(in crate::application)`** — unspellable in `ui/`, `client/`, `library/`. UI code cannot reach the domain except through a Client.
- **Clients are constructed via `Client::build(...)`** inside `application/` only. UI code cannot construct a Client because it cannot acquire the constructor arguments (sub-services live behind `pub(in crate::application)` accessors on `LibraryContext`).
- **All client storage is `OnceCell<T>`** (post-startup contract), with `Option<&SyncClient>` exposed for the Immich-only sync client.
- **Startup is four typed phase functions** (`phase1_domain`, `phase2_background_services`, `phase3_clients`, `phase4_install`) — compiler enforces ordering.
- **`SyncEngine` has its own typed identity** on `Application`; `SyncClient` holds an `Arc<SyncEngine>` for UI-driven engine control.

## Per-step breakdown (11 commits)

| Step | Commit | What |
|------|--------|------|
| Doc  | `97dcb41` | `docs/design-library-context.md` — the design |
| 1    | `7ea02bc` | Introduce `LibraryContext`; populate alongside legacy fields |
| 2    | `05b18a1` | Switch client construction to `build()` taking concrete deps |
| 3    | `85cc084` | Migrate client fields to `OnceCell<T>` |
| 4    | `395e2e8` | Remove deprecated accessors + legacy domain fields |
| 5    | `0f84c33` | Split startup into typed phase functions (`startup.rs`) |
| 6    | `8d4abb0` | Reshape `SyncHandle` → `SyncEngine` top-level service |
| 7    | `98c018d` | Extract `LibraryLoader` from duplicated wizard/open paths |
| 8    | `cac9c2c` | Extract `actions.rs` + `import.rs` from `mod.rs` |
| 9    | `c97b226` | Extract library-open lifecycle into `lifecycle.rs` |
| 10   | `3923cf5` | Tighten Album/People clients to minimal sub-services |

Steps 7–10 emerged during implementation as architecturally-adjacent cleanups (Step 7 is documented in the design doc; Steps 8–10 are pure decomposition / dependency-tightening). They were bundled into this PR because they live in `application/` and the cost of doing them separately later would be higher.

## `application/` module shape after

```
mod.rs            369  — GObject subclass + public accessors + shutdown/activate
startup.rs        503  — 4 typed startup phases
lifecycle.rs      186  — setup wizard + open-library orchestration
library_loader.rs 157  — shared bundle-open + keyring pipeline (+ 4 unit tests)
keyring.rs        144  — token resolution (unchanged)
import.rs         124  — import dialog + flow
actions.rs        108  — app actions + about/shortcuts/prefs dialogs
context.rs        106  — LibraryContext (domain owner)
```

## Notable deviations from the design doc

Two deliberate deviations are documented inline in the code:

1. **`library_context` field is `RefCell<Option<Arc<LibraryContext>>>`, not the doc's sketched `OnceCell<Arc<...>>`.** GObject `shutdown` takes `&self`, but `OnceCell::take` requires `&mut self`. The existing shutdown path needs to clear the `Arc<Library>` (and the `SqlitePool` it wraps) before `main()` drops the Tokio runtime. Converting requires a shutdown-ordering redesign — out of scope for this refactor. Documented at the field declaration in `mod.rs`.

2. **`MediaClientV2` and `ImportClient` keep `Arc<Library>`** rather than splitting into N sub-services. Both genuinely touch 6+ services plus Library-level cross-service methods; splitting would harm readability without architectural benefit. The doc explicitly allowed this ("If a client uses the whole `Arc<Library>` because it touches many services, that's acceptable"). `AlbumClientV2`, `PeopleClientV2`, and `SyncClient` were tightened (Step 10).

## Out of scope / deferred

These were flagged in the design doc as future work:

- **`BackgroundContext`** — anticipated holder for long-running background services (`SyncEngine`, `PurgeTask`) once a coordinated operation (`pause_all`, `shutdown_in_order`, `apply_config`) is needed. Trigger condition: ≥3 background-task fields or first concrete coordination need.
- **`ClientContext`** — speculative, depends on D-Bus design. Deferred until cross-cutting policy actually differs between callers.
- **`AppConfig`** — typed config struct read once from `gio::Settings`. Open question in the design doc.

## Test plan

- [x] `make lint` clean (cargo fmt + clippy `-D warnings`, both default and `--features dhat-heap`)
- [x] `make test` — 615 passed, 0 failed (baseline was 611; added 4 `LibraryLoader` unit tests in Step 7)
- [x] `make typos` clean
- [x] `make test-integration` passes
- [ ] Manual: launch via `make run-dev`, verify Local-backend setup flow (new library creation) — reviewer to confirm
- [ ] Manual: launch via `make run-dev`, verify Immich-backend setup flow and sync — reviewer to confirm
- [ ] Manual: launch with stale GSettings library path (delete the library dir, then start) — verify recovery into setup wizard with the stale-path dialog
- [ ] Manual: trigger an import — verify the import dialog and run flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)