### PR TITLE
feat: show unnamed people by default and persist the People filters

### DIFF
--- a/data/io.github.justinf555.Moments.gschema.xml.in
+++ b/data/io.github.justinf555.Moments.gschema.xml.in
@@ -67,6 +67,27 @@
 				in the order they should appear. Maximum 5.
 			</description>
 		</key>
+		<key name="people-unnamed-visibility" type="u">
+			<default>0</default>
+			<summary>Whether the People grid shows unnamed people</summary>
+			<description>
+				0 = automatic, 1 = always shown, 2 = always hidden. The
+				"Show Unnamed" toggle in the People header writes 1 or 2.
+				Automatic — the default until the user touches the toggle
+				— shows unnamed people while nobody has been named, and
+				hides them once someone has, so a freshly synced library
+				isn't an empty grid.
+			</description>
+		</key>
+		<key name="people-show-hidden" type="b">
+			<default>false</default>
+			<summary>Whether the People grid shows hidden people</summary>
+			<description>
+				State of the "Show Hidden" toggle in the People header.
+				People hidden on the server (or locally) are excluded from
+				the grid unless this is true.
+			</description>
+		</key>
 		<key name="album-sort-order" type="u">
 			<default>0</default>
 			<summary>Album grid sort order</summary>

--- a/docs/design-face-integration.md
+++ b/docs/design-face-integration.md
@@ -441,6 +441,8 @@ Phase 7 is a polish enhancement.
 ## Edge Cases
 
 - **Unnamed people**: Immich clusters faces before users name them. Show as "Unnamed" with face thumbnail. Allow filtering these out via `include_unnamed`.
+  - [#681](https://github.com/justinf555/Moments/issues/681): the filter's default is *automatic*, not off. A freshly synced library is 100% unnamed people, so defaulting the filter on rendered an empty grid with no affordance but an unlabelled header toggle. `people-unnamed-visibility` is therefore a tri-state (`0` automatic, `1` always, `2` never) rather than a boolean: automatic shows unnamed people while nobody has been named and hides them once somebody has, which is what the filter is actually for. It resolves once per view against the loaded people — naming your first person shouldn't make everyone else vanish mid-session — and stops being consulted the moment the user touches the toggle. Both toggles persist (`people-unnamed-visibility`, `people-show-hidden`); before #681 each reset on every launch.
+  - When the grid would render bare, an `Adw.StatusPage` says which case it is: no people at all, or everyone filtered out — the latter with a "Show Everyone" button that clears both filters.
 - **Hidden people**: Respect the `isHidden` flag from Immich. Don't show in sidebar by default.
 - **No faces detected**: Some assets have no face data. The People section simply shows fewer results.
 - **Person with no assets**: Can occur after face reassignment. Show in sidebar with count 0; grid view shows empty state.

--- a/src/ui/people_grid/mod.rs
+++ b/src/ui/people_grid/mod.rs
@@ -8,6 +8,7 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use gettextrs::gettext;
 use gtk::{gio, glib};
+use tracing::warn;
 
 use crate::client::{PeopleClientV2, PersonItemObject};
 use crate::ui::photo_grid::texture_cache::TextureCache;
@@ -219,7 +220,9 @@ impl PeopleGridView {
                     } else {
                         unnamed::NEVER
                     };
-                    let _ = s.set_uint("people-unnamed-visibility", value);
+                    if let Err(e) = s.set_uint("people-unnamed-visibility", value) {
+                        warn!("failed to save people-unnamed-visibility: {e}");
+                    }
                 }
             });
         }
@@ -231,7 +234,9 @@ impl PeopleGridView {
                 fs.include_hidden.set(btn.is_active());
                 cf.changed(filter_change(btn.is_active()));
                 if !fs.applying.get() {
-                    let _ = s.set_boolean("people-show-hidden", btn.is_active());
+                    if let Err(e) = s.set_boolean("people-show-hidden", btn.is_active()) {
+                        warn!("failed to save people-show-hidden: {e}");
+                    }
                 }
             });
         }
@@ -379,8 +384,11 @@ fn any_named(store: &gio::ListStore) -> bool {
     })
 }
 
