### PR TITLE
chore: release v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "moments"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "moments"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A GNOME photo management app with local and Immich server support"
 license = "GPL-3.0-or-later"

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 project('moments', 'rust', 
-          version: '0.4.1',
+          version: '0.4.2',
     meson_version: '>= 1.0.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )


### PR DESCRIPTION
Bumps version to **0.4.2**. Merging this PR creates the git tag, the GitHub Release, and the bundle build.

This is a **hotfix release**. On 0.4.1, Immich sync is completely non-functional against current server versions — every pull cycle fails and no photos, albums, people or edits reach the library. Anyone using the Immich backend should upgrade.

## What's fixed

**Immich sync restored** (#679, #682).

Immich retired the `AssetsV1` and `AssetFacesV1` sync request types. Their server-side handlers now throw a `400` outright rather than degrading, and because that happens while the response is being built, a single deprecated entry fails the whole stream before any data is emitted:

```
POST /sync/stream returned 400 Bad Request:
{"message":"SyncRequestType.AssetsV1 is deprecated, use SyncRequestType.AssetsV2 instead"}
```

Moments now requests `AssetsV2` and `AssetFacesV2`, with the matching `AssetV2` / `AssetFaceV2` entity handlers. Two regression tests pin the request-type↔handler pairing, because a mismatch there produces a sync that *reports success while importing nothing* — a worse failure than the 400 itself.

No database migration. No configuration change. Upgrade and sync resumes.

---

## ⚠️ Read before upgrading

### The first sync will re-download your whole library index

Immich tracks sync progress with per-entity-type checkpoints. Because the entity type changed from `AssetV1` to `AssetV2`, the server has no checkpoint for the new type and **re-streams every asset and face from scratch** on the first cycle after upgrading.

- On a large library this is one long sync cycle — the status bar will show sustained activity for a while
- **This is expected, not a fault.** Let it finish rather than restarting the app
- Nothing is duplicated or lost: upserts are keyed on the Immich asset ID, so re-streamed rows update in place
- Subsequent syncs return to normal incremental behaviour

### Requires a current Immich server

This release targets Immich 2.x. A server predating the `AssetsV2` sync type will reject the new request with:

```
each value in types must be one of the following values
```

If you are on an older Immich server, **0.4.2 will not fix your sync — it will change the error message**. Update your Immich server first. Supporting both request generations would require a version probe and a branched handler registry for a server generation that is already end-of-life; if that affects you, please open an issue.

---

## Known issue

After this release restores face sync, many users will populate the People view for the first time. Note that **the People view hides unnamed people by default** — if nobody in your Immich library has been named yet, the view will appear empty. Click the **Show Unnamed** button (the leftmost avatar icon in the People header bar) to reveal them.

This is tracked in #681 and is not fixed in 0.4.2.

## Also in this release

- Design docs updated with the V2 request/entity tables and why a deprecated request type is fatal to the whole stream

## Follow-ups

- #680 — persist and honour `isVisible` / `deletedAt`, which `AssetFaceV2` now provides
- #681 — show unnamed people by default
