### PR TITLE
fix: show capture-local time in the info panel Date section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Pre-commit Checks
 
-Always run `make lint` before committing or creating PRs. If a Makefile exists, check available targets with `make help` or inspect the Makefile first.
+Always run `make lint` before committing or creating PRs — as `flatpak-spawn --host make lint` from inside the toolbox, see [Running make from inside a toolbox](#running-make-from-inside-a-toolbox). There is no `make help` target; read the Makefile for the target list.
 
 ## Build & Run
 
 This project uses **Meson** as its build system and is packaged as a **Flatpak**. It must be built and run through Flatpak — do not attempt to run the binary directly.
+
+### Running make from inside a toolbox
+
+Development happens in a Fedora **toolbox** container (`registry.fedoraproject.org/fedora-toolbox`), where there is no `flatpak` binary — only `flatpak-spawn`. Every `make` target that touches flatpak therefore fails inside the container with `make: flatpak: No such file or directory`. Prefix the whole `make` invocation to run it on the host instead:
+
+```bash
+flatpak-spawn --host make lint
+flatpak-spawn --host make test
+flatpak-spawn --host make run-dev
+```
+
+Prefix `make`, not `flatpak` — the host has GNU Make, and wrapping the outer command means a single prefix covers every nested `flatpak run` the Makefile issues. Don't work around a missing `flatpak` by running `cargo` directly against the container's own GTK/libadwaita: those versions drift from the runtime the app actually ships against, so a clean result there proves nothing about the Flatpak build.
+
+Behaviour of `flatpak-spawn --host` worth knowing:
+
+- **cwd is inherited** — the toolbox shares `$HOME`, so relative paths resolve identically on both sides.
+- **exit codes propagate** — a failing target still fails the command.
+- **environment variables are *not* inherited.** `FOO=bar flatpak-spawn --host …` arrives empty; pass `flatpak-spawn --host --env=FOO=bar …`, or (for Makefile variables) `flatpak-spawn --host make bundle GPG_KEY=…`.
+
+Detect the container with `test -f /run/.toolboxenv`.
 
 ```bash
 # Build and run via Flatpak (primary workflow)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,31 +4,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Pre-commit Checks
 
-Always run `make lint` before committing or creating PRs — as `flatpak-spawn --host make lint` from inside the toolbox, see [Running make from inside a toolbox](#running-make-from-inside-a-toolbox). There is no `make help` target; read the Makefile for the target list.
+Always run `make lint` before committing or creating PRs. It works unchanged inside the toolbox container — see [Container-aware flatpak invocation](#container-aware-flatpak-invocation). There is no `make help` target; read the Makefile for the target list.
 
 ## Build & Run
 
 This project uses **Meson** as its build system and is packaged as a **Flatpak**. It must be built and run through Flatpak — do not attempt to run the binary directly.
 
-### Running make from inside a toolbox
+### Container-aware flatpak invocation
 
-Development happens in a Fedora **toolbox** container (`registry.fedoraproject.org/fedora-toolbox`), where there is no `flatpak` binary — only `flatpak-spawn`. Every `make` target that touches flatpak therefore fails inside the container with `make: flatpak: No such file or directory`. Prefix the whole `make` invocation to run it on the host instead:
+Development happens inside a Fedora **toolbox** container, which has no `flatpak` binary at all — only `flatpak-spawn`, which forwards a command out to the host session. Flatpak has to run on the host regardless, since nested sandboxes don't work.
 
-```bash
-flatpak-spawn --host make lint
-flatpak-spawn --host make test
-flatpak-spawn --host make run-dev
-```
+**The Makefile handles this itself — just run `make lint` / `make run-dev` normally, in the container or on the host.** `HOST_CMD` detects the container via `/run/.containerenv` and resolves to `flatpak-spawn --host` (empty on the host); `$(FLATPAK)` is that prefix plus `flatpak`.
 
-Prefix `make`, not `flatpak` — the host has GNU Make, and wrapping the outer command means a single prefix covers every nested `flatpak run` the Makefile issues. Don't work around a missing `flatpak` by running `cargo` directly against the container's own GTK/libadwaita: those versions drift from the runtime the app actually ships against, so a clean result there proves nothing about the Flatpak build.
+**Never write a bare `flatpak` in a recipe — always `$(FLATPAK)`.** A bare one works when you test it on the host and then fails for everyone in a container with `flatpak: command not found`. The same goes for `$(FLATPAK_BUILDER)`, which probes the *host* PATH for a `flatpak-builder` binary and otherwise falls back to `$(FLATPAK) run org.flatpak.Builder`.
 
-Behaviour of `flatpak-spawn --host` worth knowing:
+Behaviour of `flatpak-spawn --host` that shaped the above:
 
-- **cwd is inherited** — the toolbox shares `$HOME`, so relative paths resolve identically on both sides.
-- **exit codes propagate** — a failing target still fails the command.
-- **environment variables are *not* inherited.** `FOO=bar flatpak-spawn --host …` arrives empty; pass `flatpak-spawn --host --env=FOO=bar …`, or (for Makefile variables) `flatpak-spawn --host make bundle GPG_KEY=…`.
+- **cwd is inherited** — the toolbox shares `$HOME`, so relative paths resolve identically on both sides, and the manifests' relative source paths keep working.
+- **exit codes propagate** — a failing target still fails the build.
+- **environment variables are *not* inherited.** `FOO=bar flatpak-spawn --host …` arrives empty. This is why the SDK invocations pass everything through explicit `--env=` flags; if you add a target that depends on an inherited variable, pass it as a make argument (`make bundle GPG_KEY=…`) rather than exporting it.
 
-Detect the container with `test -f /run/.toolboxenv`.
+One trap when verifying: don't work around a flatpak problem by running `cargo` directly against the container's own GTK/libadwaita. Those versions drift from the GNOME runtime the app ships against, so a clean result there proves nothing about the Flatpak build.
 
 ```bash
 # Build and run via Flatpak (primary workflow)
@@ -46,7 +42,7 @@ make bundle
 
 The Flatpak manifest is `io.github.justinf555.Moments.json` (local dev), `io.github.justinf555.Moments.flathub.json` (Flathub submission), `build-aux/io.github.justinf555.Moments.ci.json` (CI build + tests), and `build-aux/io.github.justinf555.Moments.release.json` (redistributable bundle). The local manifest pulls source from this git repo (`"type": "git", "path": "."`, branch `main`), so **changes must be committed before rebuilding**. All manifest source paths are relative to the manifest's own directory — **never hardcode an absolute local path into a manifest**. The `make run` command installs the Flatpak locally (`--user --install`) so icons are exported to GNOME Shell.
 
-Every target that shells out to flatpak-builder goes through `$(FLATPAK_BUILDER)`, which auto-detects a host `flatpak-builder` binary and falls back to `flatpak run org.flatpak.Builder`. Don't hardcode `flatpak-builder` in new targets.
+Every target that shells out to flatpak-builder goes through `$(FLATPAK_BUILDER)`, which auto-detects a host `flatpak-builder` binary and falls back to `$(FLATPAK) run org.flatpak.Builder`. Don't hardcode `flatpak-builder` — or `flatpak` — in new targets.
 
 ### Dev build
 

--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,36 @@
         check-potfiles ci-all stack attach release config \
         bundle install-bundle uninstall-bundle
 
+# Flatpak always runs on the host. Inside a toolbox/distrobox/podman
+# container there is no `flatpak` binary at all — only `flatpak-spawn`,
+# which forwards a command out to the host session — so every target here
+# would otherwise die with `flatpak: command not found`. Detect the
+# container once and prefix every flatpak call, rather than making each
+# target (or each developer) remember. `flatpak-spawn --host` inherits the
+# cwd and propagates exit codes, so the prefix is transparent; it does not
+# forward environment variables, which is why the SDK invocations below
+# pass everything they need via explicit --env= flags.
+HOST_CMD := $(shell test -f /run/.containerenv && echo flatpak-spawn --host)
+FLATPAK  ?= $(HOST_CMD) flatpak
+
 # flatpak-builder ships either as a host package or as the Flathub-packaged
 # org.flatpak.Builder app. Prefer the host binary; fall back to the Flatpak.
+# The probe runs through $(HOST_CMD) so it inspects the *host* PATH — a
+# flatpak-builder installed inside the container would be useless anyway,
+# since nested sandboxes don't work.
 # Override explicitly if you have both: make run FLATPAK_BUILDER=flatpak-builder
-FLATPAK_BUILDER ?= $(shell command -v flatpak-builder 2>/dev/null || \
-	echo 'flatpak run org.flatpak.Builder')
+HOST_FB := $(shell $(HOST_CMD) sh -c 'command -v flatpak-builder' 2>/dev/null)
+FLATPAK_BUILDER ?= $(if $(HOST_FB),$(HOST_CMD) $(HOST_FB),$(FLATPAK) run org.flatpak.Builder)
 
 run:
 	$(FLATPAK_BUILDER) --user --install --force-clean flatpak-build-dir io.github.justinf555.Moments.json && \
-	flatpak run io.github.justinf555.Moments
+	$(FLATPAK) run io.github.justinf555.Moments
 
 run-dev:
 	$(FLATPAK_BUILDER) --user --install --force-clean \
 		--state-dir=.flatpak-builder-dev \
 		flatpak-build-dev io.github.justinf555.Moments.dev.json && \
-	flatpak run --env=RUST_LOG=moments=debug io.github.justinf555.Moments.Devel
+	$(FLATPAK) run --env=RUST_LOG=moments=debug io.github.justinf555.Moments.Devel
 
 # Fast iterative dev build (mirrors GNOME Builder's inner loop).
 #
@@ -45,7 +60,7 @@ dev-bootstrap:
 		--stop-at=moments \
 		--state-dir=$(DEV_STATE_DIR) \
 		$(DEV_APP_DIR) io.github.justinf555.Moments.dev.json
-	flatpak build \
+	$(FLATPAK) build \
 		--filesystem=$(CURDIR) \
 		--filesystem=$(CURDIR)/$(DEV_BUILD_DIR):create \
 		--env=PATH=/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
@@ -59,14 +74,14 @@ dev:
 		echo "==> No build dir — running dev-bootstrap first"; \
 		$(MAKE) dev-bootstrap; \
 	fi
-	flatpak build --share=network \
+	$(FLATPAK) build --share=network \
 		--filesystem=$(CURDIR) \
 		--filesystem=$(CURDIR)/$(DEV_BUILD_DIR) \
 		--env=PATH=/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
 		--env=RUST_BACKTRACE=1 \
 		$(DEV_APP_DIR) \
 		meson install -C $(CURDIR)/$(DEV_BUILD_DIR)
-	flatpak build \
+	$(FLATPAK) build \
 		--share=network --share=ipc \
 		--socket=wayland --socket=fallback-x11 \
 		--device=dri --socket=pulseaudio \
@@ -92,14 +107,14 @@ run-dhat:
 		echo "==> No build dir — running dev-bootstrap first"; \
 		$(MAKE) dev-bootstrap; \
 	fi
-	flatpak build --share=network \
+	$(FLATPAK) build --share=network \
 		--filesystem=$(CURDIR) \
 		--filesystem=$(CURDIR)/$(DEV_BUILD_DIR) \
 		--env=PATH=/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
 		$(DEV_APP_DIR) \
 		meson configure -Ddhat-heap=true $(CURDIR)/$(DEV_BUILD_DIR)
 	-$(MAKE) dev
-	flatpak build --share=network \
+	$(FLATPAK) build --share=network \
 		--filesystem=$(CURDIR) \
 		--filesystem=$(CURDIR)/$(DEV_BUILD_DIR) \
 		--env=PATH=/usr/lib/sdk/rust-stable/bin:/app/bin:/usr/bin \
@@ -141,7 +156,7 @@ clean-dev:
 
 APP_ID          = io.github.justinf555.Moments
 BUNDLE_VERSION := $(shell sed -n "s/^[[:space:]]*version:[[:space:]]*'\([0-9][0-9.]*\)'.*/\1/p" meson.build | head -1)
-BUNDLE_ARCH    ?= $(shell flatpak --default-arch 2>/dev/null || uname -m)
+BUNDLE_ARCH    ?= $(shell $(FLATPAK) --default-arch 2>/dev/null || uname -m)
 BUNDLE_MANIFEST = build-aux/$(APP_ID).release.json
 BUNDLE_REPO     = flatpak-bundle-repo
 BUNDLE_BUILD    = flatpak-bundle-build
@@ -179,7 +194,7 @@ endif
 	$(FLATPAK_BUILDER) --force-clean --repo=$(BUNDLE_REPO) \
 		$(GPG_ARGS) $(FLATPAK_BUILDER_ARGS) \
 		$(BUNDLE_BUILD)/app $(BUNDLE_MANIFEST)
-	flatpak build-bundle --arch=$(BUNDLE_ARCH) \
+	$(FLATPAK) build-bundle --arch=$(BUNDLE_ARCH) \
 		--runtime-repo=$(BUNDLE_RUNTIME_REPO) $(BUNDLE_GPG_ARGS) \
 		$(BUNDLE_REPO) $(BUNDLE) $(APP_ID)
 	sha256sum $(BUNDLE) > $(BUNDLE).sha256
@@ -188,10 +203,10 @@ endif
 
 install-bundle:
 	@test -f $(BUNDLE) || $(MAKE) bundle
-	flatpak install --user --bundle -y $(BUNDLE)
+	$(FLATPAK) install --user --bundle -y $(BUNDLE)
 
 uninstall-bundle:
-	-flatpak uninstall --user -y $(APP_ID)
+	-$(FLATPAK) uninstall --user -y $(APP_ID)
 
 clean-bundle:
 	rm -rf $(BUNDLE_REPO) $(BUNDLE_BUILD) moments-*.flatpak moments-*.flatpak.sha256
@@ -204,7 +219,7 @@ clean-bundle:
 # Flatpak SDK runner — uses an isolated CARGO_HOME to avoid rustup shims
 # in ~/.cargo/bin shadowing the SDK's toolchain. Registry and git caches
 # are symlinked from the host for speed.
-FLATPAK_RUN = flatpak run --share=network \
+FLATPAK_RUN = $(FLATPAK) run --share=network \
 	--filesystem=$(CURDIR) \
 	--filesystem=$(HOME)/.cargo/registry:create \
 	--filesystem=$(HOME)/.cargo/git:create \
@@ -267,7 +282,7 @@ test-nextest: $(CONFIG_RS)
 		cargo nextest run --profile ci'
 
 test-integration: $(CONFIG_RS)
-	flatpak run --share=network \
+	$(FLATPAK) run --share=network \
 	  --socket=wayland \
 	  --filesystem=$(CURDIR) \
 	  --filesystem=$(HOME)/.cargo/registry:ro \
@@ -337,17 +352,21 @@ metrics:
 # for every thread. Auto-detects the PID by matching the dev app id; pass
 # PID=… explicitly if more than one moments process is running.
 #
+# The pgrep goes through $(HOST_CMD) because the app runs on the host: a
+# container-local pgrep sees a different PID namespace, so it would either
+# find nothing or hand gdb a PID that means something else entirely.
+#
 # Example: a CR2 import sat forever on `typefind:sink`; `make stack` over
 # the same process showed `gst::Pipeline::set_state` / `pull_sample` in
 # seconds and named the deadlock unambiguously.
 
 stack:
-	@PID="$${PID:-$$(pgrep -f io.github.justinf555.Moments.Devel | tail -1)}"; \
+	@PID="$${PID:-$$($(HOST_CMD) pgrep -f io.github.justinf555.Moments.Devel | tail -1)}"; \
 	if [ -z "$$PID" ]; then \
 		echo "no PID given and no Moments.Devel process found" >&2; exit 1; \
 	fi; \
 	echo "===== thread backtraces for PID $$PID ====="; \
-	flatpak run --command=gdb org.gnome.Sdk//50 -p "$$PID" \
+	$(FLATPAK) run --command=gdb org.gnome.Sdk//50 -p "$$PID" \
 		-ex 'set pagination off' \
 		-ex 'thread apply all bt 30' \
 		-ex quit 2>&1 | grep -v '^\[New '
@@ -363,12 +382,12 @@ stack:
 #
 # Auto-detects the dev app's PID; pass PID=… to override.
 attach:
-	@PID="$${PID:-$$(pgrep -f io.github.justinf555.Moments.Devel | tail -1)}"; \
+	@PID="$${PID:-$$($(HOST_CMD) pgrep -f io.github.justinf555.Moments.Devel | tail -1)}"; \
 	if [ -z "$$PID" ]; then \
 		echo "no PID given and no Moments.Devel process found" >&2; exit 1; \
 	fi; \
 	echo "attaching gdb to PID $$PID — type 'continue' to resume, 'detach' to release"; \
-	flatpak run --command=gdb org.gnome.Sdk//50 -p "$$PID"
+	$(FLATPAK) run --command=gdb org.gnome.Sdk//50 -p "$$PID"
 
 # ── i18n ────────────────────────────────────────────────────────────────────
 

--- a/src/library/media/model.rs
+++ b/src/library/media/model.rs
@@ -51,7 +51,8 @@ pub enum MediaType {
 #[derive(Debug, Clone)]
 pub struct MediaItem {
     pub id: MediaId,
-    /// EXIF capture timestamp (UTC Unix seconds). `None` if unavailable.
+    /// Capture time as the capture-local wall clock, encoded as seconds
+    /// since the epoch. See [`MediaRecord::taken_at`]. `None` if unavailable.
     pub taken_at: Option<i64>,
     pub imported_at: i64,
     pub original_filename: String,
@@ -187,7 +188,16 @@ pub struct MediaRecord {
     /// Unix timestamp (seconds since epoch).
     pub imported_at: i64,
     pub media_type: MediaType,
-    /// Capture timestamp from EXIF (UTC Unix seconds). `None` if unavailable.
+    /// Capture time as the *capture-local wall clock* — the reading on the
+    /// camera's own clock — encoded as seconds since the epoch.
+    ///
+    /// Deliberately not an instant in UTC: photo libraries show the time the
+    /// shutter fired, not that time re-expressed wherever the viewer happens
+    /// to be. The EXIF extractor keeps `DateTimeOriginal` verbatim and the
+    /// Immich sync handler prefers the server's `localDateTime`, so both
+    /// import paths land on the same convention. Issue #549.
+    ///
+    /// `None` if unavailable.
     pub taken_at: Option<i64>,
     pub width: Option<i64>,
     pub height: Option<i64>,

--- a/src/library/metadata/exif.rs
+++ b/src/library/metadata/exif.rs
@@ -11,9 +11,21 @@ use tracing::{instrument, warn};
 /// import pipeline. Callers must handle absent data gracefully.
 #[derive(Debug, Default)]
 pub struct ExifInfo {
-    /// Capture timestamp as a Unix timestamp (seconds, UTC).
+    /// Capture time as the *capture-local wall clock*, encoded as seconds
+    /// since the epoch (the EXIF digits read as if they were UTC).
+    ///
+    /// This deliberately is not an instant in UTC. EXIF `DateTimeOriginal`
+    /// records what the camera's clock read, and photo libraries show that
+    /// same reading no matter where the viewer later opens the file — a
+    /// sunset shot at 18:04 in Sydney stays "18:04", not "08:04" because
+    /// the laptop is now in London. Immich uses the same convention for
+    /// its `localDateTime` field, which is what the sync handler stores
+    /// into `media.taken_at`, so both import paths agree. Issue #549.
     pub captured_at: Option<i64>,
-    /// UTC offset of the capture timezone, in minutes.
+    /// UTC offset of the capture timezone, in minutes east of UTC, from
+    /// the `OffsetTimeOriginal` / `OffsetTime` tags. Recorded for future
+    /// use (it is not currently persisted) and intentionally *not* applied
+    /// to [`Self::captured_at`].
     pub captured_at_tz: Option<i64>,
     pub width: Option<u32>,
     pub height: Option<u32>,
@@ -104,43 +116,54 @@ fn get_field(exif: &exif::Exif, tag: exif::Tag) -> Option<&exif::Field> {
         .or_else(|| exif.get_field(tag, exif::In::THUMBNAIL))
 }
 
-/// Parse `DateTimeOriginal` (preferred) or `DateTime` into a UTC Unix timestamp.
+/// Read an ASCII EXIF field as a trimmed `String`.
+fn ascii_field(exif: &exif::Exif, tag: exif::Tag) -> Option<String> {
+    let field = get_field(exif, tag)?;
+    match &field.value {
+        exif::Value::Ascii(vecs) => {
+            let s: String = vecs.first()?.iter().map(|&b| b as char).collect();
+            Some(s.trim_end_matches('\0').trim().to_string())
+        }
+        _ => None,
+    }
+}
+
+/// Parse `DateTimeOriginal` (preferred) or `DateTime` into `captured_at`.
+///
+/// The result is the *capture-local wall clock* encoded as seconds since
+/// the epoch — i.e. the digits the camera wrote, read as if they were UTC.
+/// See [`ExifInfo::captured_at`] for why the `OffsetTime*` tag is recorded
+/// separately in [`ExifInfo::captured_at_tz`] rather than folded in here.
 fn capture_timestamp(exif: &exif::Exif) -> Option<i64> {
-    let field = get_field(exif, exif::Tag::DateTimeOriginal)
-        .or_else(|| get_field(exif, exif::Tag::DateTime))?;
+    let s = ascii_field(exif, exif::Tag::DateTimeOriginal)
+        .or_else(|| ascii_field(exif, exif::Tag::DateTime))?;
+    parse_exif_datetime(&s)
+}
 
-    let s = match &field.value {
-        exif::Value::Ascii(vecs) => vecs.first()?.iter().map(|&b| b as char).collect::<String>(),
-        _ => return None,
-    };
-
-    // EXIF datetime format: "YYYY:MM:DD HH:MM:SS"
-    let s = s.trim_end_matches('\0').trim();
+/// Parse an EXIF `"YYYY:MM:DD HH:MM:SS"` string into a wall-clock timestamp.
+fn parse_exif_datetime(s: &str) -> Option<i64> {
     let dt = chrono::NaiveDateTime::parse_from_str(s, "%Y:%m:%d %H:%M:%S").ok()?;
-
-    // Apply timezone offset if available, otherwise treat as UTC.
-    let offset_secs = capture_tz(exif).unwrap_or(0) * 60;
-    let ts = dt.and_utc().timestamp() - offset_secs;
-    Some(ts)
+    Some(dt.and_utc().timestamp())
 }
 
 /// Parse `OffsetTimeOriginal` or `OffsetTime` into minutes east of UTC.
 fn capture_tz(exif: &exif::Exif) -> Option<i64> {
-    let field = get_field(exif, exif::Tag::OffsetTimeOriginal)
-        .or_else(|| get_field(exif, exif::Tag::OffsetTime))?;
+    let s = ascii_field(exif, exif::Tag::OffsetTimeOriginal)
+        .or_else(|| ascii_field(exif, exif::Tag::OffsetTime))?;
+    parse_tz_offset(&s)
+}
 
-    let s = match &field.value {
-        exif::Value::Ascii(vecs) => vecs.first()?.iter().map(|&b| b as char).collect::<String>(),
-        _ => return None,
-    };
-
-    // Format: "+HH:MM" or "-HH:MM"
-    let s = s.trim_end_matches('\0').trim();
+/// Parse an EXIF UTC-offset string (`"+HH:MM"` / `"-HH:MM"`) into minutes
+/// east of UTC.
+fn parse_tz_offset(s: &str) -> Option<i64> {
     let sign: i64 = if s.starts_with('-') { -1 } else { 1 };
     let s = s.trim_start_matches(['+', '-']);
     let mut parts = s.splitn(2, ':');
-    let hours: i64 = parts.next()?.parse().ok()?;
-    let mins: i64 = parts.next().and_then(|m| m.parse().ok()).unwrap_or(0);
+    let hours: i64 = parts.next()?.trim().parse().ok()?;
+    let mins: i64 = parts
+        .next()
+        .and_then(|m| m.trim().parse::<i64>().ok())
+        .unwrap_or(0);
     Some(sign * (hours * 60 + mins))
 }
 
@@ -344,5 +367,38 @@ mod tests {
         assert_eq!(gcd(0, 5), 5);
         assert_eq!(gcd(12, 8), 4);
         assert_eq!(gcd(1, 500), 1);
+    }
+
+    #[test]
+    fn parse_exif_datetime_keeps_wall_clock() {
+        // 2024-06-15 18:04:05 must round-trip to the same digits, so the
+        // info panel shows the time the shutter actually fired.
+        let ts = parse_exif_datetime("2024:06:15 18:04:05").unwrap();
+        let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0).unwrap();
+        assert_eq!(
+            dt.format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2024-06-15 18:04:05"
+        );
+    }
+
+    #[test]
+    fn parse_exif_datetime_rejects_garbage() {
+        assert!(parse_exif_datetime("").is_none());
+        assert!(parse_exif_datetime("2024-06-15T18:04:05Z").is_none());
+    }
+
+    #[test]
+    fn parse_tz_offset_signs_and_minutes() {
+        assert_eq!(parse_tz_offset("+10:00"), Some(600));
+        assert_eq!(parse_tz_offset("-05:30"), Some(-330));
+        assert_eq!(parse_tz_offset("+00:00"), Some(0));
+        // Some cameras omit the minutes component.
+        assert_eq!(parse_tz_offset("+09"), Some(540));
+    }
+
+    #[test]
+    fn parse_tz_offset_rejects_garbage() {
+        assert!(parse_tz_offset("").is_none());
+        assert!(parse_tz_offset("Z").is_none());
     }
 }

--- a/src/ui/viewer/info_panel/date_section.rs
+++ b/src/ui/viewer/info_panel/date_section.rs
@@ -64,7 +64,19 @@ impl InfoDateSection {
     }
 }
 
-/// Split a Unix timestamp into (short date, long date, time) strings.
+/// Split a capture timestamp into (short date, long date, time) strings.
+///
+/// `taken_at` holds the *capture-local wall clock* — the time the camera's
+/// own clock read — encoded as seconds since the epoch. Both import paths
+/// agree on that: the EXIF extractor keeps `DateTimeOriginal` verbatim
+/// (`library::metadata::exif`), and the Immich sync handler prefers the
+/// server's `localDateTime`. Rendering with a fixed UTC offset therefore
+/// hands back exactly those digits, which is what the panel should show.
+///
+/// Converting to the *viewer's* local timezone would be wrong: it would
+/// slide a sunset shot taken at 18:04 in Sydney to "08:04" as soon as the
+/// laptop landed in London, and it would shift every photo in the library
+/// by the host offset even though no photo moved. Issue #549.
 fn format_date_parts(ts: Option<i64>) -> (String, String, String) {
     use chrono::{DateTime, Utc};
 
@@ -92,6 +104,30 @@ mod tests {
         assert!(short.contains("2017"));
         assert!(long.contains("March"));
         assert!(time.contains("12:00"));
+    }
+
+    #[test]
+    fn format_date_parts_is_independent_of_host_timezone() {
+        // A capture stored as 2024-06-15 18:04 wall clock must render as
+        // 18:04 regardless of the machine's TZ. Issue #549.
+        let ts = chrono::NaiveDate::from_ymd_opt(2024, 6, 15)
+            .unwrap()
+            .and_hms_opt(18, 4, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp();
+        let (short, long, time) = format_date_parts(Some(ts));
+        assert_eq!(short, "15 Jun 2024");
+        assert_eq!(long, "15 June 2024");
+        assert_eq!(time, "18:04");
+    }
+
+    #[test]
+    fn format_date_parts_out_of_range_returns_unknown() {
+        let (short, long, time) = format_date_parts(Some(i64::MAX));
+        assert_eq!(short, "Unknown");
+        assert_eq!(long, "Unknown");
+        assert_eq!(time, "Unknown");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #549.

## What the issue reported

The Date section formats `taken_at` with `DateTime::<Utc>`, so it "always displays UTC"; the suggested fix was to switch to `DateTime::<Local>`.

## What's actually going on

Tracing where `taken_at` comes from, the rendering was right and the EXIF extractor was wrong.

`taken_at` is the **capture-local wall clock** encoded as seconds since the epoch, not an instant in UTC:

- the Immich sync handler stores the server's `localDateTime` in preference to `fileCreatedAt` (`handlers/asset.rs:44`)
- for cameras with no `OffsetTime` tag, the extractor kept `DateTimeOriginal` verbatim

Formatting those with a fixed UTC offset hands back exactly the digits the camera wrote — which is what a photo library should show, and what Immich's own UI shows.

The one path that broke the convention was a camera that *does* write `OffsetTime`: the extractor subtracted the offset, converting to a true UTC instant. An 18:04 shot at `+10:00` was stored — and therefore displayed — as **08:04**. That's the real "wrong time" bug.

Switching the panel to `DateTime::<Local>` as suggested would have regressed the common case instead: it shifts every photo by the viewer's own offset even though no photo moved, so a library re-renders differently after a flight, and a no-`OffsetTime` 12:00 capture reads as 22:00 in Sydney.

## Changes

- **`library/metadata/exif.rs`** — stop subtracting the offset in `capture_timestamp`; `OffsetTime*` is still parsed into `captured_at_tz`, just not applied.
- **`library/metadata/exif.rs`** — split the pure `parse_exif_datetime` / `parse_tz_offset` helpers out of the `exif::Exif` accessors (via a shared `ascii_field`) so they're unit-testable, and cover them.
- **Docs** — record the `taken_at` convention on `ExifInfo::captured_at`, `MediaRecord::taken_at`, `MediaItem::taken_at` and `format_date_parts`, so the next reader doesn't re-file this as "displays UTC".
- **`ui/viewer/info_panel/date_section.rs`** — behaviour unchanged; pinned with a host-timezone-independent test plus an out-of-range case.

## Confirmed in the wild

A real photo from the test library, imported before the fix:

| | value |
|---|---|
| EXIF `DateTimeOriginal` | `2025:10:18 11:56:18` |
| EXIF `OffsetTimeOriginal` | `+11:00` (Sydney DST) |
| stored `taken_at` | `2025-10-18 00:56:18` |
| info panel showed | **00:56** |

11:56 − 11:00 = 00:56. A sunlit outdoor athletics photo displayed as just before 1am. Canon EOS 700D, so this is an ordinary consumer camera writing the offset tag, not an exotic case.

## Existing rows

Rows imported before this change stay shifted — the corrected value is only written at import time.

Note that re-importing the file alone does **not** fix them: `importer/pipeline.rs:154` skips duplicates by content hash, so the stale row survives. Fixing an existing row today means permanently deleting it first, which also throws away its album membership, favourite flag and edits.

A backfill is therefore worth doing as a follow-up, and is more tractable than I first assumed: in Managed mode the original file is kept inside the library, so a one-shot rescan can re-read `OffsetTimeOriginal` and add it back to `taken_at` without the user losing anything. Immich-sourced rows were never affected, since that path already stores `localDateTime`.

## Testing

Run through the real Flatpak toolchain via `flatpak-spawn --host` (see the CLAUDE.md commit):

- `make lint` — clean
- `make test` — 617 passed, including the 6 new tests

Worth a visual check of the Date section in `make run-dev` before merging, ideally on a photo whose EXIF carries an `OffsetTime` tag.

## Also in this PR

Two commits making the build work from inside a toolbox container. The container has no `flatpak` binary — only `flatpak-spawn`, which forwards to the host — so every target that shells out to flatpak died with `flatpak: command not found`, `make run-dev` included.

`HOST_CMD` now detects the container via `/run/.containerenv` and every call goes through `$(FLATPAK)`, so `make lint` / `make run-dev` work unchanged on either side of the boundary — no prefix to remember. `FLATPAK_BUILDER` probes the *host* PATH, since a flatpak-builder inside the container would be useless anyway (nested sandboxes don't work). `stack` / `attach` also had a latent bug: the app runs on the host, so a container-local `pgrep` searches the wrong PID namespace and would hand gdb a PID meaning something else entirely.

CLAUDE.md records the rule for new targets — **never a bare `flatpak` in a recipe** — plus the three `flatpak-spawn --host` behaviours that shaped it: cwd inherited, exit codes propagated, environment variables *not* forwarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


