### PR TITLE
feat: give the development build a distinct icon

### DIFF
--- a/data/icons/hicolor/scalable/apps/io.github.justinf555.Moments.Devel.svg
+++ b/data/icons/hicolor/scalable/apps/io.github.justinf555.Moments.Devel.svg
@@ -2,8 +2,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
   <defs>
     <linearGradient id="bgGrad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#3584e4"/>
-      <stop offset="1" stop-color="#1a5fb4"/>
+      <stop offset="0" stop-color="#9141ac"/>
+      <stop offset="1" stop-color="#613583"/>
     </linearGradient>
     <linearGradient id="photoGrad" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#ffffff"/>
@@ -13,6 +13,9 @@
       <stop offset="0" stop-color="#99c1f1"/>
       <stop offset="1" stop-color="#62a0ea"/>
     </linearGradient>
+    <pattern id="develStripes" width="24" height="24" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="12" height="24" fill="#ffffff" opacity="0.14"/>
+    </pattern>
     <clipPath id="photoClip">
       <rect x="30" y="28" width="68" height="52" rx="2"/>
     </clipPath>
@@ -20,6 +23,9 @@
 
   <!-- App base: rounded square -->
   <rect x="4" y="4" width="120" height="120" rx="28" ry="28" fill="url(#bgGrad)"/>
+
+  <!-- Devel marker: hazard stripes, visible around the photo cards -->
+  <rect x="4" y="4" width="120" height="120" rx="28" ry="28" fill="url(#develStripes)"/>
 
   <!-- Subtle highlight on top edge -->
   <rect x="4" y="4" width="120" height="60" rx="28" ry="28" fill="#ffffff" opacity="0.08"/>


### PR DESCRIPTION
Dev and production builds were indistinguishable in the dash, alt-tab and notifications, despite the plumbing for a separate icon already being correct.

## The finding

Nothing needed wiring up. `data/icons/meson.build` installs `@application_id@.svg` and `data/…desktop.in` sets `Icon=@APP_ID@` — both resolve to `io.github.justinf555.Moments.Devel` under `-Dprofile=development`, and `data/icons/hicolor/scalable/apps/io.github.justinf555.Moments.Devel.svg` was already present and already installed.

It was just a **byte-for-byte copy** of the production icon:

```
$ diff io.github.justinf555.Moments{,.Devel}.svg && echo IDENTICAL
IDENTICAL
```

So this is a one-file artwork change, no build changes at all.

## The variant

GNOME purple (`#9141ac` → `#613583`) replaces the blue background gradient, with diagonal hazard stripes behind the photo cards. Colour does the work at 32px, where the stripes muddy together; the stripes carry the "not the real thing" signal at 48px and up. The photo artwork is untouched so it still reads as the same app, matching the striped headerbar the development profile already enables.

The **symbolic** variant stays shared — at 16px monochrome there's no room for a marker that survives rasterisation. Worth knowing that file is still a duplicate, so it isn't mistaken for an oversight later.

## Testing

Rebuilt the dev flatpak and inspected the exports:

- `exports/…/io.github.justinf555.Moments.Devel.svg` carries the new palette
- the production export is untouched (still `#3584e4`)
- the two desktop files name different icons (`…Moments` vs `…Moments.Devel`)

Both apps install side-by-side already, so they can be compared directly in the dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)