### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "moments"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moments"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A GNOME photo management app with local and Immich server support"
 license = "GPL-3.0-or-later"

--- a/data/io.github.justinf555.Moments.metainfo.xml.in
+++ b/data/io.github.justinf555.Moments.metainfo.xml.in
@@ -64,6 +64,16 @@
   </screenshots>
 
   <releases>
+    <release version="0.4.1" date="2026-08-13">
+      <description translate="no">
+        <p>Downloadable Flatpak bundles and security updates.</p>
+        <ul>
+          <li>Releases now ship an installable Flatpak bundle you can download and install directly, with a checksum and a GPG signature</li>
+          <li>Updated dependencies to address five security advisories, including denial-of-service issues in XML parsing</li>
+          <li>Build and packaging fixes for people building Moments from source</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.4.0" date="2026-05-13">
       <description translate="no">
         <p>Non-destructive editing and bidirectional sync for edits.</p>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('moments', 'rust', 
-          version: '0.4.0',
+          version: '0.4.1',
     meson_version: '>= 1.0.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )


### PR DESCRIPTION
Bump version to 0.4.1.

**Merging this PR triggers `release.yml`**, which will:

1. Create the annotated tag `v0.4.1`
2. Create the GitHub Release
3. Build the Flatpak bundle from that tag via `bundle.yml`
4. Attach `moments-0.4.1-x86_64.flatpak`, its `.sha256`, and `moments-releases.asc`

Giving the first public, linkable download:

```
https://github.com/justinf555/Moments/releases/download/v0.4.1/moments-0.4.1-x86_64.flatpak
```

This matters because `main`'s README already documents installing from a release bundle, and the current latest release (`v0.4.0`) has no assets.

## Contents

Everything merged since v0.4.0:

- Redistributable Flatpak bundle pipeline (#668) — `make bundle`, `bundle.yml`, release attachment, GPG signing
- Five security advisories fixed by dependency bumps (#669) — quick-xml 0.39→0.41 and gettext-rs 0.7→0.8 among them
- CI dep-install fix so `bundle.yml` passes (#670)

## Notes

- First execution of the `tag-and-release` → `bundle` → `publish` chain. The bundle job itself is already proven by `workflow_dispatch` [run 31694281312](https://github.com/justinf555/Moments/actions/runs/31694281312), whose artifact was downloaded, checksum-verified, signature-verified and installed.
- `Cargo.lock` was regenerated with `make check` rather than relying on the `cargo check || true` in `make release`, which no-ops where host cargo can't build the project.
- AppStream release notes validated: `appstreamcli validate --no-net` → successful, 1 pedantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)