### PR TITLE
fix: resolve all cargo audit/deny advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,31 @@
+# cargo-audit configuration.
+#
+# Why this file exists: cargo-audit reads Cargo.lock, and Cargo resolves the
+# lockfile *feature-agnostically* — it lists every optional dependency of every
+# crate in the graph, whether or not an enabled feature activates it. So
+# cargo-audit can fire on crates that are never compiled into the binary.
+# cargo-deny does not have this problem: its graph comes from `cargo metadata`
+# and honours the real feature set.
+#
+# Keeping the ignore list here rather than as a `--ignore` flag means it lives
+# in one place (local `make audit` and CI both pick it up) and each entry can
+# carry the reasoning for why it is safe to ignore.
+#
+# Every entry must say either why the code is unreachable, or why no fix exists.
+
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071 — "Marvin attack": timing side-channel in `rsa`
+    # allowing potential key recovery. No fixed version exists upstream.
+    #
+    # Not exposed. `rsa` only reaches Cargo.lock through sqlx-macros-core's
+    # *optional* sqlx-mysql dependency; we enable only the sqlite driver, so
+    # neither sqlx-mysql nor rsa is ever compiled or linked. Verified with:
+    #
+    #     cargo tree -i rsa --target all -e all   → "nothing to print"
+    #
+    # cargo-deny agrees and does not flag it; only cargo-audit does, because
+    # it reads the lockfile directly. Revisit if a sqlx driver change ever
+    # puts rsa into the built graph.
+    "RUSTSEC-2023-0071",
+]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Run audit
         id: audit
         run: |
-          OUTPUT=$(cargo audit --ignore RUSTSEC-2023-0071 2>&1) || true
+          # Ignores live in .cargo/audit.toml, with the reasoning for each.
+          OUTPUT=$(cargo audit 2>&1) || true
           echo "$OUTPUT"
 
           if echo "$OUTPUT" | grep -q "vulnerability found"; then
@@ -41,7 +42,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           # Fail if real vulnerabilities (not just warnings).
-          cargo audit --ignore RUSTSEC-2023-0071
+          cargo audit
 
   deny:
     name: Cargo deny

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-trait"
@@ -262,6 +262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,15 +283,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -300,6 +302,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -340,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -489,11 +500,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -762,36 +772,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "gettext-rs"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5857dc1b7f0fee86961de833f434e29494d72af102ce5355738c0664222bdf"
+checksum = "9df5e3fa8c077b15fdfa8ce130e2bc73d663b8aaa6d51b71421b8659980b1d80"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -1657,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-grid"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e0ef92d5d60e76bf41098e57e985f523185e08fad54268da448637feca6989"
+checksum = "01671307879a033bfa52e6e8784b941aca770b3f3a7d33830b455b6844f793fb"
 dependencies = [
  "tracing",
 ]
@@ -1991,9 +1990,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.0",
 ]
@@ -2046,9 +2045,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -2561,9 +2560,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2590,14 +2589,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2634,12 +2634,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2651,18 +2645,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2676,16 +2671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,11 +2681,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3074,7 +3065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3085,7 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dhat-heap = ["dep:dhat"]
 # GTK/GNOME — keep these version-aligned
 gtk = { version = "0.11", features = ["gnome_50"], package = "gtk4" }
 adw = { version = "0.9", features = ["v1_9"], package = "libadwaita" }
-gettext-rs = { version = "0.7", features = ["gettext-system"] }
+gettext-rs = { version = "0.8", features = ["gettext-system"] }
 
 # Async runtime
 async-trait = "0.1"
@@ -43,7 +43,7 @@ toml = "0.8"
 # XMP read-back robustness — embedded edits in rendered JPEGs need to
 # survive Immich's media pipeline rewriting attributes/whitespace.
 # Encode is still hand-rolled for deterministic output.
-quick-xml = "0.39"
+quick-xml = "0.41"
 
 # Image processing
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp", "tiff"] }

--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,21 @@ fmt-check:
 typos:
 	typos
 
+# cargo-audit and cargo-deny aren't part of the SDK, and assuming a host
+# install means `make audit` dies with "no such command" on a fresh machine.
+# Install them into a persistent root under target/ (the SDK's /tmp is
+# per-sandbox, so anything installed there is gone next invocation) and
+# reuse them on later runs.
+AUDIT_TOOLS = $(CURDIR)/target/audit-tools
+
 audit:
