### PR TITLE
ci: install manifest deps before building the bundle

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -81,12 +81,23 @@ jobs:
           echo "homedir=$GNUPGHOME" >> "$GITHUB_OUTPUT"
           echo "key_id=$GPG_KEY_ID" >> "$GITHUB_OUTPUT"
 
+      # --install-deps-from pulls the runtime, SDK and sdk-extensions the
+      # manifest declares. Without it flatpak-builder can't read the SDK's
+      # extension point (which pins org.freedesktop.Sdk.Extension to 25.08)
+      # and falls back to the runtime's own branch, asking for a
+      # rust-stable/x86_64/50 that doesn't exist:
+      #
+      #   error: Requested extension org.freedesktop.Sdk.Extension.rust-stable/x86_64/50 not installed
+      #
+      # ci.yml doesn't hit this because the flatpak-builder action installs
+      # deps for you. Resolving it from the manifest rather than pinning
+      # 25.08 here keeps it correct across future GNOME SDK bumps.
       - name: Build bundle
         run: |
           make bundle \
             GPG_KEY='${{ steps.gpg.outputs.key_id }}' \
             GPG_HOMEDIR='${{ steps.gpg.outputs.homedir }}' \
-            FLATPAK_BUILDER_ARGS='--disable-rofiles-fuse'
+            FLATPAK_BUILDER_ARGS='--disable-rofiles-fuse --install-deps-from=flathub'
 
       - name: Export public signing key
         if: steps.gpg.outputs.key_id != ''


### PR DESCRIPTION
## Problem

The first real `bundle.yml` run ([31693926391](https://github.com/justinf555/Moments/actions/runs/31693926391)) failed after 1m41s:

```
error: Requested extension org.freedesktop.Sdk.Extension.rust-stable/x86_64/50 not installed
```

`org.gnome.Sdk//50` declares its extension point as:

```
[Extension org.freedesktop.Sdk.Extension]
version = 25.08
```

so the correct branch is **25.08** — which is why this builds fine locally, where that extension is installed. In the CI container flatpak-builder couldn't resolve the extension point and fell back to the runtime's own branch, requesting a `rust-stable//50` that doesn't exist on Flathub.

`ci.yml` never hit this because it drives flatpak-builder through the `flatpak-github-actions` action, which installs manifest deps itself. `bundle.yml` calls flatpak-builder directly via `make bundle`.

## Fix

Pass `--install-deps-from=flathub` through the existing `FLATPAK_BUILDER_ARGS` hook. Resolving the branch from the manifest beats pinning `25.08` here, which would drift at the next GNOME SDK bump. CI-only, so a local `make bundle` still won't install anything behind the user's back.

## Verification

Dispatched `bundle.yml` against this branch — [run 31694281312](https://github.com/justinf555/Moments/actions/runs/31694281312), **success in 8m3s**. Artifact downloaded and checked:

| File | |
|---|---|
| `moments-0.4.0-x86_64.flatpak` | 5.6M, `sha256 -c` → OK |
| `moments-0.4.0-x86_64.flatpak.sha256` | |
| `moments-releases.asc` | ed25519, signing active |

Bundle metadata is correct: `app/io.github.justinf555.Moments/x86_64/master`, `runtime=org.gnome.Platform/x86_64/50`, `command=moments`.

Note this failure was only reachable in CI — locally the extension is installed, so `make bundle` would never have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)