### PR TITLE
fix: move Immich sync to the AssetsV2 and AssetFacesV2 request types

### DIFF
--- a/docs/design-face-integration.md
+++ b/docs/design-face-integration.md
@@ -58,6 +58,8 @@ No ML models, no face detection, no image processing — just data sync and UI.
 ### Sync Stream Entity Types
 
 Adding `"PeopleV1"` and `"AssetFacesV1"` to the sync stream request causes the server to include person and face records in the same NDJSON stream we already process.
+> **Superseded (#679):** `AssetsV1` and `AssetFacesV1` were retired server-side and now return 400. The live list is `SYNC_REQUEST_TYPES` in `src/sync/providers/immich/pull.rs` — see `docs/design-immich-backend.md`.
+
 
 **PersonV1** (upsert):
 ```json

--- a/docs/design-immich-backend.md
+++ b/docs/design-immich-backend.md
@@ -76,8 +76,8 @@ All reads delegate to `self.db` — identical SQL to `LocalLibrary`. Writes go t
 4. **Per-asset event emission** — fires `AssetSynced` events for incremental grid updates (no full reload)
 
 **Sync Protocol:**
-- Uses Immich's `POST /sync/stream` (newline-delimited JSON) with entity types: `AssetsV1`, `AssetExifsV1`
-- Match-based dispatch for entity types (AssetV1, AssetExifV1, AssetDeleteV1, SyncCompleteV1, SyncResetV1)
+- Uses Immich's `POST /sync/stream` (newline-delimited JSON) with entity types: `AssetsV2`, `AssetExifsV1`
+- Match-based dispatch for entity types (AssetV2, AssetExifV1, AssetDeleteV1, SyncCompleteV1, SyncResetV1)
 - Tracks sync checkpoints via `POST /sync/ack`, persisted locally in `sync_checkpoints` table
 - `INSERT OR REPLACE` for all upserts — no pre-check queries needed
 - Transient errors don't abort the polling loop — logged and retried next cycle
@@ -253,7 +253,7 @@ The sync engine uses `POST /sync/stream` which returns **newline-delimited JSON*
 (content-type `application/jsonlines+json`). Each line is:
 
 ```json
-{"type":"AssetV1","data":{...},"ack":"AssetV1|019513a2-..."}
+{"type":"AssetV2","data":{...},"ack":"AssetV2|019513a2-..."}
 ```
 
 The `ack` field is sent back via `POST /sync/ack` to checkpoint progress. The
@@ -270,14 +270,51 @@ acknowledged position on subsequent syncs.
 
 We subscribe to these types via the `types` array in the request:
 
+The canonical list lives in `SYNC_REQUEST_TYPES` (`src/sync/providers/immich/pull.rs`).
+
 | Request Type | Entity Types Produced | What Changes |
 |-------------|----------------------|-------------|
-| `AssetsV1` | `AssetV1`, `AssetDeleteV1` | Asset created/updated/deleted |
+| `AssetsV2` | `AssetV2`, `AssetDeleteV1` | Asset created/updated/deleted |
 | `AssetExifsV1` | `AssetExifV1` | EXIF metadata changes |
-| `AlbumsV1` | `AlbumV1`, `AlbumDeleteV1` | Album created/updated/deleted (🔜 #105) |
-| `AlbumToAssetsV1` | `AlbumToAssetV1`, `AlbumToAssetDeleteV1` | Assets added/removed from albums (🔜 #105) |
+| `AlbumsV1` | `AlbumV1`, `AlbumDeleteV1` | Album created/updated/deleted |
+| `AlbumToAssetsV1` | `AlbumToAssetV1`, `AlbumToAssetDeleteV1` | Assets added/removed from albums |
+| `PeopleV1` | `PersonV1`, `PersonDeleteV1` | People created/updated/deleted |
+| `AssetFacesV2` | `AssetFaceV2`, `AssetFaceDeleteV1` | Faces detected/assigned/removed |
+| `StacksV1` | `StackV1`, `StackDeleteV1` | Stacks created/removed (#224) |
+| `AssetEditsV1` | `AssetEditV1`, `AssetEditDeleteV1` | Geometric edit actions (#224 Phase B) |
 
-Other types (People, Faces, Memories, Partners, Stacks) can be added later.
+Other types (Memories, Partners, OCR, asset metadata) can be added later.
+
+### V1 request types are fatal (#679)
+
+Immich retired `AssetsV1`, `AssetFacesV1`, `PartnerAssetsV1` and
+`AlbumAssetsV1`. Their server-side handlers now **throw a 400 outright**
+rather than degrading, and because the failure happens while building the
+response, a single deprecated entry in `types` kills the whole stream
+before any entity is emitted — it does not merely drop that one entity
+type. Requesting one takes down all of sync.
+
+Two consequences for this code:
+
+- **Request type and entity type move together.** `AssetsV2` emits
+  `AssetV2`, not `AssetV1`. Renaming one side without the other is a
+  *silent* break: unhandled entity types hit the
+  `debug!("ignoring unknown sync entity type")` branch in the dispatch
+  loop, so sync reports success while importing nothing. The
+  `requested_types_have_handlers` test pins the pairing.
+- **Delete entities stay at V1.** `syncAssetsV2()` and
+  `syncAssetFacesV2()` still emit `AssetDeleteV1` / `AssetFaceDeleteV1`.
+
+Payload differences from the retired shapes:
+
+| Entity | Change |
+|---|---|
+| `AssetV2` | `duration` is integer milliseconds, not a `"0:01:30.000000"` string |
+| `AssetFaceV2` | adds `deletedAt` (soft-delete) and `isVisible`; not yet persisted — migration tracked in #680 |
+
+Because Immich keys ack checkpoints by entity type, the first sync after
+moving to V2 re-streams every asset and face from scratch. Upserts are
+keyed on `external_id`, so this is idempotent — just slow once.
 
 ## API Endpoints Used
 

--- a/docs/design-immich-edit-sync.md
+++ b/docs/design-immich-edit-sync.md
@@ -190,6 +190,8 @@ types: vec![
 ],
 ```
 
+> **Superseded (#679):** `AssetsV1` and `AssetFacesV1` were retired server-side and now return 400. The live list is `SYNC_REQUEST_TYPES` in `src/sync/providers/immich/pull.rs` — see `docs/design-immich-backend.md`.
+
 ### 4.3 Push side: new outbox mutation types
 
 Add to `src/library/mutation.rs::Mutation`:

--- a/src/sync/providers/immich/handlers/asset.rs
+++ b/src/sync/providers/immich/handlers/asset.rs
@@ -16,7 +16,7 @@ pub struct AssetHandler;
 #[async_trait]
 impl SyncEntityHandler for AssetHandler {
     fn entity_type(&self) -> &'static str {
-        "AssetV1"
+        "AssetV2"
     }
 
     async fn handle(
@@ -25,7 +25,7 @@ impl SyncEntityHandler for AssetHandler {
         line_number: usize,
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
-        let asset: SyncAssetV1 = deserialize_entity(data, "AssetV1", line_number)?;
+        let asset: SyncAssetV2 = deserialize_entity(data, "AssetV2", line_number)?;
         handle_asset(asset, ctx).await?;
         Ok(HandlerResult {
             audit_action: "upsert",
@@ -35,7 +35,7 @@ impl SyncEntityHandler for AssetHandler {
 }
 
 #[instrument(skip(ctx, asset), fields(asset_id = %asset.id))]
-async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), LibraryError> {
+async fn handle_asset(asset: SyncAssetV2, ctx: &SyncContext) -> Result<(), LibraryError> {
     let media_type = match asset.asset_type.as_str() {
         "VIDEO" => MediaType::Video,
         _ => MediaType::Image,
@@ -55,7 +55,9 @@ async fn handle_asset(asset: SyncAssetV1, ctx: &SyncContext) -> Result<(), Libra
 
     let is_trashed = asset.deleted_at.is_some();
     let trashed_at = parse_datetime(&asset.deleted_at);
-    let duration_ms = asset.duration.as_deref().and_then(parse_duration_ms);
+    // `AssetsV2` sends milliseconds directly — the `"0:01:30.000000"`
+    // string parsing the V1 stream needed is gone with it. Issue #679.
+    let duration_ms = asset.duration.map(|ms| ms.max(0) as u64);
 
     // Issue #626: keep the locally-owned `MediaId` stable across the
     // upload→pull round-trip. The Immich UUID lives only in

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -15,17 +15,17 @@ pub struct AssetFaceHandler;
 #[async_trait]
 impl SyncEntityHandler for AssetFaceHandler {
     fn entity_type(&self) -> &'static str {
-        "AssetFaceV1"
+        "AssetFaceV2"
     }
 
-    #[instrument(skip(self, data, ctx), fields(entity = "AssetFaceV1"))]
+    #[instrument(skip(self, data, ctx), fields(entity = "AssetFaceV2"))]
     async fn handle(
         &self,
         data: &serde_json::Value,
         line_number: usize,
         ctx: &SyncContext,
     ) -> Result<HandlerResult, LibraryError> {
-        let face: SyncAssetFaceV1 = deserialize_entity(data, "AssetFaceV1", line_number)?;
+        let face: SyncAssetFaceV2 = deserialize_entity(data, "AssetFaceV2", line_number)?;
 
         // Issue #626: `face.asset_id` is the Immich UUID; `asset_faces.asset_id`
         // references the local `MediaId`. Translate via `external_id` lookup;
@@ -41,7 +41,7 @@ impl SyncEntityHandler for AssetFaceHandler {
                 warn!(
                     face_id = %face.id,
                     asset_id = %face.asset_id,
-                    "AssetFaceV1: parent asset not found locally; skipping face row"
+                    "AssetFaceV2: parent asset not found locally; skipping face row"
                 );
                 return Ok(HandlerResult {
                     audit_action: "upsert",

--- a/src/sync/providers/immich/handlers/mod.rs
+++ b/src/sync/providers/immich/handlers/mod.rs
@@ -82,7 +82,7 @@ pub struct SyncContext {
 /// A handler for one Immich sync entity type.
 #[async_trait]
 pub trait SyncEntityHandler: Send + Sync {
-    /// The entity type string this handler matches (e.g. "AssetV1").
+    /// The entity type string this handler matches (e.g. "AssetV2").
     fn entity_type(&self) -> &'static str;
 
     /// Deserialize the raw JSON data, apply the change, and return

--- a/src/sync/providers/immich/pull.rs
+++ b/src/sync/providers/immich/pull.rs
@@ -23,6 +23,37 @@ use super::handlers::{self, CounterKind, SyncContext};
 use super::types::*;
 use super::ACK_FLUSH_THRESHOLD;
 
+/// Entity streams requested from `POST /sync/stream`, in the order we
+/// declare them (the server applies its own `SYNC_TYPES_ORDER`).
+///
+/// Issue #679: the `AssetsV1` and `AssetFacesV1` request types were
+/// retired server-side. Immich's handlers for them now throw a 400
+/// outright rather than degrading, which fails the entire stream before
+/// a single entity is emitted — so a deprecated entry here takes down
+/// all of sync, not just its own entity type.
+///
+/// Each entry's entity types must have a registered handler in
+/// [`handlers::all_handlers`]; `requested_types_have_handlers` pins that
+/// pairing, because an unhandled entity type is silently ignored by the
+/// dispatch loop rather than raised as an error.
+const SYNC_REQUEST_TYPES: &[&str] = &[
+    "AssetsV2",
+    "AssetExifsV1",
+    "AlbumsV1",
+    "AlbumToAssetsV1",
+    "PeopleV1",
+    "AssetFacesV2",
+    // Issue #224: stacks arrive on their own stream as SyncStackV1 /
+    // SyncStackDeleteV1. AssetV2 carries only `stackId`; the primary
+    // lives on StackV1.
+    "StacksV1",
+    // Issue #224 Phase B: per-action geometric edit records. Each
+    // SyncAssetEditV1 carries one (action, parameters, sequence) tuple;
+    // the handler caches them and recomposes a local EditState from the
+    // asset's full action list.
+    "AssetEditsV1",
+];
+
 /// Counters for a single sync cycle.
 #[derive(Default)]
 struct SyncCounters {
@@ -150,23 +181,10 @@ impl PullManager {
     #[instrument(skip(self))]
     async fn run_sync(&self) -> Result<(usize, usize), LibraryError> {
         let request = SyncStreamRequest {
-            types: vec![
-                "AssetsV1".to_string(),
-                "AssetExifsV1".to_string(),
-                "AlbumsV1".to_string(),
-                "AlbumToAssetsV1".to_string(),
-                "PeopleV1".to_string(),
-                "AssetFacesV1".to_string(),
-                // Issue #224: stacks arrive on their own stream as
-                // SyncStackV1 / SyncStackDeleteV1. AssetV1 carries
-                // only `stackId`; the primary lives on StackV1.
-                "StacksV1".to_string(),
-                // Issue #224 Phase B: per-action geometric edit records.
-                // Each SyncAssetEditV1 carries one (action, parameters,
-                // sequence) tuple; the handler caches them and recomposes
-                // a local EditState from the asset's full action list.
-                "AssetEditsV1".to_string(),
-            ],
+            types: SYNC_REQUEST_TYPES
+                .iter()
+                .map(|t| (*t).to_string())
+                .collect(),
         };
 
         debug!("starting sync stream");
@@ -487,5 +505,64 @@ mod tests {
         assert_eq!(c.assets, 2);
         assert_eq!(c.deletes, 1);
         assert_eq!(c.errors, 0);
+    }
+
+    /// Issue #679: a request type and the entity types it produces move
+    /// together. Renaming one side without the other is not a loud
+    /// failure — the dispatch loop logs unknown entity types at `debug`
+    /// and carries on, so sync reports success while importing nothing.
+    /// This pins the pairing so that combination cannot ship.
+    #[test]
+    fn requested_types_have_handlers() {
+        // (request type, entity types it emits on the stream)
+        let contract: &[(&str, &[&str])] = &[
+            ("AssetsV2", &["AssetV2", "AssetDeleteV1"]),
+            ("AssetExifsV1", &["AssetExifV1"]),
+            ("AlbumsV1", &["AlbumV1", "AlbumDeleteV1"]),
+            (
+                "AlbumToAssetsV1",
+                &["AlbumToAssetV1", "AlbumToAssetDeleteV1"],
+            ),
+            ("PeopleV1", &["PersonV1", "PersonDeleteV1"]),
+            ("AssetFacesV2", &["AssetFaceV2", "AssetFaceDeleteV1"]),
+            ("StacksV1", &["StackV1", "StackDeleteV1"]),
+            ("AssetEditsV1", &["AssetEditV1", "AssetEditDeleteV1"]),
+        ];
+
+        let requested: Vec<&str> = contract.iter().map(|(req, _)| *req).collect();
+        assert_eq!(
+            requested, SYNC_REQUEST_TYPES,
+            "SYNC_REQUEST_TYPES changed without updating the entity-type contract below"
+        );
+
+        let handlers = handlers::all_handlers();
+        let registered: Vec<&str> = handlers.iter().map(|h| h.entity_type()).collect();
+
+        for (request_type, entity_types) in contract {
+            for entity in *entity_types {
+                assert!(
+                    registered.contains(entity),
+                    "requesting {request_type} but no handler is registered for its \
+                     {entity} entities — sync would silently drop them"
+                );
+            }
+        }
+    }
+
+    /// Immich throws a 400 for these rather than degrading, which takes
+    /// down the whole stream. Issue #679.
+    #[test]
+    fn no_retired_request_types() {
+        for retired in [
+            "AssetsV1",
+            "AssetFacesV1",
+            "PartnerAssetsV1",
+            "AlbumAssetsV1",
+        ] {
+            assert!(
+                !SYNC_REQUEST_TYPES.contains(&retired),
+                "{retired} is deprecated server-side and 400s the entire sync stream"
+            );
+        }
     }
 }

--- a/src/sync/providers/immich/types.rs
+++ b/src/sync/providers/immich/types.rs
@@ -32,8 +32,14 @@ pub(crate) struct SyncAckRequest {
 
 // ── Asset types ─────────────────────────────────────────────────────────────
 
+/// Asset entity emitted on the `AssetsV2` sync stream.
+///
+/// Identical to the retired `SyncAssetV1` except for `duration`, which
+/// Immich changed from a formatted `"H:MM:SS.ffffff"` string to plain
+/// integer milliseconds when `asset.duration` became an `integer`
+/// column server-side. Issue #679.
 #[derive(Debug, Deserialize)]
-pub(crate) struct SyncAssetV1 {
+pub(crate) struct SyncAssetV2 {
     pub id: String,
     #[serde(rename = "originalFileName")]
     pub original_file_name: String,
@@ -49,7 +55,10 @@ pub(crate) struct SyncAssetV1 {
     pub is_favorite: bool,
     pub width: Option<i64>,
     pub height: Option<i64>,
-    pub duration: Option<String>,
+    /// Runtime in milliseconds, or `None` for stills. Already in the
+    /// unit `media.duration_ms` stores, so no conversion is needed —
+    /// `AssetsV1` sent this as a `"0:01:30.000000"` string instead.
+    pub duration: Option<i64>,
     /// SHA-1 of the file's bytes, base64-encoded. Stored verbatim into
     /// `media.content_hash` so locally-imported and server-pulled rows
     /// share a comparable dedup key. Optional in the serde shape so
@@ -206,8 +215,12 @@ pub(crate) struct SyncPersonDeleteV1 {
     pub person_id: String,
 }
 
+/// Face entity emitted on the `AssetFacesV2` sync stream.
+///
+/// A superset of the retired `SyncAssetFaceV1`: same geometry, plus
+/// `deletedAt` and `isVisible`. Issue #679.
 #[derive(Debug, Deserialize)]
-pub(crate) struct SyncAssetFaceV1 {
+pub(crate) struct SyncAssetFaceV2 {
     pub id: String,
     #[serde(rename = "assetId")]
     pub asset_id: String,
@@ -227,6 +240,26 @@ pub(crate) struct SyncAssetFaceV1 {
     pub bounding_box_y2: i32,
     #[serde(rename = "sourceType")]
     pub source_type: Option<String>,
+    /// Server-side soft-deletion timestamp, or `None` while the face is
+    /// live. Hard deletes still arrive separately as
+    /// `AssetFaceDeleteV1`, so this is purely the soft-delete state.
+    ///
+    /// Captured for the contract but not yet persisted — `asset_faces`
+    /// has no column for it. Migration tracked in #680.
+    #[allow(dead_code)]
+    #[serde(rename = "deletedAt", default)]
+    pub deleted_at: Option<String>,
+    /// Whether the face is visible in the asset. Defaults to `true` so
+    /// a server that pre-dates the field doesn't hide every face.
+    ///
+    /// Captured for the contract but not yet persisted — see #680.
+    #[allow(dead_code)]
+    #[serde(rename = "isVisible", default = "default_true")]
+    pub is_visible: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize)]
@@ -261,18 +294,6 @@ pub(crate) fn parse_datetime(s: &Option<String>) -> Option<i64> {
         .map(|dt| dt.timestamp())
 }
 
-/// Parse Immich duration string (e.g. "0:01:30.000000") to milliseconds.
-pub(crate) fn parse_duration_ms(s: &str) -> Option<u64> {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-    let hours: u64 = parts[0].parse().ok()?;
-    let minutes: u64 = parts[1].parse().ok()?;
-    let seconds: f64 = parts[2].parse().ok()?;
-    Some(hours * 3_600_000 + minutes * 60_000 + (seconds * 1000.0) as u64)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,50 +318,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_duration_ms_standard() {
-        assert_eq!(parse_duration_ms("0:01:30.000000"), Some(90_000));
-    }
-
-    #[test]
-    fn parse_duration_ms_with_hours() {
-        assert_eq!(parse_duration_ms("1:02:03.500000"), Some(3_723_500));
-    }
-
-    #[test]
-    fn parse_duration_ms_invalid_format() {
-        assert!(parse_duration_ms("invalid").is_none());
-    }
-
-    #[test]
     fn deserialize_sync_line() {
-        let json = r#"{"type":"AssetV1","data":{},"ack":"abc123"}"#;
+        let json = r#"{"type":"AssetV2","data":{},"ack":"abc123"}"#;
         let line: SyncLine = serde_json::from_str(json).unwrap();
-        assert_eq!(line.entity_type, "AssetV1");
+        assert_eq!(line.entity_type, "AssetV2");
         assert_eq!(line.ack, "abc123");
     }
 
     // ── Additional DTO deserialization tests ──────────────────────────
-
-    #[test]
-    fn parse_duration_ms_zero() {
-        assert_eq!(parse_duration_ms("0:00:00.000000"), Some(0));
-    }
-
-    #[test]
-    fn parse_duration_ms_fractional_seconds() {
-        // 0h 0m 1.5s = 1500ms
-        assert_eq!(parse_duration_ms("0:00:01.500000"), Some(1_500));
-    }
-
-    #[test]
-    fn parse_duration_ms_too_few_parts() {
-        assert!(parse_duration_ms("30.000").is_none());
-    }
-
-    #[test]
-    fn parse_duration_ms_non_numeric() {
-        assert!(parse_duration_ms("a:b:c").is_none());
-    }
 
     #[test]
     fn parse_datetime_with_offset() {
@@ -351,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_sync_asset_v1() {
+    fn deserialize_sync_asset_v2() {
         let json = serde_json::json!({
             "id": "uuid-1234",
             "originalFileName": "DSC_0001.jpg",
@@ -366,7 +351,7 @@ mod tests {
             "checksum": "qZk+NkcGgWq6PiVxeFDCbJzQ2J0="
         });
 
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert_eq!(asset.id, "uuid-1234");
         assert_eq!(asset.original_file_name, "DSC_0001.jpg");
         assert_eq!(asset.asset_type, "IMAGE");
@@ -385,7 +370,7 @@ mod tests {
     /// `checksum` field — deserialisation must still succeed and leave
     /// the field as `None` rather than failing the whole sync line.
     #[test]
-    fn deserialize_sync_asset_v1_without_checksum_is_optional() {
+    fn deserialize_sync_asset_v2_without_checksum_is_optional() {
         let json = serde_json::json!({
             "id": "uuid-noosum",
             "originalFileName": "old.jpg",
@@ -398,14 +383,35 @@ mod tests {
             "height": null,
             "duration": null
         });
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert!(asset.checksum.is_none());
     }
 
-    /// Issue #224: `AssetV1` carries flat `stackId` (not a nested
+    /// Issue #679: `AssetsV2` sends `duration` as integer milliseconds
+    /// rather than the `"0:01:30.000000"` string `AssetsV1` used.
+    #[test]
+    fn deserialize_sync_asset_v2_duration_is_integer_milliseconds() {
+        let json = serde_json::json!({
+            "id": "uuid-video",
+            "originalFileName": "clip.mp4",
+            "fileCreatedAt": "2024-06-15T10:30:00.000Z",
+            "localDateTime": null,
+            "type": "VIDEO",
+            "deletedAt": null,
+            "isFavorite": false,
+            "width": 1920,
+            "height": 1080,
+            "duration": 3_723_500
+        });
+
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
+        assert_eq!(asset.duration, Some(3_723_500));
+    }
+
+    /// Issue #224: `AssetV2` carries flat `stackId` (not a nested
     /// object). The matching `SyncStackV1` event carries the primary.
     #[test]
-    fn deserialize_sync_asset_v1_with_stack_id() {
+    fn deserialize_sync_asset_v2_with_stack_id() {
         let json = serde_json::json!({
             "id": "asset-uuid",
             "originalFileName": "burst.jpg",
@@ -420,14 +426,14 @@ mod tests {
             "stackId": "stack-uuid",
             "isEdited": true
         });
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert_eq!(asset.stack_id.as_deref(), Some("stack-uuid"));
         assert_eq!(asset.is_edited, Some(true));
     }
 
     /// `stackId` is `null` when the asset is not in a stack.
     #[test]
-    fn deserialize_sync_asset_v1_with_null_stack_id() {
+    fn deserialize_sync_asset_v2_with_null_stack_id() {
         let json = serde_json::json!({
             "id": "asset-uuid",
             "originalFileName": "lone.jpg",
@@ -442,7 +448,7 @@ mod tests {
             "stackId": null,
             "isEdited": false
         });
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert!(asset.stack_id.is_none());
         assert_eq!(asset.is_edited, Some(false));
     }
@@ -450,7 +456,7 @@ mod tests {
     /// Older Immich versions don't emit `stackId`/`isEdited` at all —
     /// deserialisation must succeed and leave both fields `None`.
     #[test]
-    fn deserialize_sync_asset_v1_without_stack_fields_is_optional() {
+    fn deserialize_sync_asset_v2_without_stack_fields_is_optional() {
         let json = serde_json::json!({
             "id": "asset-old",
             "originalFileName": "old.jpg",
@@ -463,7 +469,7 @@ mod tests {
             "height": null,
             "duration": null
         });
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert!(asset.stack_id.is_none());
         assert!(asset.is_edited.is_none());
     }
@@ -492,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_sync_asset_v1_video() {
+    fn deserialize_sync_asset_v2_video() {
         let json = serde_json::json!({
             "id": "video-uuid",
             "originalFileName": "MOV_001.mp4",
@@ -503,16 +509,16 @@ mod tests {
             "isFavorite": false,
             "width": 1920,
             "height": 1080,
-            "duration": "0:01:30.000000"
+            "duration": 90_000
         });
 
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert_eq!(asset.asset_type, "VIDEO");
-        assert_eq!(asset.duration.as_deref(), Some("0:01:30.000000"));
+        assert_eq!(asset.duration, Some(90_000));
     }
 
     #[test]
-    fn deserialize_sync_asset_v1_trashed() {
+    fn deserialize_sync_asset_v2_trashed() {
         let json = serde_json::json!({
             "id": "trashed-uuid",
             "originalFileName": "photo.jpg",
@@ -526,7 +532,7 @@ mod tests {
             "duration": null
         });
 
-        let asset: SyncAssetV1 = serde_json::from_value(json).unwrap();
+        let asset: SyncAssetV2 = serde_json::from_value(json).unwrap();
         assert!(asset.deleted_at.is_some());
         assert_eq!(
             asset.deleted_at.as_deref(),
@@ -690,7 +696,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_sync_asset_face_v1() {
+    fn deserialize_sync_asset_face_v2() {
         let json = serde_json::json!({
             "id": "face-uuid",
             "assetId": "asset-uuid",
@@ -704,7 +710,7 @@ mod tests {
             "sourceType": "MachineLearning"
         });
 
-        let face: SyncAssetFaceV1 = serde_json::from_value(json).unwrap();
+        let face: SyncAssetFaceV2 = serde_json::from_value(json).unwrap();
         assert_eq!(face.id, "face-uuid");
         assert_eq!(face.asset_id, "asset-uuid");
         assert_eq!(face.person_id.as_deref(), Some("person-uuid"));
@@ -718,7 +724,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_sync_asset_face_v1_no_person() {
+    fn deserialize_sync_asset_face_v2_no_person() {
         let json = serde_json::json!({
             "id": "face-no-person",
             "assetId": "asset-uuid",
@@ -732,9 +738,55 @@ mod tests {
             "sourceType": null
         });
 
-        let face: SyncAssetFaceV1 = serde_json::from_value(json).unwrap();
+        let face: SyncAssetFaceV2 = serde_json::from_value(json).unwrap();
         assert!(face.person_id.is_none());
         assert!(face.source_type.is_none());
+    }
+
+    /// Issue #679: `AssetFaceV2` adds `deletedAt` and `isVisible` on top
+    /// of the retired V1 shape.
+    #[test]
+    fn deserialize_sync_asset_face_v2_visibility_fields() {
+        let json = serde_json::json!({
+            "id": "face-v2",
+            "assetId": "asset-uuid",
+            "personId": "person-uuid",
+            "imageWidth": 4032,
+            "imageHeight": 3024,
+            "boundingBoxX1": 100,
+            "boundingBoxY1": 200,
+            "boundingBoxX2": 300,
+            "boundingBoxY2": 400,
+            "sourceType": "MachineLearning",
+            "deletedAt": "2026-08-23T10:15:18.000Z",
+            "isVisible": false
+        });
+
+        let face: SyncAssetFaceV2 = serde_json::from_value(json).unwrap();
+        assert_eq!(face.deleted_at.as_deref(), Some("2026-08-23T10:15:18.000Z"));
+        assert!(!face.is_visible);
+    }
+
+    /// A server that pre-dates the V2 face fields must not make every
+    /// face invisible — `isVisible` defaults to `true` when absent.
+    #[test]
+    fn deserialize_sync_asset_face_v2_defaults_to_visible() {
+        let json = serde_json::json!({
+            "id": "face-no-visibility",
+            "assetId": "asset-uuid",
+            "personId": null,
+            "imageWidth": 1920,
+            "imageHeight": 1080,
+            "boundingBoxX1": 50,
+            "boundingBoxY1": 50,
+            "boundingBoxX2": 150,
+            "boundingBoxY2": 150,
+            "sourceType": null
+        });
+
+        let face: SyncAssetFaceV2 = serde_json::from_value(json).unwrap();
+        assert!(face.is_visible);
+        assert!(face.deleted_at.is_none());
     }
 
     #[test]
@@ -765,12 +817,12 @@ mod tests {
     #[test]
     fn sync_stream_request_serializes() {
         let req = SyncStreamRequest {
-            types: vec!["AssetsV1".to_string(), "AlbumsV1".to_string()],
+            types: vec!["AssetsV2".to_string(), "AlbumsV1".to_string()],
         };
         let json = serde_json::to_value(&req).unwrap();
         let types = json["types"].as_array().unwrap();
         assert_eq!(types.len(), 2);
-        assert_eq!(types[0], "AssetsV1");
+        assert_eq!(types[0], "AssetsV2");
     }
 
     #[test]

--- a/src/sync/state/repository.rs
+++ b/src/sync/state/repository.rs
@@ -175,7 +175,7 @@ mod tests {
         let repo = SyncStateRepository::new(db.clone());
 
         let row_id = repo
-            .start_audit("AssetV1", "uuid-1", "cycle-1")
+            .start_audit("AssetV2", "uuid-1", "cycle-1")
             .await
             .unwrap();
         assert!(row_id > 0);
@@ -198,7 +198,7 @@ mod tests {
         let repo = SyncStateRepository::new(db.clone());
 
         let row_id = repo
-            .start_audit("AssetV1", "uuid-fail", "cycle-2")
+            .start_audit("AssetV2", "uuid-fail", "cycle-2")
             .await
             .unwrap();
 
@@ -220,13 +220,13 @@ mod tests {
         let repo = SyncStateRepository::new(db.clone());
 
         let pairs = vec![
-            ("AssetV1".to_string(), "ack-asset-100".to_string()),
+            ("AssetV2".to_string(), "ack-asset-100".to_string()),
             ("AlbumV1".to_string(), "ack-album-50".to_string()),
         ];
         repo.save_checkpoints(&pairs).await.unwrap();
 
         let row: (String,) =
-            sqlx::query_as("SELECT ack FROM sync_checkpoints WHERE entity_type = 'AssetV1'")
+            sqlx::query_as("SELECT ack FROM sync_checkpoints WHERE entity_type = 'AssetV2'")
                 .fetch_one(db.pool())
                 .await
                 .unwrap();
@@ -246,15 +246,15 @@ mod tests {
         let (_dir, db) = open_db().await;
         let repo = SyncStateRepository::new(db.clone());
 
-        repo.save_checkpoints(&[("AssetV1".to_string(), "ack-1".to_string())])
+        repo.save_checkpoints(&[("AssetV2".to_string(), "ack-1".to_string())])
             .await
             .unwrap();
-        repo.save_checkpoints(&[("AssetV1".to_string(), "ack-2".to_string())])
+        repo.save_checkpoints(&[("AssetV2".to_string(), "ack-2".to_string())])
             .await
             .unwrap();
 
         let row: (String,) =
-            sqlx::query_as("SELECT ack FROM sync_checkpoints WHERE entity_type = 'AssetV1'")
+            sqlx::query_as("SELECT ack FROM sync_checkpoints WHERE entity_type = 'AssetV2'")
                 .fetch_one(db.pool())
                 .await
                 .unwrap();
@@ -355,7 +355,7 @@ mod tests {
         let (_dir, db) = open_db().await;
         let repo = SyncStateRepository::new(db.clone());
 
-        // Most recent reset/complete is the reset; AssetV1 rows after
+        // Most recent reset/complete is the reset; AssetV2 rows after
         // it (the dispatch in the resumed stream) shouldn't shift us
         // out of reset mode.
         let reset_id = repo
@@ -364,13 +364,13 @@ mod tests {
             .unwrap();
         repo.complete_audit(reset_id, "reset").await.unwrap();
         for _ in 0..3 {
-            let aid = repo.start_audit("AssetV1", "", "cycle-1").await.unwrap();
+            let aid = repo.start_audit("AssetV2", "", "cycle-1").await.unwrap();
             repo.complete_audit(aid, "upsert").await.unwrap();
         }
 
         assert!(
             repo.current_reset_checkpoint().await.unwrap().is_some(),
-            "AssetV1 audit rows must not close the reset cycle"
+            "AssetV2 audit rows must not close the reset cycle"
         );
     }
 }


### PR DESCRIPTION
Fixes #679.

Immich retired the V1 sync request types. Their server-side handlers now throw a 400 outright rather than degrading:

```ts
private syncAssetsV1(): Promise<void> {
  throw new BadRequestException('SyncRequestType.AssetsV1 is deprecated, use SyncRequestType.AssetsV2 instead');
}
```

Because that happens while building the response, one deprecated entry in `types` fails the entire stream before a single entity is emitted. Every pull cycle died, nothing reached the local library, and the sidebar indicator sat in `Error`.

**Two of our eight request types were deprecated, not one.** `AssetsV1` *and* `AssetFacesV1`. The server iterates its own `SYNC_TYPES_ORDER`, so assets throws first and masks faces — fixing only assets would have moved the identical 400 onto faces on the very next cycle.

## What changed

The request type governs the entity type on the stream, so the handlers move with it:

| | before | after |
|---|---|---|
| request | `AssetsV1`, `AssetFacesV1` | `AssetsV2`, `AssetFacesV2` |
| entity | `AssetV1`, `AssetFaceV1` | `AssetV2`, `AssetFaceV2` |
| delete entity | `AssetDeleteV1`, `AssetFaceDeleteV1` | unchanged |

Delete entities genuinely stay at V1 — `syncAssetsV2()` and `syncAssetFacesV2()` still emit the V1 delete shapes.

**Payload differences:**

- `AssetV2.duration` is integer milliseconds instead of a `"0:01:30.000000"` string, following Immich's `asset.duration` becoming an `integer` column. That is already the unit `media.duration_ms` stores, so `parse_duration_ms` and its seven tests are deleted rather than adapted.
- `AssetFaceV2` adds `deletedAt` and `isVisible`. Captured for the contract but **not persisted** — `asset_faces` has no columns for them, and adding them needs a migration plus read-path filtering. Tracked in #680.

No schema migration in this PR.

## The silent-failure guard

An unhandled entity type falls through to `debug!("ignoring unknown sync entity type")` in the dispatch loop. So renaming a request type without its handler doesn't error — it reports a **successful sync that imported nothing**. That is a worse failure than the 400 this PR fixes.

The request list is now a `SYNC_REQUEST_TYPES` const with two tests pinning it:

- `requested_types_have_handlers` — every requested type has registered handlers for each entity it produces
- `no_retired_request_types` — no deprecated type creeps back in

I verified the first one actually fails by reverting `AssetHandler::entity_type()` to `"AssetV1"` and confirming a red run before restoring it.

## Verification

- `make lint` clean (clippy + fmt, both feature sets)
- `make test` — 615 passed, 0 failed
- **Verified against a live Immich server**: full sync completed, producing 10 people, 307 `asset_faces`, 394 media, correct `face_count` values, and all 10 person thumbnails downloaded

## One thing to expect on upgrade

The first sync after this **re-streams every asset and face**. Immich keys ack checkpoints by entity type, so `AssetV2` starts with no checkpoint. Upserts key on `external_id`, so it is idempotent — just one slow cycle before it settles.

## Compatibility

This drops support for Immich servers predating `AssetsV2`; an older server will 400 with "each value in types must be one of the following values". Supporting both would need a version probe and a branched handler registry, for a server generation that is already EOL — `client.rs` already carries a `Verified idempotent on Immich v2.7.5` note, so we were targeting 2.x regardless. Happy to revisit if you'd rather keep a compatibility path.

## Docs

`docs/design-immich-backend.md` gets the current request-type table and a new section on why a V1 type is fatal and how request/entity types must move together. The two historical design docs (`design-face-integration.md`, `design-immich-edit-sync.md`) get superseded notes pointing at the live list rather than being rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