-/// How a toggle's new state changes the filter's strictness — turning a
-/// filter off admits more items, turning it on admits fewer.
+/// How a toggle's new state changes the filter's strictness.
+///
+/// Both toggles are "show me more" switches — Show Unnamed, Show Hidden
+/// — so activating one *relaxes* the filter and admits items it was
+/// rejecting.
 fn filter_change(now_active: bool) -> gtk::FilterChange {
     if now_active {
         gtk::FilterChange::LessStrict
@@ -478,7 +486,7 @@ mod tests {
     // ── filter_change ─────────────────────────────────────────────────
 
     #[test]
-    fn turning_a_filter_on_admits_fewer_items() {
+    fn turning_a_toggle_on_admits_more_items() {
         assert_eq!(filter_change(true), gtk::FilterChange::LessStrict);
         assert_eq!(filter_change(false), gtk::FilterChange::MoreStrict);
     }

--- a/src/ui/people_grid/mod.rs
+++ b/src/ui/people_grid/mod.rs
@@ -1,19 +1,32 @@
 // SPDX-FileCopyrightText: 2026 Justin F
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use adw::prelude::*;
 use adw::subclass::prelude::*;
+use gettextrs::gettext;
 use gtk::{gio, glib};
 
-use crate::client::PeopleClientV2;
+use crate::client::{PeopleClientV2, PersonItemObject};
 use crate::ui::photo_grid::texture_cache::TextureCache;
 
 mod actions;
 pub mod cell;
 pub mod factory;
+
+/// Values of the `people-unnamed-visibility` GSetting.
+///
+/// Issue #681: a plain boolean can't express "the user hasn't chosen
+/// yet". `Auto` is that third state — it resolves once, against the
+/// people actually loaded, and stops being consulted the moment the
+/// user touches the toggle.
+mod unnamed {
+    pub const AUTO: u32 = 0;
+    pub const ALWAYS: u32 = 1;
+    pub const NEVER: u32 = 2;
+}
 
 /// Shared filter state for the people grid.
 ///
@@ -22,6 +35,21 @@ pub mod factory;
 pub(crate) struct PeopleFilter {
     include_hidden: Cell<bool>,
     include_unnamed: Cell<bool>,
+    /// Set while a toggle is being driven from code rather than by the
+    /// user — restoring the persisted state at startup, or resolving
+    /// `unnamed::AUTO` once the people have loaded. The `toggled`
+    /// handlers skip writing GSettings while it's set, so neither
+    /// counts as the user making a choice.
+    applying: Cell<bool>,
+}
+
+impl PeopleFilter {
+    /// Apply `f` to the toggles without it counting as a user choice.
+    fn apply_silently(self: &Rc<Self>, f: impl FnOnce()) {
+        self.applying.set(true);
+        f();
+        self.applying.set(false);
+    }
 }
 
 // ── GObject subclass ─────────────────────────────────────────────────────────
@@ -43,6 +71,12 @@ mod imp {
         pub unnamed_toggle: TemplateChild<gtk::ToggleButton>,
         #[template_child]
         pub hidden_toggle: TemplateChild<gtk::ToggleButton>,
+        #[template_child]
+        pub content_stack: TemplateChild<gtk::Stack>,
+        #[template_child]
+        pub empty_page: TemplateChild<adw::StatusPage>,
+        #[template_child]
+        pub empty_show_all_btn: TemplateChild<gtk::Button>,
 
         // Service dependencies
         pub people_client: OnceCell<PeopleClientV2>,
@@ -109,9 +143,11 @@ impl PeopleGridView {
             "setup called twice"
         );
 
+        let unnamed_setting = settings.uint("people-unnamed-visibility");
         let filter_state = Rc::new(PeopleFilter {
-            include_hidden: Cell::new(false),
-            include_unnamed: Cell::new(false),
+            include_hidden: Cell::new(settings.boolean("people-show-hidden")),
+            include_unnamed: Cell::new(unnamed_visible_initially(unnamed_setting)),
+            applying: Cell::new(false),
         });
 
         // Client returns all people — filtering happens here via FilterListModel.
@@ -119,16 +155,10 @@ impl PeopleGridView {
 
         let fs = Rc::clone(&filter_state);
         let custom_filter = gtk::CustomFilter::new(move |obj| {
-            let Some(person) = obj.downcast_ref::<crate::client::PersonItemObject>() else {
-                return false;
-            };
-            if person.is_hidden() && !fs.include_hidden.get() {
-                return false;
-            }
-            if person.name().is_empty() && !fs.include_unnamed.get() {
-                return false;
-            }
-            true
+            obj.downcast_ref::<PersonItemObject>()
+                .is_some_and(|person| {
+                    person_passes(person, fs.include_hidden.get(), fs.include_unnamed.get())
+                })
         });
 
         let filter_model =
@@ -140,33 +170,13 @@ impl PeopleGridView {
         imp.grid_view.set_model(Some(&selection));
         imp.grid_view.set_factory(Some(&factory));
 
-        // Wire toggle buttons to update filter state and re-evaluate.
-        {
-            let fs = Rc::clone(&filter_state);
-            let cf = custom_filter.clone();
-            imp.unnamed_toggle.connect_toggled(move |btn| {
-                fs.include_unnamed.set(btn.is_active());
-                let change = if btn.is_active() {
-                    gtk::FilterChange::LessStrict
-                } else {
-                    gtk::FilterChange::MoreStrict
-                };
-                cf.changed(change);
-            });
+        self.wire_toggles(&filter_state, &custom_filter, &settings);
+        // Resolution runs before the empty-state refresh so the status
+        // page never flashes for a filter that's about to be lifted.
+        if unnamed_setting == unnamed::AUTO {
+            self.wire_auto_unnamed(&store, &filter_state);
         }
-        {
-            let fs = Rc::clone(&filter_state);
-            let cf = custom_filter;
-            imp.hidden_toggle.connect_toggled(move |btn| {
-                fs.include_hidden.set(btn.is_active());
-                let change = if btn.is_active() {
-                    gtk::FilterChange::LessStrict
-                } else {
-                    gtk::FilterChange::MoreStrict
-                };
-                cf.changed(change);
-            });
-        }
+        self.wire_empty_state(&store, &filter_model);
 
         // Wire item activation and context menu.
         actions::wire_activation(
@@ -184,5 +194,292 @@ impl PeopleGridView {
         assert!(imp.store.set(store).is_ok());
         assert!(imp.filter_model.set(filter_model).is_ok());
         assert!(imp.filter_state.set(filter_state).is_ok());
+    }
+
+    /// Wire both header toggles to the filter state, restore their
+    /// persisted positions, and persist any later change.
+    fn wire_toggles(
+        &self,
+        filter_state: &Rc<PeopleFilter>,
+        custom_filter: &gtk::CustomFilter,
+        settings: &gio::Settings,
+    ) {
+        let imp = self.imp();
+
+        {
+            let fs = Rc::clone(filter_state);
+            let cf = custom_filter.clone();
+            let s = settings.clone();
+            imp.unnamed_toggle.connect_toggled(move |btn| {
+                fs.include_unnamed.set(btn.is_active());
+                cf.changed(filter_change(btn.is_active()));
+                if !fs.applying.get() {
+                    let value = if btn.is_active() {
+                        unnamed::ALWAYS
+                    } else {
+                        unnamed::NEVER
+                    };
+                    let _ = s.set_uint("people-unnamed-visibility", value);
+                }
+            });
+        }
+        {
+            let fs = Rc::clone(filter_state);
+            let cf = custom_filter.clone();
+            let s = settings.clone();
+            imp.hidden_toggle.connect_toggled(move |btn| {
+                fs.include_hidden.set(btn.is_active());
+                cf.changed(filter_change(btn.is_active()));
+                if !fs.applying.get() {
+                    let _ = s.set_boolean("people-show-hidden", btn.is_active());
+                }
+            });
+        }
+
+        // Restoring the persisted state isn't the user re-choosing it.
+        filter_state.apply_silently(|| {
+            imp.unnamed_toggle
+                .set_active(filter_state.include_unnamed.get());
+            imp.hidden_toggle
+                .set_active(filter_state.include_hidden.get());
+        });
+
+        // The empty page's escape hatch: turn every filter off.
+        let unnamed_toggle = imp.unnamed_toggle.get();
+        let hidden_toggle = imp.hidden_toggle.get();
+        imp.empty_show_all_btn.connect_clicked(glib::clone!(
+            #[weak]
+            unnamed_toggle,
+            #[weak]
+            hidden_toggle,
+            move |_| {
+                unnamed_toggle.set_active(true);
+                hidden_toggle.set_active(true);
+            }
+        ));
+    }
+
+    /// Resolve `unnamed::AUTO` once the people have loaded: show unnamed
+    /// people while nobody has been named, hide them once somebody has.
+    ///
+    /// Issue #681: a fresh Immich sync is all unnamed people, so the
+    /// pre-#681 default hid 100% of the library and the view looked
+    /// broken. The filter still earns its keep on a named library, where
+    /// it stops a long tail of anonymous faces burying the people you
+    /// care about — hence the split rather than a flat default-on.
+    ///
+    /// Resolved once per view, not re-evaluated live: naming your first
+    /// person shouldn't make everyone else vanish mid-session.
+    fn wire_auto_unnamed(&self, store: &gio::ListStore, filter_state: &Rc<PeopleFilter>) {
+        let handler: Rc<RefCell<Option<glib::SignalHandlerId>>> = Rc::new(RefCell::new(None));
+
+        let toggle = self.imp().unnamed_toggle.get();
+        let id = store.connect_items_changed(glib::clone!(
+            #[weak]
+            toggle,
+            #[strong]
+            handler,
+            #[strong]
+            filter_state,
+            move |store, _, _, _| {
+                if store.n_items() == 0 {
+                    return; // Nothing to resolve against yet.
+                }
+                if let Some(id) = handler.borrow_mut().take() {
+                    store.disconnect(id);
+                }
+                // Silently: resolving the automatic default is not the
+                // user choosing, so the setting stays on `AUTO` and gets
+                // re-resolved next launch.
+                let show = !any_named(store);
+                filter_state.apply_silently(|| toggle.set_active(show));
+            }
+        ));
+        *handler.borrow_mut() = Some(id);
+    }
+
+    /// Swap in a status page whenever the grid would render bare, and
+    /// tell the two cases apart: a library with no people at all, versus
+    /// one whose people are all filtered out.
+    fn wire_empty_state(&self, store: &gio::ListStore, filter_model: &gtk::FilterListModel) {
+        let imp = self.imp();
+        let refresh = {
+            let stack = imp.content_stack.get();
+            let page = imp.empty_page.get();
+            let button = imp.empty_show_all_btn.get();
+            // Weak: both models end up owning this closure through their
+            // own `items-changed` handlers, and a strong capture would
+            // make each a cycle with itself.
+            let store = store.downgrade();
+            let filter_model = filter_model.downgrade();
+            move || {
+                let (Some(store), Some(filter_model)) = (store.upgrade(), filter_model.upgrade())
+                else {
+                    return;
+                };
+                if filter_model.n_items() > 0 {
+                    stack.set_visible_child_name("grid");
+                    return;
+                }
+                let filtered_out = store.n_items() > 0;
+                if filtered_out {
+                    page.set_title(&gettext("Everyone Is Filtered Out"));
+                    page.set_description(Some(&gettext(
+                        "Unnamed or hidden people are being left out of this view.",
+                    )));
+                } else {
+                    page.set_title(&gettext("No People Yet"));
+                    page.set_description(Some(&gettext(
+                        "People appear here once faces have been detected in your photos.",
+                    )));
+                }
+                button.set_visible(filtered_out);
+                stack.set_visible_child_name("empty");
+            }
+        };
+
+        // The filter model alone isn't enough: people arriving that the
+        // filter rejects leave its count at zero, so the status page
+        // would keep claiming there are none at all.
+        let r = refresh.clone();
+        store.connect_items_changed(move |_, _, _, _| r());
+        let r = refresh.clone();
+        filter_model.connect_items_changed(move |_, _, _, _| r());
+        refresh();
+    }
+}
+
+/// Whether a person survives the two header filters.
+fn person_passes(person: &PersonItemObject, include_hidden: bool, include_unnamed: bool) -> bool {
+    if person.is_hidden() && !include_hidden {
+        return false;
+    }
+    if person.name().is_empty() && !include_unnamed {
+        return false;
+    }
+    true
+}
+
+/// Where the unnamed toggle starts for a persisted setting value.
+///
+/// `AUTO` starts permissive and is resolved against the real people once
+/// they load — while we don't know yet, an empty grid is the failure
+/// mode worth avoiding. Anything unrecognised is treated the same way.
+fn unnamed_visible_initially(setting: u32) -> bool {
+    setting != unnamed::NEVER
+}
+
+/// Whether at least one loaded person has been given a name.
+fn any_named(store: &gio::ListStore) -> bool {
+    (0..store.n_items()).any(|i| {
+        store
+            .item(i)
+            .and_then(|o| o.downcast::<PersonItemObject>().ok())
+            .is_some_and(|p| !p.name().is_empty())
+    })
+}
+
+/// How a toggle's new state changes the filter's strictness — turning a
+/// filter off admits more items, turning it on admits fewer.
+fn filter_change(now_active: bool) -> gtk::FilterChange {
+    if now_active {
+        gtk::FilterChange::LessStrict
+    } else {
+        gtk::FilterChange::MoreStrict
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::library::faces::{Person, PersonId};
+
+    fn person(name: &str, is_hidden: bool) -> PersonItemObject {
+        PersonItemObject::new(
+            &Person {
+                id: PersonId::from_raw("p1".to_string()),
+                name: name.to_string(),
+                face_count: 0,
+                is_hidden,
+            },
+            None,
+        )
+    }
+
+    fn store_of(names: &[&str]) -> gio::ListStore {
+        let store = gio::ListStore::new::<PersonItemObject>();
+        for name in names {
+            store.append(&person(name, false));
+        }
+        store
+    }
+
+    // ── person_passes ─────────────────────────────────────────────────
+
+    #[test]
+    fn named_visible_person_always_passes() {
+        assert!(person_passes(&person("Alice", false), false, false));
+    }
+
+    #[test]
+    fn unnamed_person_passes_only_when_included() {
+        assert!(!person_passes(&person("", false), false, false));
+        assert!(person_passes(&person("", false), false, true));
+    }
+
+    #[test]
+    fn hidden_person_passes_only_when_included() {
+        assert!(!person_passes(&person("Alice", true), false, false));
+        assert!(person_passes(&person("Alice", true), true, false));
+    }
+
+    /// Both filters apply — clearing one isn't enough for a person that
+    /// trips the other.
+    #[test]
+    fn hidden_and_unnamed_needs_both_filters_off() {
+        assert!(!person_passes(&person("", true), true, false));
+        assert!(!person_passes(&person("", true), false, true));
+        assert!(person_passes(&person("", true), true, true));
+    }
+
+    // ── unnamed_visible_initially ─────────────────────────────────────
+
+    #[test]
+    fn only_an_explicit_never_starts_unnamed_hidden() {
+        assert!(unnamed_visible_initially(unnamed::AUTO));
+        assert!(unnamed_visible_initially(unnamed::ALWAYS));
+        assert!(!unnamed_visible_initially(unnamed::NEVER));
+        assert!(
+            unnamed_visible_initially(99),
+            "unknown values stay permissive"
+        );
+    }
+
+    // ── any_named ─────────────────────────────────────────────────────
+
+    /// Issue #681: a freshly synced Immich library is all unnamed
+    /// people. `AUTO` must resolve to "show them" or the grid renders
+    /// empty and looks broken.
+    #[test]
+    fn fresh_library_of_unnamed_people_resolves_to_showing_them() {
+        assert!(!any_named(&store_of(&["", "", ""])));
+    }
+
+    #[test]
+    fn one_named_person_is_enough_to_hide_the_rest() {
+        assert!(any_named(&store_of(&["", "Alice", ""])));
+    }
+
+    #[test]
+    fn empty_store_has_nobody_named() {
+        assert!(!any_named(&store_of(&[])));
+    }
+
+    // ── filter_change ─────────────────────────────────────────────────
+
+    #[test]
+    fn turning_a_filter_on_admits_fewer_items() {
+        assert_eq!(filter_change(true), gtk::FilterChange::LessStrict);
+        assert_eq!(filter_change(false), gtk::FilterChange::MoreStrict);
     }
 }

--- a/src/ui/people_grid/people_grid.blp
+++ b/src/ui/people_grid/people_grid.blp
@@ -32,14 +32,40 @@ template $MomentsPeopleGridView : Gtk.Widget {
           }
         }
 
-        content: Gtk.ScrolledWindow {
-          hscrollbar-policy: never;
-          vexpand: true;
+        content: Gtk.Stack content_stack {
+          transition-type: crossfade;
 
-          child: Gtk.GridView grid_view {
-            min-columns: 3;
-            max-columns: 8;
-          };
+          Gtk.StackPage {
+            name: "grid";
+
+            child: Gtk.ScrolledWindow {
+              hscrollbar-policy: never;
+              vexpand: true;
+
+              child: Gtk.GridView grid_view {
+                min-columns: 3;
+                max-columns: 8;
+              };
+            };
+          }
+
+          Gtk.StackPage {
+            name: "empty";
+
+            child: Adw.StatusPage empty_page {
+              icon-name: "avatar-default-symbolic";
+              title: _("No People Yet");
+              description: _("People appear here once faces have been detected in your photos.");
+              vexpand: true;
+
+              Gtk.Button empty_show_all_btn {
+                label: _("Show Everyone");
+                halign: center;
+                visible: false;
+                styles ["pill", "suggested-action"]
+              }
+            };
+          }
         };
       };
     }


### PR DESCRIPTION
Closes #681.

## What

The People grid hid unnamed people by default. A freshly synced Immich library is entirely unnamed people, so the view rendered empty and the only way out was a header toggle whose sole affordance was a hover tooltip.

## Open question from the issue: which default?

**Option 2 — automatic**, as the issue leaned. Defaulting the filter flatly off trades one problem for another: on a library with named people the filter is doing real work, keeping a long tail of anonymous faces from burying the ones you care about.

So `people-unnamed-visibility` is a tri-state rather than a boolean — a plain bool can't express "the user hasn't chosen yet":

| value | meaning |
|---|---|
| `0` | automatic (default) |
| `1` | always shown |
| `2` | always hidden |

Automatic shows unnamed people while nobody has been named and hides them once somebody has. Two details that make the "silently changing once" concern manageable:

- It resolves **once per view**, against the people actually loaded — naming your first person doesn't make everyone else vanish mid-session.
- It stops being consulted the moment the user touches the toggle, which writes `1` or `2`.

## Persistence

Both toggles now persist — `people-unnamed-visibility` and `people-show-hidden`. Previously each reset on every launch, so whatever the user chose they had to re-choose next time. That's what made the wrong default costly rather than merely wrong.

A `PeopleFilter::apply_silently` guard keeps programmatic toggle changes (restoring persisted state at startup, resolving `AUTO`) from being mistaken for user choices — without it, the first auto-resolution would write `1`/`2` and permanently destroy the automatic state.

## Optional item: empty state

Included. The grid gains an `Adw.StatusPage` for when it would render bare, distinguishing "No People Yet" from "Everyone Is Filtered Out" — the latter with a **Show Everyone** button that clears both filters. The default change removes the common path into it, but any future filter-to-empty case now explains itself instead of looking like a failure.

It listens on both the store and the filter model: people arriving that the filter rejects leave the filter model's count at zero, so watching it alone would keep claiming there are none at all.

## Tests

The filter predicate, the setting mapping, and the named-person check are lifted out as free functions, so the decision logic is testable without a GTK main loop — 9 new tests. `make lint` and `make test` pass (624 tests). The Blueprint template and the GSettings schema were both compiled to check them.

**Worth a manual look:** `make run-dev` — this is UI behaviour and the runtime template binding isn't exercised by the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)