### PR TITLE
chore(deps): bump jxl-grid 0.6.1 → 0.6.2 (RUSTSEC-2026-0151)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e0ef92d5d60e76bf41098e57e985f523185e08fad54268da448637feca6989"
+checksum = "01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb"
 dependencies = [
  "tracing",
 ]


### PR DESCRIPTION
## Summary

- Bumps transitive dependency `jxl-grid` from `0.6.1` to `0.6.2` to resolve [RUSTSEC-2026-0151](https://rustsec.org/advisories/RUSTSEC-2026-0151) ("Out-of-bounds writes due to integer overflow in jxl-grid on 32-bit platforms"), published 2026-05-29.
- Pulled transitively: `moments` → `rawler 0.7.2` → `jxl-oxide 0.12.5` → `jxl-grid`. Resolved via `cargo update -p jxl-grid` — no `Cargo.toml` change needed; the existing semver requirement on `jxl-oxide`'s side accepted the patch release.
- Single-file change to `Cargo.lock` (version + checksum).

## Background

The advisory landed between main's last successful Security workflow run (2026-05-25) and PR #663's first run (2026-05-29), causing the security checks to fail on #663 despite that PR not touching any dependencies. Addressing this on its own branch keeps the refactor PR clean and lets the dep bump land on main first.

## Test plan

- [x] `make audit` — "advisories ok, bans ok, licenses ok, sources ok"
- [x] `make lint` — clean (cargo fmt + clippy `-D warnings`, both default and `--features dhat-heap`)
- [x] `make test` — 611 passed, 0 failed (matches main baseline)
- [ ] Manual smoke test (reviewer): open a JPEG XL image to confirm the patched `jxl-grid` decode path still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)