-	cargo audit --ignore RUSTSEC-2023-0071
-	cargo deny check
+	$(FLATPAK_RUN) -c '$(SDK_INIT) && \
+		export CARGO_INSTALL_ROOT=$(AUDIT_TOOLS) && \
+		export PATH=$(AUDIT_TOOLS)/bin:$$PATH && \
+		{ command -v cargo-audit >/dev/null || cargo install cargo-audit --locked; } && \
+		{ command -v cargo-deny  >/dev/null || cargo install cargo-deny  --locked; } && \
+		cargo audit && \
+		cargo deny check'
 
 coverage:
 	$(FLATPAK_RUN) -c '$(SDK_INIT) && \


### PR DESCRIPTION
`cargo deny check` has been failing on main since at least 2026-07-27 with `advisories FAILED` — five vulnerabilities, three of them 7.5 high. Fixed by version bumps; no new ignores were added.

Reachable by targeted `cargo update`:

  crossbeam-epoch  0.9.18  -> 0.9.20   RUSTSEC-2026-0204 (>=0.9.20)
  jxl-grid         0.6.1   -> 0.6.2    RUSTSEC-2026-0151 (>=0.6.2)
  quinn-proto      0.11.14 -> 0.11.16  RUSTSEC-2026-0185 (>=0.11.15, high)
  lru              0.18.0  -> 0.18.2   RUSTSEC-2026-0253 (>=0.18.2)
  anyhow           1.0.102 -> 1.0.104  RUSTSEC-2026-0190
  event-listener   5.4.1   -> 5.4.2    RUSTSEC-2026-0221
  memmap2          0.9.10  -> 0.9.11   RUSTSEC-2026-0186

Needing a Cargo.toml bump, because the pin sat below the fixed version:

  quick-xml   0.39 -> 0.41  RUSTSEC-2026-0194 + 0195, both 7.5 high
                            (quadratic attribute parsing, unbounded
                            namespace allocation — DoS on XMP input)
  gettext-rs  0.7  -> 0.8   RUSTSEC-2026-0244 (unsynchronised setlocale)

Neither needed a code change: src/renderer/xmp.rs and src/main.rs compile unmodified against the new APIs. `rand` moves 0.9 -> 0.10 transitively via the quinn chain; it is not a direct dependency and deny.toml permits the duplicate.

Also fixes two things the investigation turned up:

- `make audit` shelled out to host cargo-audit/cargo-deny, so on a machine without them it failed with "no such command" rather than reporting advisories. It now runs in the SDK and installs the tools into a persistent target/audit-tools root — the SDK's /tmp is per-sandbox, so tools installed there don't survive to the next invocation.

- `--ignore RUSTSEC-2023-0071` was duplicated across the Makefile and two places in security.yml with no explanation anywhere. Moved to a single documented entry in .cargo/audit.toml. That ignore is still required: cargo-audit reads Cargo.lock, which Cargo resolves feature-agnostically, so it sees `rsa` even though only the sqlite driver is enabled and rsa is never compiled (`cargo tree -i rsa --target all -e all` prints nothing). cargo-deny's graph honours features and never flagged it.

Remaining warnings are non-vulnerabilities with no action available: paste unmaintained via gstreamer (ignore is load-bearing — cargo-deny 0.20.2 treats unmaintained as an error) and spin yanked via flume -> sqlx-sqlite.

cargo-sources.json is deliberately untouched: it is a matched pair with flathub.json's v0.3.0 pin (quick-xml and lru are absent from it because they post-date that tag), so regenerating it now against 0.4.0's lockfile would break that pairing. It belongs with the next Flathub tag bump.

Verified: make audit exits 0 (advisories ok, bans ok, licenses ok, sources ok), make lint clean, make test 611 passed / 0 failed.

## Summary

Brief description of what this PR does and why.

Closes #<!-- issue number -->

## Changes

-

## Test Plan

- [ ] `cargo test` passes
- [ ] Tested manually via `make run` or GNOME Builder
-

## Screenshots

<!-- If applicable -->
