### PR TITLE
feat: persist and honour isVisible / deletedAt from AssetFaceV2

### DIFF
--- a/docs/design-face-integration.md
+++ b/docs/design-face-integration.md
@@ -158,6 +158,26 @@ CREATE INDEX idx_asset_faces_asset ON asset_faces(asset_id);
 CREATE INDEX idx_asset_faces_person ON asset_faces(person_id);
 ```
 
+### Migration 027: `add_asset_face_visibility` — [#680](https://github.com/justinf555/Moments/issues/680)
+
+`AssetFaceV2` carries two fields V1 did not, and Immich distinguishes three face states where the original schema had one:
+
+```sql
+ALTER TABLE asset_faces ADD COLUMN is_visible INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE asset_faces ADD COLUMN deleted_at INTEGER;
+```
+
+| state | wire | local |
+|---|---|---|
+| live and visible | `isVisible: true`, `deletedAt: null` | counts and shows |
+| hidden in the asset | `isVisible: false` | row kept, filtered out |
+| soft-deleted | `deletedAt` set | row kept, filtered out |
+| hard-deleted | `AssetFaceDeleteV1` | row deleted |
+
+Inactive faces are **filtered, not deleted**: that matches the server's own model, and an un-delete or un-hide on the server takes effect on the next sync with no resync. Both column defaults leave pre-027 rows in the "live and visible" state, so existing libraries upgrade with no visible change.
+
+Every read that answers "which media / how many faces does this person have" filters on `is_visible = 1 AND deleted_at IS NULL` — `FacesRepository::list_media_for_person`, `FacesRepository::update_face_count`, `FacesRepository::get_asset_face_effective_person_id`, and `MediaFilter::Person` in `MediaRepository`. The heartbeat sweeps (`delete_*_with_stale_heartbeat`, `persons_with_stale_faces`) deliberately do not: they reap rows the server has stopped sending regardless of state.
+
 The `face_count` column on `people` is a denormalised count maintained by triggers or updated during sync. It enables sorting the People sidebar by number of photos without a join.
 
 ## Library Trait

--- a/src/library/db/migrations/027_add_asset_face_visibility.sql
+++ b/src/library/db/migrations/027_add_asset_face_visibility.sql
@@ -1,0 +1,16 @@
+-- Issue #680: persist the `isVisible` / `deletedAt` fields that
+-- `AssetFaceV2` brings down the sync stream.
+--
+-- Immich distinguishes three face states that we previously flattened
+-- into one: live and visible, live but hidden (`isVisible: false`), and
+-- soft-deleted (`deletedAt` set, hard delete still arrives later as a
+-- separate `AssetFaceDeleteV1`). Faces in the latter two states must
+-- stop contributing to a person's grid and `face_count`.
+--
+-- Soft-deleted rows are filtered, not deleted: that matches the server's
+-- own model and survives an un-delete without waiting for a resync.
+--
+-- Both defaults keep existing rows in the current "live and visible"
+-- behaviour, so no backfill and no forced resync.
+ALTER TABLE asset_faces ADD COLUMN is_visible INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE asset_faces ADD COLUMN deleted_at INTEGER;

--- a/src/library/faces/repository.rs
+++ b/src/library/faces/repository.rs
@@ -16,6 +16,7 @@ struct PersonRow {
 }
 
 /// Internal row type for asset face upserts (from sync).
+#[derive(Clone)]
 pub(crate) struct AssetFaceRow {
     pub id: String,
     pub asset_id: String,
@@ -27,6 +28,11 @@ pub(crate) struct AssetFaceRow {
     pub bbox_x2: i32,
     pub bbox_y2: i32,
     pub source_type: String,
+    /// Issue #680: `false` when Immich hides the face in the asset.
+    pub is_visible: bool,
+    /// Issue #680: server-side soft-deletion timestamp, or `None` while
+    /// the face is live.
+    pub deleted_at: Option<i64>,
 }
 
 /// Faces/people persistence layer.
@@ -86,6 +92,11 @@ impl FacesRepository {
     }
 
     /// List media IDs for all assets containing a specific person.
+    ///
+    /// Issue #680: faces hidden (`is_visible = 0`) or soft-deleted
+    /// (`deleted_at` set) on the server don't put their asset in the
+    /// person's grid. The rows stay — Immich can reverse either state —
+    /// so this is a filter, not a delete.
     pub async fn list_media_for_person(
         &self,
         person_id: &str,
@@ -96,6 +107,7 @@ impl FacesRepository {
              LEFT JOIN stacks s ON m.stack_id = s.id
              LEFT JOIN media render ON render.stack_id = s.id AND render.is_moments_render = 1
              WHERE af.person_id = ? AND m.is_trashed = 0
+               AND af.is_visible = 1 AND af.deleted_at IS NULL
                AND (s.id IS NULL AND m.is_moments_render = 0
                     OR (render.id IS NULL AND s.primary_asset_id = m.id)
                     OR (render.id IS NOT NULL AND m.is_moments_render = 0))
@@ -190,8 +202,8 @@ impl FacesRepository {
     /// Upsert an asset face record (from sync).
     pub(crate) async fn upsert_asset_face(&self, face: &AssetFaceRow) -> Result<(), LibraryError> {
         sqlx::query(
-            "INSERT INTO asset_faces (id, asset_id, person_id, image_width, image_height, bbox_x1, bbox_y1, bbox_x2, bbox_y2, source_type)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "INSERT INTO asset_faces (id, asset_id, person_id, image_width, image_height, bbox_x1, bbox_y1, bbox_x2, bbox_y2, source_type, is_visible, deleted_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(id) DO UPDATE SET
                  asset_id = excluded.asset_id,
                  person_id = excluded.person_id,
@@ -201,7 +213,9 @@ impl FacesRepository {
                  bbox_y1 = excluded.bbox_y1,
                  bbox_x2 = excluded.bbox_x2,
                  bbox_y2 = excluded.bbox_y2,
-                 source_type = excluded.source_type",
+                 source_type = excluded.source_type,
+                 is_visible = excluded.is_visible,
+                 deleted_at = excluded.deleted_at",
         )
         .bind(&face.id)
         .bind(&face.asset_id)
@@ -213,24 +227,36 @@ impl FacesRepository {
         .bind(face.bbox_x2)
         .bind(face.bbox_y2)
         .bind(&face.source_type)
+        .bind(face.is_visible)
+        .bind(face.deleted_at)
         .execute(self.db.pool())
         .await
         .map_err(LibraryError::Db)?;
         Ok(())
     }
 
-    /// Look up the `person_id` currently assigned to an asset face.
+    /// Look up the person an asset face currently contributes media to.
     ///
-    /// Returns `None` if the face row does not exist, or if the row exists
-    /// with a null `person_id`. Callers that need to distinguish those two
-    /// cases must query separately.
-    pub async fn get_asset_face_person_id(&self, id: &str) -> Result<Option<String>, LibraryError> {
-        let row: Option<(Option<String>,)> =
-            sqlx::query_as("SELECT person_id FROM asset_faces WHERE id = ?")
-                .bind(id)
-                .fetch_optional(self.db.pool())
-                .await
-                .map_err(LibraryError::Db)?;
+    /// Returns `None` if the face row does not exist, if it has a null
+    /// `person_id`, or — issue #680 — if it is hidden or soft-deleted
+    /// server-side and so contributes to nobody. Callers that need to
+    /// distinguish those cases must query separately.
+    ///
+    /// Folding visibility into the answer is what lets
+    /// `FacesService::upsert_asset_face` emit `PersonMediaChanged` when a
+    /// face is hidden or un-hidden without its `person_id` changing.
+    pub async fn get_asset_face_effective_person_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<String>, LibraryError> {
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT person_id FROM asset_faces
+             WHERE id = ? AND is_visible = 1 AND deleted_at IS NULL",
+        )
+        .bind(id)
+        .fetch_optional(self.db.pool())
+        .await
+        .map_err(LibraryError::Db)?;
         Ok(row.and_then(|(p,)| p))
     }
 
@@ -251,10 +277,14 @@ impl FacesRepository {
     }
 
     /// Recount faces for a person and update the denormalised face_count.
+    ///
+    /// Issue #680: counts only faces that are visible and not
+    /// soft-deleted server-side, matching `list_media_for_person`.
     pub async fn update_face_count(&self, person_id: &str) -> Result<(), LibraryError> {
         sqlx::query(
             "UPDATE people SET face_count = (
-                SELECT COUNT(*) FROM asset_faces WHERE person_id = ?
+                SELECT COUNT(*) FROM asset_faces
+                WHERE person_id = ? AND is_visible = 1 AND deleted_at IS NULL
             ) WHERE id = ?",
         )
         .bind(person_id)
@@ -386,6 +416,26 @@ mod tests {
         (repo, media, db)
     }
 
+    /// A visible, live face row — what every test assumed before #680
+    /// gave `asset_faces` a visibility state. Override with struct
+    /// update syntax for the hidden/soft-deleted cases.
+    fn face_row(id: &str, asset_id: &str, person_id: Option<&str>) -> AssetFaceRow {
+        AssetFaceRow {
+            id: id.to_string(),
+            asset_id: asset_id.to_string(),
+            person_id: person_id.map(str::to_string),
+            image_width: 100,
+            image_height: 100,
+            bbox_x1: 0,
+            bbox_y1: 0,
+            bbox_x2: 50,
+            bbox_y2: 50,
+            source_type: "MachineLearning".to_string(),
+            is_visible: true,
+            deleted_at: None,
+        }
+    }
+
     #[tokio::test]
     async fn upsert_and_list_people() {
         let dir = tempdir().unwrap();
@@ -455,42 +505,9 @@ mod tests {
         media.insert(&rec1).await.unwrap();
         media.insert(&rec2).await.unwrap();
 
-        let face1 = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p2".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
-        let face2 = AssetFaceRow {
-            id: "f2".to_string(),
-            asset_id: "m2".to_string(),
-            person_id: Some("p2".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
-        let face3 = AssetFaceRow {
-            id: "f3".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 60,
-            bbox_y1: 60,
-            bbox_x2: 90,
-            bbox_y2: 90,
-            source_type: "MachineLearning".to_string(),
-        };
+        let face1 = face_row("f1", "m1", Some("p2"));
+        let face2 = face_row("f2", "m2", Some("p2"));
+        let face3 = face_row("f3", "m1", Some("p1"));
         repo.upsert_asset_face(&face1).await.unwrap();
         repo.upsert_asset_face(&face2).await.unwrap();
         repo.upsert_asset_face(&face3).await.unwrap();
@@ -559,18 +576,7 @@ mod tests {
         let rec = test_record(MediaId::new("m1".to_string()));
         media.insert(&rec).await.unwrap();
 
-        let face = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 10,
-            bbox_y1: 20,
-            bbox_x2: 50,
-            bbox_y2: 60,
-            source_type: "MachineLearning".to_string(),
-        };
+        let face = face_row("f1", "m1", Some("p1"));
         repo.upsert_asset_face(&face).await.unwrap();
         repo.update_face_count("p1").await.unwrap();
 
@@ -586,6 +592,171 @@ mod tests {
 
         let people = repo.list_people().await.unwrap();
         assert_eq!(people[0].face_count, 0);
+    }
+
+    // ── #680: server-side face visibility ─────────────────────────
+
+    #[tokio::test]
+    async fn hidden_and_soft_deleted_faces_are_excluded() {
+        let dir = tempdir().unwrap();
+        let (repo, media, _db) = test_repo(dir.path()).await;
+
+        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        for (n, taken) in [(1, 1000), (2, 2000), (3, 3000)] {
+            let rec = record_with_taken_at(
+                MediaId::new(format!("m{n}")),
+                &format!("a/photo{n}.jpg"),
+                Some(taken),
+            );
+            media.insert(&rec).await.unwrap();
+        }
+
+        repo.upsert_asset_face(&face_row("f1", "m1", Some("p1")))
+            .await
+            .unwrap();
+        repo.upsert_asset_face(&AssetFaceRow {
+            is_visible: false,
+            ..face_row("f2", "m2", Some("p1"))
+        })
+        .await
+        .unwrap();
+        repo.upsert_asset_face(&AssetFaceRow {
+            deleted_at: Some(12345),
+            ..face_row("f3", "m3", Some("p1"))
+        })
+        .await
+        .unwrap();
+        repo.update_face_count("p1").await.unwrap();
+
+        let media = repo.list_media_for_person("p1").await.unwrap();
+        assert_eq!(media, vec!["m1"], "only the visible, live face counts");
+
+        let people = repo.list_people().await.unwrap();
+        assert_eq!(people[0].face_count, 1);
+    }
+
+    /// Hiding a face server-side must drop it from the person on the
+    /// next sync, and un-hiding must bring it back — the row is filtered,
+    /// never deleted, so no resync is needed either way.
+    #[tokio::test]
+    async fn hiding_and_unhiding_a_face_round_trips() {
+        let dir = tempdir().unwrap();
+        let (repo, media, db) = test_repo(dir.path()).await;
+
+        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+
+        repo.upsert_asset_face(&face_row("f1", "m1", Some("p1")))
+            .await
+            .unwrap();
+        repo.update_face_count("p1").await.unwrap();
+        assert_eq!(repo.list_media_for_person("p1").await.unwrap(), vec!["m1"]);
+
+        repo.upsert_asset_face(&AssetFaceRow {
+            is_visible: false,
+            ..face_row("f1", "m1", Some("p1"))
+        })
+        .await
+        .unwrap();
+        repo.update_face_count("p1").await.unwrap();
+        assert!(repo.list_media_for_person("p1").await.unwrap().is_empty());
+        assert_eq!(repo.list_people().await.unwrap()[0].face_count, 0);
+
+        let surviving: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM asset_faces WHERE id = 'f1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(surviving.0, 1, "hidden face is filtered, not deleted");
+
+        repo.upsert_asset_face(&face_row("f1", "m1", Some("p1")))
+            .await
+            .unwrap();
+        repo.update_face_count("p1").await.unwrap();
+        assert_eq!(repo.list_media_for_person("p1").await.unwrap(), vec!["m1"]);
+        assert_eq!(repo.list_people().await.unwrap()[0].face_count, 1);
+    }
+
+    #[tokio::test]
+    async fn effective_person_id_is_none_for_inactive_faces() {
+        let dir = tempdir().unwrap();
+        let (repo, media, _db) = test_repo(dir.path()).await;
+
+        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+
+        repo.upsert_asset_face(&face_row("f1", "m1", Some("p1")))
+            .await
+            .unwrap();
+        assert_eq!(
+            repo.get_asset_face_effective_person_id("f1").await.unwrap(),
+            Some("p1".to_string())
+        );
+
+        repo.upsert_asset_face(&AssetFaceRow {
+            is_visible: false,
+            ..face_row("f1", "m1", Some("p1"))
+        })
+        .await
+        .unwrap();
+        assert!(repo
+            .get_asset_face_effective_person_id("f1")
+            .await
+            .unwrap()
+            .is_none());
+
+        repo.upsert_asset_face(&AssetFaceRow {
+            deleted_at: Some(12345),
+            ..face_row("f1", "m1", Some("p1"))
+        })
+        .await
+        .unwrap();
+        assert!(repo
+            .get_asset_face_effective_person_id("f1")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    /// Rows written before migration 027 must keep their old behaviour:
+    /// the column defaults leave them visible and live.
+    #[tokio::test]
+    async fn pre_migration_rows_default_to_visible_and_live() {
+        let dir = tempdir().unwrap();
+        let (repo, media, db) = test_repo(dir.path()).await;
+
+        repo.upsert_person("p1", "Alice", None, false, false, None, None, None)
+            .await
+            .unwrap();
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+
+        // Insert without the #680 columns, as migration 026 would have.
+        sqlx::query(
+            "INSERT INTO asset_faces (id, asset_id, person_id, image_width, image_height,
+                                      bbox_x1, bbox_y1, bbox_x2, bbox_y2, source_type)
+             VALUES ('f1', 'm1', 'p1', 100, 100, 0, 0, 50, 50, 'MachineLearning')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        repo.update_face_count("p1").await.unwrap();
+
+        assert_eq!(repo.list_media_for_person("p1").await.unwrap(), vec!["m1"]);
+        assert_eq!(repo.list_people().await.unwrap()[0].face_count, 1);
     }
 
     #[tokio::test]
@@ -605,30 +776,8 @@ mod tests {
         media.insert(&rec1).await.unwrap();
         media.insert(&rec2).await.unwrap();
 
-        let face1 = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
-        let face2 = AssetFaceRow {
-            id: "f2".to_string(),
-            asset_id: "m2".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
+        let face1 = face_row("f1", "m1", Some("p1"));
+        let face2 = face_row("f2", "m2", Some("p1"));
         repo.upsert_asset_face(&face1).await.unwrap();
         repo.upsert_asset_face(&face2).await.unwrap();
 
@@ -647,18 +796,7 @@ mod tests {
         let rec = test_record(MediaId::new("m1".to_string()));
         media.insert(&rec).await.unwrap();
 
-        let face = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
+        let face = face_row("f1", "m1", Some("p1"));
         repo.upsert_asset_face(&face).await.unwrap();
 
         // Deleting person should SET NULL on the face, not delete it.
@@ -701,18 +839,7 @@ mod tests {
             .insert(&test_record(MediaId::new("m1".to_string())))
             .await
             .unwrap();
-        let face = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: None,
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
+        let face = face_row("f1", "m1", None);
         repo.upsert_asset_face(&face).await.unwrap();
 
         repo.bump_asset_face_last_seen_at("f1", 12345)
@@ -772,18 +899,7 @@ mod tests {
             .unwrap();
         repo.bump_person_last_seen_at("p1", 100).await.unwrap();
 
-        let face = AssetFaceRow {
-            id: "f1".to_string(),
-            asset_id: "m1".to_string(),
-            person_id: Some("p1".to_string()),
-            image_width: 100,
-            image_height: 100,
-            bbox_x1: 0,
-            bbox_y1: 0,
-            bbox_x2: 50,
-            bbox_y2: 50,
-            source_type: "MachineLearning".to_string(),
-        };
+        let face = face_row("f1", "m1", Some("p1"));
         repo.upsert_asset_face(&face).await.unwrap();
 
         repo.delete_people_with_stale_heartbeat(200).await.unwrap();
@@ -808,18 +924,7 @@ mod tests {
             .unwrap();
 
         for (id, beat) in [("stale", 100), ("fresh", 300)] {
-            let face = AssetFaceRow {
-                id: id.to_string(),
-                asset_id: "m1".to_string(),
-                person_id: None,
-                image_width: 100,
-                image_height: 100,
-                bbox_x1: 0,
-                bbox_y1: 0,
-                bbox_x2: 50,
-                bbox_y2: 50,
-                source_type: "MachineLearning".to_string(),
-            };
+            let face = face_row(id, "m1", None);
             repo.upsert_asset_face(&face).await.unwrap();
             repo.bump_asset_face_last_seen_at(id, beat).await.unwrap();
         }

--- a/src/library/faces/service.rs
+++ b/src/library/faces/service.rs
@@ -106,14 +106,25 @@ impl FacesService {
     /// Emits `PersonMediaChanged` for every person whose membership set
     /// changed. For a reassignment from A to B, two events fire — one for
     /// A (a media was removed) and one for B (a media was added). If the
-    /// person_id is unchanged, no events fire.
+    /// membership is unchanged, no events fire.
+    ///
+    /// Issue #680: membership is the *effective* person — a face hidden
+    /// or soft-deleted server-side contributes to nobody, so hiding a
+    /// face fires the same event as unassigning it.
     pub(crate) async fn upsert_asset_face(
         &self,
         face: &super::repository::AssetFaceRow,
     ) -> Result<(), LibraryError> {
-        let prev_person_id = self.repo.get_asset_face_person_id(&face.id).await?;
+        let prev_person_id = self
+            .repo
+            .get_asset_face_effective_person_id(&face.id)
+            .await?;
         self.repo.upsert_asset_face(face).await?;
-        let new_person_id = face.person_id.clone();
+        let new_person_id = if face.is_visible && face.deleted_at.is_none() {
+            face.person_id.clone()
+        } else {
+            None
+        };
         if prev_person_id != new_person_id {
             if let Some(p) = prev_person_id {
                 self.emit(FacesEvent::PersonMediaChanged(PersonId::from_raw(p)));
@@ -373,6 +384,77 @@ mod tests {
         assert!(rx.try_recv().is_err(), "fresh person wasn't swept");
     }
 
+    /// Issue #680: hiding a face server-side removes its asset from the
+    /// person's grid, so it must fire `PersonMediaChanged` even though
+    /// the face's `person_id` never changed. Un-hiding fires it again.
+    #[tokio::test]
+    async fn hiding_a_face_emits_person_media_changed() {
+        use crate::library::db::test_helpers::test_record;
+        use crate::library::faces::repository::AssetFaceRow;
+        use crate::library::media::repository::MediaRepository;
+        use crate::library::media::MediaId;
+
+        let thumb_root = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_test_db(dir.path()).await;
+        let media = MediaRepository::new(db.clone());
+        let svc = FacesService::new(db, thumb_root.path().to_path_buf(), Arc::new(NoOpRecorder));
+
+        media
+            .insert(&test_record(MediaId::new("m1".to_string())))
+            .await
+            .unwrap();
+        svc.upsert_person("p1", "Alice", None, false, false, None, None, None)
+            .await
+            .unwrap();
+
+        let visible = AssetFaceRow {
+            id: "f1".to_string(),
+            asset_id: "m1".to_string(),
+            person_id: Some("p1".to_string()),
+            image_width: 100,
+            image_height: 100,
+            bbox_x1: 0,
+            bbox_y1: 0,
+            bbox_x2: 50,
+            bbox_y2: 50,
+            source_type: "MachineLearning".to_string(),
+            is_visible: true,
+            deleted_at: None,
+        };
+        svc.upsert_asset_face(&visible).await.unwrap();
+
+        // Subscribe AFTER setup so the person/face upserts don't pollute
+        // the channel.
+        let mut rx = svc.subscribe();
+
+        svc.upsert_asset_face(&AssetFaceRow {
+            is_visible: false,
+            ..visible.clone()
+        })
+        .await
+        .unwrap();
+        match rx.try_recv().expect("hiding a face is a membership change") {
+            FacesEvent::PersonMediaChanged(id) => assert_eq!(id.as_str(), "p1"),
+            other => panic!("expected PersonMediaChanged; got {other:?}"),
+        }
+
+        // Re-applying the same hidden state is not a change.
+        svc.upsert_asset_face(&AssetFaceRow {
+            is_visible: false,
+            ..visible.clone()
+        })
+        .await
+        .unwrap();
+        assert!(rx.try_recv().is_err(), "no membership change, no event");
+
+        svc.upsert_asset_face(&visible).await.unwrap();
+        match rx.try_recv().expect("un-hiding is a membership change too") {
+            FacesEvent::PersonMediaChanged(id) => assert_eq!(id.as_str(), "p1"),
+            other => panic!("expected PersonMediaChanged; got {other:?}"),
+        }
+    }
+
     /// Issue #628: when stale faces are swept, every surviving person
     /// who lost faces gets their denormalised `face_count` recomputed.
     /// Without this the count drifts until the next sync cycle re-emits
@@ -420,6 +502,8 @@ mod tests {
                 bbox_x2: 50,
                 bbox_y2: 50,
                 source_type: "MachineLearning".to_string(),
+                is_visible: true,
+                deleted_at: None,
             };
             svc.repo.upsert_asset_face(&row).await.unwrap();
             svc.repo

--- a/src/library/media/repository.rs
+++ b/src/library/media/repository.rs
@@ -334,8 +334,12 @@ impl MediaRepository {
                 " AND m.is_trashed = 0 AND m.id IN (SELECT media_id FROM album_media WHERE album_id = ?)",
                 "COALESCE(m.taken_at, 0)",
             ),
+            // Issue #680: faces hidden or soft-deleted server-side don't
+            // put their asset in the person's grid — see
+            // `FacesRepository::list_media_for_person`.
             MediaFilter::Person { .. } => (
-                " AND m.is_trashed = 0 AND m.id IN (SELECT DISTINCT asset_id FROM asset_faces WHERE person_id = ?)",
+                " AND m.is_trashed = 0 AND m.id IN (SELECT DISTINCT asset_id FROM asset_faces
+                   WHERE person_id = ? AND is_visible = 1 AND deleted_at IS NULL)",
                 "COALESCE(m.taken_at, 0)",
             ),
         };
@@ -998,6 +1002,63 @@ mod tests {
         let db = open_test_db(dir).await;
         let repo = MediaRepository::new(db.clone());
         (repo, db)
+    }
+
+    /// Issue #680: the person grid is the other half of
+    /// `FacesRepository::list_media_for_person` — a face hidden or
+    /// soft-deleted server-side must not put its asset here either.
+    #[tokio::test]
+    async fn person_filter_excludes_hidden_and_soft_deleted_faces() {
+        use crate::library::faces::PersonId;
+
+        let dir = tempdir().unwrap();
+        let (repo, db) = test_repo(dir.path()).await;
+
+        sqlx::query("INSERT INTO people (id, name) VALUES ('p1', 'Alice')")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        for (n, taken) in [(1, 1000), (2, 2000), (3, 3000)] {
+            let rec = record_with_taken_at(
+                MediaId::new(format!("m{n}")),
+                &format!("a/photo{n}.jpg"),
+                Some(taken),
+            );
+            repo.insert(&rec).await.unwrap();
+        }
+
+        // f1 live and visible, f2 hidden, f3 soft-deleted.
+        for (id, asset, visible, deleted) in [
+            ("f1", "m1", 1, None),
+            ("f2", "m2", 0, None),
+            ("f3", "m3", 1, Some(12345_i64)),
+        ] {
+            sqlx::query(
+                "INSERT INTO asset_faces (id, asset_id, person_id, is_visible, deleted_at)
+                 VALUES (?, ?, 'p1', ?, ?)",
+            )
+            .bind(id)
+            .bind(asset)
+            .bind(visible)
+            .bind(deleted)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        }
+
+        let items = repo
+            .list(
+                MediaFilter::Person {
+                    person_id: PersonId::from_raw("p1".to_string()),
+                },
+                None,
+                50,
+            )
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, vec!["m1"]);
     }
 
     #[tokio::test]

--- a/src/sync/providers/immich/handlers/asset_face.rs
+++ b/src/sync/providers/immich/handlers/asset_face.rs
@@ -63,6 +63,12 @@ impl SyncEntityHandler for AssetFaceHandler {
             source_type: face
                 .source_type
                 .unwrap_or_else(|| "MachineLearning".to_string()),
+            // Issue #680: a face the server hides or soft-deletes stays
+            // in the table but stops contributing to its person's grid
+            // and face_count. The hard delete still arrives separately
+            // as `AssetFaceDeleteV1`.
+            is_visible: face.is_visible,
+            deleted_at: parse_datetime(&face.deleted_at),
         };
 
         ctx.library.faces().upsert_asset_face(&row).await?;

--- a/src/sync/providers/immich/types.rs
+++ b/src/sync/providers/immich/types.rs
@@ -244,16 +244,15 @@ pub(crate) struct SyncAssetFaceV2 {
     /// live. Hard deletes still arrive separately as
     /// `AssetFaceDeleteV1`, so this is purely the soft-delete state.
     ///
-    /// Captured for the contract but not yet persisted — `asset_faces`
-    /// has no column for it. Migration tracked in #680.
-    #[allow(dead_code)]
+    /// Issue #680: persisted to `asset_faces.deleted_at`; soft-deleted
+    /// faces are filtered out of person queries rather than deleted, so
+    /// an un-delete on the server needs no resync.
     #[serde(rename = "deletedAt", default)]
     pub deleted_at: Option<String>,
     /// Whether the face is visible in the asset. Defaults to `true` so
     /// a server that pre-dates the field doesn't hide every face.
     ///
-    /// Captured for the contract but not yet persisted — see #680.
-    #[allow(dead_code)]
+    /// Issue #680: persisted to `asset_faces.is_visible`.
     #[serde(rename = "isVisible", default = "default_true")]
     pub is_visible: bool,
 }


### PR DESCRIPTION
Closes #680.

## What

`AssetFacesV2` (#679) brought `isVisible` and `deletedAt` down the wire, but `asset_faces` had nowhere to put them, so both were parsed and dropped. A face hidden or soft-deleted on the Immich server kept inflating that person's `face_count` and kept its asset in their grid until a hard `AssetFaceDeleteV1` arrived.

Migration `027_add_asset_face_visibility.sql` adds `is_visible INTEGER NOT NULL DEFAULT 1` and `deleted_at INTEGER`. Both defaults leave pre-027 rows "live and visible", so existing libraries upgrade with no visible change and no forced resync.

## Open question from the issue: filter or delete?

**Filtered.** It matches Immich's own model — the server can reverse either a hide or a soft delete — so the local row survives and the next sync restores the face with no resync. Deleting would lose the row on an un-delete.

| state | wire | local |
|---|---|---|
| live and visible | `isVisible: true`, `deletedAt: null` | counts and shows |
| hidden in the asset | `isVisible: false` | row kept, filtered out |
| soft-deleted | `deletedAt` set | row kept, filtered out |
| hard-deleted | `AssetFaceDeleteV1` | row deleted |

## Readers audited

Every read that answers "which media / how many faces does this person have" now filters on `is_visible = 1 AND deleted_at IS NULL`:

- `FacesRepository::list_media_for_person`
- `FacesRepository::update_face_count`
- `MediaFilter::Person` in `MediaRepository::list` — the person grid is the other half of the same question, and the issue's list didn't include it
- `get_asset_face_person_id` → `get_asset_face_effective_person_id`

That last rename is load-bearing. Folding visibility into "which person does this face contribute to" is what lets `FacesService::upsert_asset_face` emit `PersonMediaChanged` when a face is hidden **without its `person_id` changing** — otherwise hiding a face would silently drop it from the person's grid with no event to refresh the view.

The heartbeat sweeps (`delete_*_with_stale_heartbeat`, `persons_with_stale_faces`) deliberately do **not** filter: they reap rows the server stopped sending, whatever state those rows are in.

## Not applicable

The issue's step 4 (`cargo sqlx prepare`, commit `.sqlx/`) doesn't apply — this repo has no `.sqlx/` directory and uses no compile-time `query!` macros; every query is a runtime string.

## Tests

New coverage for the hidden/soft-deleted exclusion, the hide → un-hide round trip (proving the row survives), effective-person-id resolution, the person grid filter, the `PersonMediaChanged` emission, and a pre-migration row inserted the way migration 026 would have, to prove the column defaults preserve old behaviour.

The repository tests grow a `face_row` helper rather than a tenth copy of the same ten-field literal.

`make lint` and `make test` pass (624 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)