### PR TITLE
chore: adopt REUSE-compliant SPDX licensing headers

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # cargo-audit configuration.
 #
 # Why this file exists: cargo-audit reads Cargo.lock, and Cargo resolves the

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 [profile.ci]
 # JUnit XML output for Codecov Test Analytics.
 [profile.ci.junit]

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Flatpak bundle
 
 # Builds the redistributable single-file Flatpak bundle (`make bundle`) and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: CI
 
 on:
@@ -15,6 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@v1
+
+  reuse:
+    name: REUSE compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fsfe/reuse-action@v5
 
   build-and-test:
     name: Build & test
@@ -36,7 +46,7 @@ jobs:
   summary:
     name: CI summary
     runs-on: ubuntu-latest
-    needs: [typos, build-and-test]
+    needs: [typos, reuse, build-and-test]
     if: github.event_name == 'pull_request' && always()
 
     steps:
@@ -50,6 +60,7 @@ jobs:
             | Check | Status |
             |-------|--------|
             | Typo check | ${{ needs.typos.result == 'success' && '✅ Pass' || '❌ Fail' }} |
+            | REUSE compliance | ${{ needs.reuse.result == 'success' && '✅ Pass' || '❌ Fail' }} |
             | Build & test (fmt + clippy + unit + integration) | ${{ needs.build-and-test.result == 'success' && '✅ Pass' || '❌ Fail' }} |
 
             <sub>[full run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Claude Code Review
 
 on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Claude Code
 
 on:

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Metrics
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Release
 
 on:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 name: Security
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 [package]
 name = "moments"
 version = "0.4.1"

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/LICENSES/GPL-3.0-or-later.txt
+++ b/LICENSES/GPL-3.0-or-later.txt
@@ -1,0 +1,675 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 .PHONY: run run-dev run-dhat dev-bootstrap dev clean clean-dev clean-bundle \
         check test test-nextest test-integration test-all \
         lint fmt fmt-check typos audit coverage metrics \

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+version = 1
+SPDX-PackageName = "Moments"
+SPDX-PackageDownloadLocation = "https://github.com/justinf555/Moments"
+
+# Documentation and repository metadata.
+[[annotations]]
+path = [
+    "README.md",
+    "ARCHITECTURE.md",
+    "CHANGELOG.md",
+    "CLAUDE.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md",
+    "docs/**.md",
+    ".github/pull_request_template.md",
+    ".github/ISSUE_TEMPLATE/**.md",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Justin F"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# Adapted from the Contributor Covenant v2.1, which is CC-BY-4.0.
+[[annotations]]
+path = "CODE_OF_CONDUCT.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Contributor Covenant contributors"
+SPDX-License-Identifier = "CC-BY-4.0"
+
+# Verbatim GPLv3 text, kept at the root for GitHub license detection.
+[[annotations]]
+path = "COPYING"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2007 Free Software Foundation, Inc."
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# JSON has no comment syntax; Cargo.lock and cargo-sources.json are generated.
+[[annotations]]
+path = [
+    ".gitignore",
+    ".vscode/*.json",
+    "Cargo.lock",
+    "cargo-sources.json",
+    "io.github.justinf555.Moments*.json",
+    "build-aux/*.json",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Justin F"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# AppStream, desktop and GSettings templates are left byte-exact so that
+# appstream-util and desktop-file-validate see exactly what ships.
+[[annotations]]
+path = "data/io.github.justinf555.Moments.*.in"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Justin F"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# Binary and vector assets carry no comments.
+[[annotations]]
+path = [
+    "data/icons/**.svg",
+    "data/screenshots/*.png",
+]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Justin F"
+SPDX-License-Identifier = "GPL-3.0-or-later"
+
+# Migrations must stay byte-exact: sqlx records a checksum of each applied
+# migration in _sqlx_migrations and refuses to run if the file changes.
+[[annotations]]
+path = "src/library/db/migrations/*.sql"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Justin F"
+SPDX-License-Identifier = "GPL-3.0-or-later"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 [files]
 extend-exclude = [
     "*.svg",

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 coverage:
   status:
     project:

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 scalable_dir = 'hicolor' / 'scalable' / 'apps'
 install_data(
   scalable_dir / ('@0@.svg').format(application_id),

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 data_conf = configuration_data()
 data_conf.set('APP_ID', application_id)
 data_conf.set('APP_PATH', application_id.replace('.', '/'))

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 [advisories]
 version = 2
 ignore = [

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 project('moments', 'rust', 
           version: '0.4.1',
     meson_version: '>= 1.0.0',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 option('profile', type: 'combo', choices: ['default', 'development'], value: 'default',
        description: 'Build profile: "default" for production, "development" for Devel app ID')
 option('dhat-heap', type: 'boolean', value: false,

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # Please keep this file sorted alphabetically.

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # List of source files containing translatable strings.
 # Please keep this file sorted alphabetically.
 data/io.github.justinf555.Moments.desktop.in

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 i18n.gettext('moments', preset: 'glib')

--- a/scripts/complexity-report.py
+++ b/scripts/complexity-report.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 """Parse rust-code-analysis JSON output into a complexity summary table.
 
 Usage: rust-code-analysis-cli --metrics -O json -p src/ | python3 scripts/complexity-report.py

--- a/src/application/keyring.rs
+++ b/src/application/keyring.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! GNOME Keyring integration for storing Immich session tokens.
 //!
 //! Thin wrapper around `libsecret` — the keyring is an application-level

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,22 +1,5 @@
-/* application.rs
- *
- * Copyright 2026 Unknown
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 pub mod keyring;
 
@@ -336,11 +319,11 @@ impl MomentsApplication {
         let about = adw::AboutDialog::builder()
             .application_name(app_name)
             .application_icon(APP_ID)
-            .developer_name("Unknown")
+            .developer_name("Justin F")
             .version(VERSION)
-            .developers(vec!["Unknown"])
+            .developers(vec!["Justin F"])
             .translator_credits(gettext("translator-credits"))
-            .copyright("© 2026 Unknown")
+            .copyright("© 2026 Justin F")
             .build();
 
         about.present(Some(&window));

--- a/src/client/album/client_v2.rs
+++ b/src/client/album/client_v2.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/client/album/mod.rs
+++ b/src/client/album/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod client_v2;
 pub mod model;
 mod picker_data;

--- a/src/client/album/model.rs
+++ b/src/client/album/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 
 use gtk::{gdk, glib, prelude::*, subclass::prelude::*};

--- a/src/client/album/picker_data.rs
+++ b/src/client/album/picker_data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Data types for the album picker dialog.
 
 use crate::library::album::AlbumId;

--- a/src/client/import/client.rs
+++ b/src/client/import/client.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/client/import/event.rs
+++ b/src/client/import/event.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::importer::{ImportProgress, ImportSummary};
 
 /// Client-internal events for decoupling the import pipeline from

--- a/src/client/import/mod.rs
+++ b/src/client/import/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod client;
 mod event;
 

--- a/src/client/media/client_v2.rs
+++ b/src/client/media/client_v2.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/src/client/media/mod.rs
+++ b/src/client/media/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod client_v2;
 pub mod model;
 

--- a/src/client/media/model.rs
+++ b/src/client/media/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, OnceCell, RefCell};
 
 use gtk::{gdk, glib, prelude::*, subclass::prelude::*};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod album;
 pub mod import;
 pub mod media;

--- a/src/client/people/client_v2.rs
+++ b/src/client/people/client_v2.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::sync::Arc;
 

--- a/src/client/people/mod.rs
+++ b/src/client/people/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod client_v2;
 pub mod model;
 

--- a/src/client/people/model.rs
+++ b/src/client/people/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 

--- a/src/client/sync/client.rs
+++ b/src/client/sync/client.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 
 use gtk::glib;

--- a/src/client/sync/mod.rs
+++ b/src/client/sync/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod client;
 
 pub use client::{SyncClient, SyncState};

--- a/src/config.rs.in
+++ b/src/config.rs.in
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub static VERSION: &str = @VERSION@;
 pub static GETTEXT_PACKAGE: &str = @GETTEXT_PACKAGE@;
 pub static LOCALEDIR: &str = @LOCALEDIR@;

--- a/src/event_emitter.rs
+++ b/src/event_emitter.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Multi-subscriber event fan-out primitive used by library services.
 //!
 //! Each service holds one `EventEmitter<Event>` as a private field. The

--- a/src/importer/builder.rs
+++ b/src/importer/builder.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/src/importer/discovery.rs
+++ b/src/importer/discovery.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::{Path, PathBuf};
 
 use tracing::warn;

--- a/src/importer/error.rs
+++ b/src/importer/error.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::library::error::LibraryError;
 use crate::renderer::error::RenderError;
 

--- a/src/importer/filter.rs
+++ b/src/importer/filter.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use crate::library::media::MediaType;

--- a/src/importer/hasher.rs
+++ b/src/importer/hasher.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use base64::engine::general_purpose::STANDARD as B64;

--- a/src/importer/metadata.rs
+++ b/src/importer/metadata.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use tracing::instrument;

--- a/src/importer/mod.rs
+++ b/src/importer/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod builder;
 pub mod discovery;
 mod error;

--- a/src/importer/persistence.rs
+++ b/src/importer/persistence.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src/importer/pipeline.rs
+++ b/src/importer/pipeline.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;

--- a/src/importer/thumbnail.rs
+++ b/src/importer/thumbnail.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Thumbnail generation for imported assets.
 //!
 //! Wraps the render pipeline with I/O and DB bookkeeping:

--- a/src/importer/types.rs
+++ b/src/importer/types.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::library::media::MediaId;
 
 /// Reason a source file was skipped without being imported.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod application;
 
 mod user_facing_error;

--- a/src/library/album/event.rs
+++ b/src/library/album/event.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::model::AlbumId;
 
 /// Events emitted by `AlbumService` after state changes.

--- a/src/library/album/mod.rs
+++ b/src/library/album/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod event;
 mod model;
 pub mod repository;

--- a/src/library/album/model.rs
+++ b/src/library/album/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::super::media::MediaId;
 
 /// Unique identifier for an album (UUID v4).

--- a/src/library/album/repository.rs
+++ b/src/library/album/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::collections::HashMap;
 
 use super::model::{Album, AlbumId};

--- a/src/library/album/service.rs
+++ b/src/library/album/service.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/src/library/bundle/mod.rs
+++ b/src/library/bundle/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/src/library/config/mod.rs
+++ b/src/library/config/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /// How the local backend stores original photos.
 ///
 /// Written into the `[local]` section of `library.toml` so the correct

--- a/src/library/db/mod.rs
+++ b/src/library/db/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 use std::time::Duration;
 

--- a/src/library/editing/mod.rs
+++ b/src/library/editing/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod model;
 pub mod repository;
 mod service;

--- a/src/library/editing/model.rs
+++ b/src/library/editing/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use serde::{Deserialize, Serialize};
 
 /// Normalized crop rectangle with coordinates in the 0.0–1.0 range,

--- a/src/library/editing/repository.rs
+++ b/src/library/editing/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::library::db::Database;
 use crate::library::error::LibraryError;
 use crate::library::media::MediaId;

--- a/src/library/editing/service.rs
+++ b/src/library/editing/service.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::sync::Arc;
 
 use super::model::EditState;

--- a/src/library/error/mod.rs
+++ b/src/library/error/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use gettextrs::gettext;
 
 use crate::UserFacingError;

--- a/src/library/faces/event.rs
+++ b/src/library/faces/event.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::model::PersonId;
 
 /// Events emitted by `FacesService` after state changes.

--- a/src/library/faces/mod.rs
+++ b/src/library/faces/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod event;
 mod model;
 pub mod repository;

--- a/src/library/faces/model.rs
+++ b/src/library/faces/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /// Unique identifier for a person (Immich UUID or future local ID).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PersonId(String);

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::library::db::Database;
 use crate::library::error::LibraryError;
 

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::sync::Arc;
 
 use tokio::sync::mpsc;

--- a/src/library/media/event.rs
+++ b/src/library/media/event.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::model::MediaId;
 
 /// Events emitted by `MediaService` after state changes.

--- a/src/library/media/mod.rs
+++ b/src/library/media/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod event;
 mod model;
 pub mod repository;

--- a/src/library/media/model.rs
+++ b/src/library/media/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /// Opaque identity for every media asset in the library.
 ///
 /// A UUID v4 stored as a 32-char lowercase hex string (no dashes).

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::model::{MediaCursor, MediaFilter, MediaId, MediaItem, MediaRecord, MediaType, Stack};
 use crate::library::db::{id_placeholders, Database, LibraryStats};
 use crate::library::error::LibraryError;

--- a/src/library/media/service.rs
+++ b/src/library/media/service.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/src/library/metadata/exif.rs
+++ b/src/library/metadata/exif.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use tracing::{instrument, warn};

--- a/src/library/metadata/mod.rs
+++ b/src/library/metadata/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod exif;
 mod model;
 pub mod repository;

--- a/src/library/metadata/model.rs
+++ b/src/library/metadata/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::super::media::MediaId;
 
 /// A row in the `media_metadata` table — full EXIF detail, loaded on demand.

--- a/src/library/metadata/repository.rs
+++ b/src/library/metadata/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::model::MediaMetadataRecord;
 use crate::library::db::Database;
 use crate::library::error::LibraryError;

--- a/src/library/metadata/service.rs
+++ b/src/library/metadata/service.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::model::MediaMetadataRecord;
 use super::repository::MetadataRepository;
 use crate::library::db::Database;

--- a/src/library/metadata/video_meta.rs
+++ b/src/library/metadata/video_meta.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use gstreamer as gst;

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod album;
 pub mod bundle;
 pub mod config;

--- a/src/library/mutation.rs
+++ b/src/library/mutation.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Library mutation types.
 //!
 //! Every state change the library can produce is represented as a

--- a/src/library/recorder.rs
+++ b/src/library/recorder.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Mutation recording trait.
 //!
 //! Services call [`MutationRecorder::record`] after each successful

--- a/src/library/resolver.rs
+++ b/src/library/resolver.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Original file resolution trait.
 //!
 //! Abstracts how the original asset file is located or fetched.

--- a/src/library/thumbnail/event.rs
+++ b/src/library/thumbnail/event.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::library::media::MediaId;
 
 /// Events emitted by `ThumbnailService` after thumbnail state changes.

--- a/src/library/thumbnail/mod.rs
+++ b/src/library/thumbnail/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod event;
 mod model;
 pub mod repository;

--- a/src/library/thumbnail/model.rs
+++ b/src/library/thumbnail/model.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /// Processing state of a single thumbnail, mirroring the `thumbnails.status` column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i64)]

--- a/src/library/thumbnail/repository.rs
+++ b/src/library/thumbnail/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use crate::library::db::Database;
 use crate::library::error::LibraryError;
 use crate::library::media::MediaId;

--- a/src/library/thumbnail/service.rs
+++ b/src/library/thumbnail/service.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::PathBuf;
 
 use tokio::sync::mpsc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,5 @@
-/* main.rs
- *
- * Copyright 2026 Unknown
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 use moments::application::MomentsApplication;
 use moments::config;

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Justin F
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 pkgdatadir = get_option('prefix') / get_option('datadir') / meson.project_name()
 gnome = import('gnome')
 

--- a/src/moments.gresource.xml
+++ b/src/moments.gresource.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: 2026 Justin F -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
 <gresources>
   <gresource prefix="/io/github/justinf555/Moments">
     <file preprocess="xml-stripblanks">ui/window/window.ui</file>

--- a/src/renderer/decode.rs
+++ b/src/renderer/decode.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Image decode step.
 //!
 //! Decodes an image file using magic-byte format detection. This is the

--- a/src/renderer/edits.rs
+++ b/src/renderer/edits.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Edit application step.
 //!
 //! Applies non-destructive edits (transforms, exposure, color) to a

--- a/src/renderer/error.rs
+++ b/src/renderer/error.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Render pipeline errors.
 
 use std::path::PathBuf;

--- a/src/renderer/format/detect.rs
+++ b/src/renderer/format/detect.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::io::Read;
 use std::path::Path;
 

--- a/src/renderer/format/mod.rs
+++ b/src/renderer/format/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod detect;
 pub(crate) mod raw;
 pub(crate) mod registry;

--- a/src/renderer/format/raw.rs
+++ b/src/renderer/format/raw.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use rawler::decoders::RawDecodeParams;

--- a/src/renderer/format/registry.rs
+++ b/src/renderer/format/registry.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;

--- a/src/renderer/format/standard.rs
+++ b/src/renderer/format/standard.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use crate::renderer::error::RenderError;

--- a/src/renderer/format/video.rs
+++ b/src/renderer/format/video.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::path::Path;
 
 use gstreamer as gst;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Unified render pipeline.
 //!
 //! Each step is a separate module:

--- a/src/renderer/orientation.rs
+++ b/src/renderer/orientation.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! EXIF orientation correction.
 //!
 //! Pipeline step: reads the EXIF orientation tag from the source file

--- a/src/renderer/output.rs
+++ b/src/renderer/output.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Output helpers.
 //!
 //! Convenience functions for converting a `DynamicImage` into the

--- a/src/renderer/pipeline.rs
+++ b/src/renderer/pipeline.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Unified render pipeline.
 //!
 //! Central, stateless orchestrator that composes the individual step

--- a/src/renderer/resize.rs
+++ b/src/renderer/resize.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Resize step.
 //!
 //! Resizes an image to fit within a maximum edge length, preserving

--- a/src/renderer/target.rs
+++ b/src/renderer/target.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Render-target hint for edit stages.
 //!
 //! Lives in its own module so both [`super::pipeline`] and [`super::edits`]

--- a/src/renderer/xmp.rs
+++ b/src/renderer/xmp.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! XMP encode/decode + JPEG APP1 segment injection.
 //!
 //! Phase C (#224) embeds a Moments-specific XMP block in every

--- a/src/shortcuts-dialog.blp
+++ b/src/shortcuts-dialog.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
+/* SPDX-FileCopyrightText: 2026 Justin F
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 /* ── Selection highlighting for the photo grid ────────────────────────────
  *
  * Selection is driven by checkboxes via the app-owned SelectionState

--- a/src/sync/event.rs
+++ b/src/sync/event.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /// Events emitted by the sync engine for UI state tracking.
 ///
 /// Consumed by `SyncClient` to update GObject properties.

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Bidirectional sync engine.
 //!
 //! Backend-agnostic orchestration lives here (`SyncHandle`, `outbox/`).

--- a/src/sync/outbox/mod.rs
+++ b/src/sync/outbox/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! [`MutationRecorder`] implementations and outbox persistence.
 //!
 //! - [`NoOpRecorder`] — local backend, does nothing.

--- a/src/sync/outbox/mutation.rs
+++ b/src/sync/outbox/mutation.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Single-entity mutation type used by the push manager.
 //!
 //! [`Mutation`](crate::library::mutation::Mutation) is the in-process

--- a/src/sync/outbox/repository.rs
+++ b/src/sync/outbox/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Outbox table persistence.
 
 use tracing::{debug, info, instrument};

--- a/src/sync/providers/immich/client.rs
+++ b/src/sync/providers/immich/client.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! HTTP client for the Immich server API.
 //!
 //! Uses session-based authentication (`Authorization: Bearer {token}`).

--- a/src/sync/providers/immich/edit_action.rs
+++ b/src/sync/providers/immich/edit_action.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Immich-shaped projection of [`EditState`].
 //!
 //! Immich's `PUT /assets/{id}/edits` API takes an ordered array of

--- a/src/sync/providers/immich/handlers/album.rs
+++ b/src/sync/providers/immich/handlers/album.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::{instrument, warn};
 

--- a/src/sync/providers/immich/handlers/album_asset.rs
+++ b/src/sync/providers/immich/handlers/album_asset.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::warn;
 

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::{debug, instrument};
 

--- a/src/sync/providers/immich/handlers/asset_edit.rs
+++ b/src/sync/providers/immich/handlers/asset_edit.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Pull-side handlers for Immich's per-action edit stream.
 //!
 //! Each `SyncAssetEditV1` carries one geometric action (`crop`,

--- a/src/sync/providers/immich/handlers/asset_exif.rs
+++ b/src/sync/providers/immich/handlers/asset_exif.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::warn;
 

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::{instrument, warn};
 

--- a/src/sync/providers/immich/handlers/mod.rs
+++ b/src/sync/providers/immich/handlers/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Sync entity handlers.
 //!
 //! Each handler processes one Immich sync entity type (e.g. `AssetV1`,

--- a/src/sync/providers/immich/handlers/person.rs
+++ b/src/sync/providers/immich/handlers/person.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::{debug, instrument};
 

--- a/src/sync/providers/immich/handlers/stack.rs
+++ b/src/sync/providers/immich/handlers/stack.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 use tracing::{instrument, warn};
 

--- a/src/sync/providers/immich/handlers/sync_lifecycle.rs
+++ b/src/sync/providers/immich/handlers/sync_lifecycle.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use async_trait::async_trait;
 
 use crate::library::error::LibraryError;

--- a/src/sync/providers/immich/mod.rs
+++ b/src/sync/providers/immich/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Immich sync provider.
 //!
 //! Implements bidirectional sync with an Immich server:

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Pull sync manager — streams changes from Immich and upserts locally.
 //!
 //! Connects to `POST /sync/stream`, processes NDJSON entity records,

--- a/src/sync/providers/immich/push.rs
+++ b/src/sync/providers/immich/push.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Push sync manager — drains the outbox and pushes local mutations to Immich.
 //!
 //! Reads pending entries from the `sync_outbox` table, maps each to an

--- a/src/sync/providers/immich/resolver.rs
+++ b/src/sync/providers/immich/resolver.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Cached original resolver for the Immich backend.
 //!
 //! Checks if the original file is cached locally. On miss, fetches from

--- a/src/sync/providers/immich/types.rs
+++ b/src/sync/providers/immich/types.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Sync protocol deserialization types for the Immich `/sync/stream` endpoint.
 //!
 //! All types are newline-delimited JSON (NDJSON) sent by the server.

--- a/src/sync/providers/mod.rs
+++ b/src/sync/providers/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Sync backend providers.
 //!
 //! Each provider implements the pull/push protocol for a specific server.

--- a/src/sync/state/mod.rs
+++ b/src/sync/state/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Sync-engine state persistence: ack checkpoints + per-line audit log.
 //!
 //! These tables are sync-engine concerns (resume points, error tracing)

--- a/src/sync/state/repository.rs
+++ b/src/sync/state/repository.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! `sync_checkpoints` + `sync_audit` table persistence.
 //!
 //! Both tables are owned by the Immich pull engine: checkpoints record

--- a/src/tasks/mod.rs
+++ b/src/tasks/mod.rs
@@ -1,1 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod purge_trash;

--- a/src/tasks/purge_trash.rs
+++ b/src/tasks/purge_trash.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Periodic auto-purge of expired trash items.
 //!
 //! Runs on the Tokio runtime: queries for items past the retention period

--- a/src/ui/album_dialogs/mod.rs
+++ b/src/ui/album_dialogs/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 
 /// Show a dialog for creating a new album.

--- a/src/ui/album_grid/actions.rs
+++ b/src/ui/album_grid/actions.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::rc::Rc;
 
 use crate::application::MomentsApplication;

--- a/src/ui/album_grid/album_grid.blp
+++ b/src/ui/album_grid/album_grid.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/album_grid/card/card.blp
+++ b/src/ui/album_grid/card/card.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 
 template $MomentsAlbumCard : Gtk.Widget {

--- a/src/ui/album_grid/card/mod.rs
+++ b/src/ui/album_grid/card/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 
 use gettextrs::ngettext;

--- a/src/ui/album_grid/factory.rs
+++ b/src/ui/album_grid/factory.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::Cell;
 use std::rc::Rc;
 

--- a/src/ui/album_grid/mod.rs
+++ b/src/ui/album_grid/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::Cell;
 use std::rc::Rc;
 

--- a/src/ui/album_grid/selection.rs
+++ b/src/ui/album_grid/selection.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::rc::Rc;
 
 use adw::prelude::*;

--- a/src/ui/album_picker_dialog/album_row.rs
+++ b/src/ui/album_picker_dialog/album_row.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Album row widget for the album picker dialog.
 
 use adw::prelude::*;

--- a/src/ui/album_picker_dialog/dialog.rs
+++ b/src/ui/album_picker_dialog/dialog.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Album picker dialog widget.
 
 use std::cell::RefCell;

--- a/src/ui/album_picker_dialog/mod.rs
+++ b/src/ui/album_picker_dialog/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Album picker dialog — lets the user choose or create an album to add
 //! selected photos to.
 

--- a/src/ui/coordinator/mod.rs
+++ b/src/ui/coordinator/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::collections::HashMap;
 
 use gtk::prelude::*;

--- a/src/ui/empty_library/mod.rs
+++ b/src/ui/empty_library/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use gtk;
 

--- a/src/ui/import_dialog/import_dialog.blp
+++ b/src/ui/import_dialog/import_dialog.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/import_dialog/mod.rs
+++ b/src/ui/import_dialog/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib;
 use std::cell::{Cell, RefCell};

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod album_dialogs;
 pub mod album_grid;
 pub mod album_picker_dialog;

--- a/src/ui/people_grid/actions.rs
+++ b/src/ui/people_grid/actions.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::rc::Rc;
 
 use adw::prelude::*;

--- a/src/ui/people_grid/cell.blp
+++ b/src/ui/people_grid/cell.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/people_grid/cell.rs
+++ b/src/ui/people_grid/cell.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 
 use gettextrs::gettext;

--- a/src/ui/people_grid/factory.rs
+++ b/src/ui/people_grid/factory.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use gtk::{glib, prelude::*};
 
 use crate::application::MomentsApplication;

--- a/src/ui/people_grid/mod.rs
+++ b/src/ui/people_grid/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::Cell;
 use std::rc::Rc;
 

--- a/src/ui/people_grid/people_grid.blp
+++ b/src/ui/people_grid/people_grid.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/photo_grid/action_bar.rs
+++ b/src/ui/photo_grid/action_bar.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Factory for building context-sensitive action bar buttons.
 //!
 //! The action bar buttons change depending on which view the user is in:

--- a/src/ui/photo_grid/actions.rs
+++ b/src/ui/photo_grid/actions.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Context menu and album popover wiring for the photo grid.
 
 use std::cell::Cell;

--- a/src/ui/photo_grid/cell.blp
+++ b/src/ui/photo_grid/cell.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 
 template $MomentsPhotoGridCell : Gtk.Widget {

--- a/src/ui/photo_grid/cell.rs
+++ b/src/ui/photo_grid/cell.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 
 use gettextrs::gettext;

--- a/src/ui/photo_grid/factory.rs
+++ b/src/ui/photo_grid/factory.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::Cell;
 use std::rc::Rc;
 use std::sync::Arc;

--- a/src/ui/photo_grid/mod.rs
+++ b/src/ui/photo_grid/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 

--- a/src/ui/photo_grid/photo_grid.blp
+++ b/src/ui/photo_grid/photo_grid.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/photo_grid/selection.rs
+++ b/src/ui/photo_grid/selection.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! App-owned selection state for the photo grid.
 //!
 //! The grid uses [`gtk::NoSelection`] as its `GridView` selection model

--- a/src/ui/photo_grid/texture_cache.rs
+++ b/src/ui/photo_grid/texture_cache.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::num::NonZeroUsize;
 

--- a/src/ui/preferences_dialog/mod.rs
+++ b/src/ui/preferences_dialog/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use gtk::{gio, glib};
 use tracing::debug;

--- a/src/ui/setup_window/backend_picker_page.blp
+++ b/src/ui/setup_window/backend_picker_page.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/setup_window/backend_picker_page.rs
+++ b/src/ui/setup_window/backend_picker_page.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::glib;

--- a/src/ui/setup_window/immich_setup_page.blp
+++ b/src/ui/setup_window/immich_setup_page.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/setup_window/immich_setup_page.rs
+++ b/src/ui/setup_window/immich_setup_page.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::sync::OnceLock;
 

--- a/src/ui/setup_window/local_setup_page.blp
+++ b/src/ui/setup_window/local_setup_page.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/setup_window/local_setup_page.rs
+++ b/src/ui/setup_window/local_setup_page.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::sync::OnceLock;
 
 use adw::prelude::*;

--- a/src/ui/setup_window/mod.rs
+++ b/src/ui/setup_window/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod backend_picker_page;
 pub mod immich_setup_page;
 pub mod local_setup_page;

--- a/src/ui/setup_window/setup_window.blp
+++ b/src/ui/setup_window/setup_window.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/sidebar/mod.rs
+++ b/src/ui/sidebar/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod route;
 
 use std::cell::Cell;

--- a/src/ui/sidebar/route.rs
+++ b/src/ui/sidebar/route.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use gettextrs::gettext;
 use tracing::warn;
 

--- a/src/ui/sidebar/sidebar.blp
+++ b/src/ui/sidebar/sidebar.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/video_viewer/mod.rs
+++ b/src/ui/video_viewer/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::{gdk, gio, glib};

--- a/src/ui/video_viewer/video_viewer.blp
+++ b/src/ui/video_viewer/video_viewer.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/edit_panel/adjust_section.blp
+++ b/src/ui/viewer/edit_panel/adjust_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/edit_panel/adjust_section.rs
+++ b/src/ui/viewer/edit_panel/adjust_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/ui/viewer/edit_panel/adjustments/brightness.rs
+++ b/src/ui/viewer/edit_panel/adjustments/brightness.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Brightness;

--- a/src/ui/viewer/edit_panel/adjustments/contrast.rs
+++ b/src/ui/viewer/edit_panel/adjustments/contrast.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Contrast;

--- a/src/ui/viewer/edit_panel/adjustments/highlights.rs
+++ b/src/ui/viewer/edit_panel/adjustments/highlights.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Highlights;

--- a/src/ui/viewer/edit_panel/adjustments/mod.rs
+++ b/src/ui/viewer/edit_panel/adjustments/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod brightness;
 mod contrast;
 mod highlights;

--- a/src/ui/viewer/edit_panel/adjustments/saturation.rs
+++ b/src/ui/viewer/edit_panel/adjustments/saturation.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Saturation;

--- a/src/ui/viewer/edit_panel/adjustments/shadows.rs
+++ b/src/ui/viewer/edit_panel/adjustments/shadows.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Shadows;

--- a/src/ui/viewer/edit_panel/adjustments/temperature.rs
+++ b/src/ui/viewer/edit_panel/adjustments/temperature.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Temperature;

--- a/src/ui/viewer/edit_panel/adjustments/tint.rs
+++ b/src/ui/viewer/edit_panel/adjustments/tint.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Tint;

--- a/src/ui/viewer/edit_panel/adjustments/vibrance.rs
+++ b/src/ui/viewer/edit_panel/adjustments/vibrance.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Vibrance;

--- a/src/ui/viewer/edit_panel/adjustments/vignette.rs
+++ b/src/ui/viewer/edit_panel/adjustments/vignette.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{AdjustGroup, Adjustment, EditState};
 
 pub struct Vignette;

--- a/src/ui/viewer/edit_panel/edit_panel.blp
+++ b/src/ui/viewer/edit_panel/edit_panel.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 
 template $MomentsEditPanel : Gtk.Widget {

--- a/src/ui/viewer/edit_panel/filter_section.blp
+++ b/src/ui/viewer/edit_panel/filter_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/edit_panel/filter_section.rs
+++ b/src/ui/viewer/edit_panel/filter_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/ui/viewer/edit_panel/filter_swatch.blp
+++ b/src/ui/viewer/edit_panel/filter_swatch.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 
 template $MomentsEditFilterSwatch : Gtk.Widget {

--- a/src/ui/viewer/edit_panel/filter_swatch.rs
+++ b/src/ui/viewer/edit_panel/filter_swatch.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/ui/viewer/edit_panel/filters/black_and_white.rs
+++ b/src/ui/viewer/edit_panel/filters/black_and_white.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct BlackAndWhite;

--- a/src/ui/viewer/edit_panel/filters/chrome.rs
+++ b/src/ui/viewer/edit_panel/filters/chrome.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Chrome;

--- a/src/ui/viewer/edit_panel/filters/cool.rs
+++ b/src/ui/viewer/edit_panel/filters/cool.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Cool;

--- a/src/ui/viewer/edit_panel/filters/fade.rs
+++ b/src/ui/viewer/edit_panel/filters/fade.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Fade;

--- a/src/ui/viewer/edit_panel/filters/golden.rs
+++ b/src/ui/viewer/edit_panel/filters/golden.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Golden;

--- a/src/ui/viewer/edit_panel/filters/matte.rs
+++ b/src/ui/viewer/edit_panel/filters/matte.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Matte;

--- a/src/ui/viewer/edit_panel/filters/mod.rs
+++ b/src/ui/viewer/edit_panel/filters/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod black_and_white;
 mod chrome;
 mod cool;

--- a/src/ui/viewer/edit_panel/filters/noir.rs
+++ b/src/ui/viewer/edit_panel/filters/noir.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Noir;

--- a/src/ui/viewer/edit_panel/filters/none.rs
+++ b/src/ui/viewer/edit_panel/filters/none.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct None;

--- a/src/ui/viewer/edit_panel/filters/vintage.rs
+++ b/src/ui/viewer/edit_panel/filters/vintage.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Vintage;

--- a/src/ui/viewer/edit_panel/filters/vivid.rs
+++ b/src/ui/viewer/edit_panel/filters/vivid.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Vivid;

--- a/src/ui/viewer/edit_panel/filters/warm.rs
+++ b/src/ui/viewer/edit_panel/filters/warm.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{EditState, Filter};
 
 pub struct Warm;

--- a/src/ui/viewer/edit_panel/mod.rs
+++ b/src/ui/viewer/edit_panel/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod adjust_section;
 mod adjustments;
 mod filter_section;

--- a/src/ui/viewer/edit_panel/transform_section.blp
+++ b/src/ui/viewer/edit_panel/transform_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/edit_panel/transform_section.rs
+++ b/src/ui/viewer/edit_panel/transform_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/ui/viewer/edit_panel/transforms/flip_horizontal.rs
+++ b/src/ui/viewer/edit_panel/transforms/flip_horizontal.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{Transform, TransformState};
 
 pub struct FlipHorizontal;

--- a/src/ui/viewer/edit_panel/transforms/flip_vertical.rs
+++ b/src/ui/viewer/edit_panel/transforms/flip_vertical.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{Transform, TransformState};
 
 pub struct FlipVertical;

--- a/src/ui/viewer/edit_panel/transforms/mod.rs
+++ b/src/ui/viewer/edit_panel/transforms/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod flip_horizontal;
 mod flip_vertical;
 mod rotate_ccw;

--- a/src/ui/viewer/edit_panel/transforms/rotate_ccw.rs
+++ b/src/ui/viewer/edit_panel/transforms/rotate_ccw.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{Transform, TransformState};
 
 pub struct RotateCcw;

--- a/src/ui/viewer/edit_panel/transforms/rotate_cw.rs
+++ b/src/ui/viewer/edit_panel/transforms/rotate_cw.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use super::{Transform, TransformState};
 
 pub struct RotateCw;

--- a/src/ui/viewer/info_panel/camera_section.blp
+++ b/src/ui/viewer/info_panel/camera_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/info_panel/camera_section.rs
+++ b/src/ui/viewer/info_panel/camera_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::subclass::prelude::*;
 use gtk::glib;
 use gtk::prelude::*;

--- a/src/ui/viewer/info_panel/date_section.blp
+++ b/src/ui/viewer/info_panel/date_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/info_panel/date_section.rs
+++ b/src/ui/viewer/info_panel/date_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::subclass::prelude::*;
 use gtk::glib;
 use gtk::prelude::*;

--- a/src/ui/viewer/info_panel/file_section.blp
+++ b/src/ui/viewer/info_panel/file_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/info_panel/file_section.rs
+++ b/src/ui/viewer/info_panel/file_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::subclass::prelude::*;
 use gtk::glib;
 use gtk::prelude::*;

--- a/src/ui/viewer/info_panel/image_section.blp
+++ b/src/ui/viewer/info_panel/image_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/info_panel/image_section.rs
+++ b/src/ui/viewer/info_panel/image_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::subclass::prelude::*;
 use gtk::glib;
 use gtk::prelude::*;

--- a/src/ui/viewer/info_panel/info_panel.blp
+++ b/src/ui/viewer/info_panel/info_panel.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 
 template $MomentsInfoPanel : Gtk.Widget {

--- a/src/ui/viewer/info_panel/location_section.blp
+++ b/src/ui/viewer/info_panel/location_section.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/viewer/info_panel/location_section.rs
+++ b/src/ui/viewer/info_panel/location_section.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use std::cell::RefCell;
 
 use adw::subclass::prelude::*;

--- a/src/ui/viewer/info_panel/mod.rs
+++ b/src/ui/viewer/info_panel/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 mod camera_section;
 mod date_section;
 mod file_section;

--- a/src/ui/viewer/loading.rs
+++ b/src/ui/viewer/loading.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::{gdk, glib};

--- a/src/ui/viewer/menu.rs
+++ b/src/ui/viewer/menu.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 

--- a/src/ui/viewer/mod.rs
+++ b/src/ui/viewer/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gtk::{gdk, glib};

--- a/src/ui/viewer/viewer.blp
+++ b/src/ui/viewer/viewer.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/ui/widgets/activity_indicator/activity_indicator.blp
+++ b/src/ui/widgets/activity_indicator/activity_indicator.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 
 template $MomentsActivityIndicator : Gtk.Widget {

--- a/src/ui/widgets/activity_indicator/mod.rs
+++ b/src/ui/widgets/activity_indicator/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Compact activity indicator for the sidebar header bar.
 //!
 //! Shows a spinner when sync or import is active, a status icon for

--- a/src/ui/widgets/context_menu_bin.rs
+++ b/src/ui/widgets/context_menu_bin.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! A container widget that adds right-click and long-press context menu support.
 //!
 //! Wraps a child widget and shows a `PopoverMenu` on right-click or long-press.

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Shared reusable UI components.
 
 pub mod activity_indicator;

--- a/src/ui/window/mod.rs
+++ b/src/ui/window/mod.rs
@@ -1,22 +1,5 @@
-/* window.rs
- *
- * Copyright 2026 Unknown
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/src/ui/window/window.blp
+++ b/src/ui/window/window.blp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 using Gtk 4.0;
 using Adw 1;
 

--- a/src/user_facing_error.rs
+++ b/src/user_facing_error.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! User-facing error trait.
 //!
 //! Separates human-readable error messages (for toasts, dialogs) from

--- a/tests/baseline_event_wiring.rs
+++ b/tests/baseline_event_wiring.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Phase 0: Baseline tests for event wiring before the event bus migration.
 //!
 //! These tests cover the current ModelRegistry → PhotoGridModel broadcast

--- a/tests/common/mock_library.rs
+++ b/tests/common/mock_library.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! A real Library backed by a temp-dir SQLite DB for integration tests.
 
 use std::sync::Arc;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,2 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pub mod mock_library;
 pub mod resources;

--- a/tests/common/resources.rs
+++ b/tests/common/resources.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Compile and register GResources for integration tests.
 //!
 //! Composite template widgets (PhotoGridCell, AlbumCard, etc.) require the

--- a/tests/headless_poc.rs
+++ b/tests/headless_poc.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Justin F
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Proof-of-concept: headless integration tests for Moments.
 //!
 //! Validates that GTK4/libadwaita widgets can be instantiated and tested


### PR DESCRIPTION
## Summary

Replaces the three GNOME Builder license blocks — which all carried the placeholder `Copyright 2026 Unknown` — with two-line SPDX headers, and extends the same headers across every comment-capable source file.

This also fixes the About dialog, which rendered **`Unknown`** to users as `developer_name`, `developers` and `copyright`. The name now matches the developer declared in the AppStream metainfo, which is what reviewers cross-check.

## Changes

- SPDX headers on 250 files (`.rs`, `.blp`, `meson.build`, `.toml`, `.yml`, `.py`, `.css`, `gresource.xml`, `Makefile`, gettext control files)
- `LICENSES/GPL-3.0-or-later.txt` and `LICENSES/CC-BY-4.0.txt`
- `REUSE.toml` covering files that cannot carry comments: docs, JSON manifests, icons, screenshots, AppStream/desktop templates
- A **REUSE compliance** job in CI (`fsfe/reuse-action@v5`), wired into the summary table, so coverage cannot silently regress

`CODE_OF_CONDUCT.md` is annotated `CC-BY-4.0` rather than GPL, since it is adapted from the Contributor Covenant v2.1.

## Deliberately left byte-exact

**SQL migrations** are covered via `REUSE.toml` instead of headers. `sqlx::migrate!` records a checksum of every applied migration in `_sqlx_migrations` and refuses to run when a previously-applied file changes — headering them would break the upgrade path for every existing install. Verified identical to `main`.

The **AppStream, desktop and GSettings templates** are untouched for the same class of reason, so `appstream-util` and `desktop-file-validate` see exactly what ships.

## Verification

| Check | Result |
|---|---|
| `reuse lint` (v6.2.0) | compliant with REUSE 3.3 — 322/322 files, 0 missing, 0 unused |
| `make lint` (fmt + clippy ×2) | pass, 0 warnings |
| `make test` | 611 passed, 0 failed |
| `meson setup` | pass — all 5 `meson.build`, gettext files OK |
| Blueprint + gresource compile | pass — all 28 `.blp` |
| TOML parse ×6 | pass |
| Migrations vs `main` | byte-identical |

## Note

The new `ci.yml` job could not be machine-validated locally (no `yaml` module available in either environment). It was checked structurally — no tabs, job keys aligned, step indentation matching siblings — but this PR's own CI run is its first real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)